### PR TITLE
Dispose of WebReponse after each use

### DIFF
--- a/source/OctopusTools/Client/OctopusClient.cs
+++ b/source/OctopusTools/Client/OctopusClient.cs
@@ -48,11 +48,13 @@ namespace OctopusTools.Client
                 {
                     var request = CreateWebRequest("GET", uri);
 
-                    var response = request.GetResponse();
-                    using (var reader = new StreamReader(response.GetResponseStream()))
+                    using (var response = request.GetResponse())
                     {
-                        var content = reader.ReadToEnd();
-                        return JsonConvert.DeserializeObject<TResource>(content);
+                        using (var reader = new StreamReader(response.GetResponseStream()))
+                        {
+                            var content = reader.ReadToEnd();
+                            return JsonConvert.DeserializeObject<TResource>(content);
+                        }
                     }
                 });
         }
@@ -70,9 +72,11 @@ namespace OctopusTools.Client
                     request.ContentType = "application/json";
                     AppendBody(request, postData);
 
-                    var response = ReadResponse(request);
-                    var location = response.Headers.Get("Location");
-                    return Get<TResource>(location).Execute();
+                    using (var response = ReadResponse(request))
+                    {
+                        var location = response.Headers.Get("Location");
+                        return Get<TResource>(location).Execute();
+                    }
                 });
         }
 
@@ -90,7 +94,7 @@ namespace OctopusTools.Client
                     request.Headers["X-HTTP-Method-Override"] = "PUT";
                     AppendBody(request, postData);
 
-                    ReadResponse(request);
+                    using (ReadResponse(request)) { }
 
                     return Get<TResource>(uri.AbsolutePath).Execute();
                 });


### PR DESCRIPTION
I was running Octopus-Tools this evening when I came across a `The operation has timed out` error during a deployment. `OctopusClient.Get<TResource>()` was working correctly except when it was trying to retrieve the new deployment information (/Api/Projects/3/Releases/36/Deployments/37). I came across [this Stack Overflow question](http://stackoverflow.com/questions/1386628/webrequest-getresponse-locks-up) and I realized that the WebResponse objects were not being disposed from the previous requests.

Here is the console output generated by Octopus-Tools:

```
C:\Users\CharTek\Documents\Development\octopus-tools\source\OctopusTools\bin>octo create-release --server=http://octopus/ --project=Test --deployto=Staging --version=1.0.0.3 --force
Octopus Command Line Tool, version 1.0.0.0

Handshaking with Octopus server: http://octopus/api
Handshake successful. Octopus version: 0.9.568.2630
Searching for project 'Test'
Found project: Test [3]
Searching for environment 'Staging'
Found environment: Staging [1]
Getting project steps...
Found 1 steps
Getting latest version of package: nexuspwn.Web
Latest available version of package 'nexuspwn.Web' is '0.1.249'
Creating release: 1.0.0.3
Release created successfully!
The operation has timed out
System.Net.WebException: The operation has timed out
   at System.Net.HttpWebRequest.GetResponse()
   at OctopusTools.Client.OctopusClient.<>c__DisplayClass2`1.<Get>b__1() in C:\Users\CharTek\Documents\Development\octopus-tools\source\OctopusTools\Client\OctopusClient.cs:line 51
   at System.Threading.Tasks.Task`1.InvokeFuture(Object futureAsObj)
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
```

And here is the output after I made the changes included in this pull request:

```
C:\Users\CharTek\Documents\Development\octopus-tools\source\OctopusTools\bin>octo create-release --server=http://octopus/ --project=Test --deployto=Staging --version=1.0.0.13 --force
Octopus Command Line Tool, version 1.0.0.0

Handshaking with Octopus server: http://octopus/api
Handshake successful. Octopus version: 0.9.568.2630
Searching for project 'Test'
Found project: Test [3]
Searching for environment 'Staging'
Found environment: Staging [1]
Getting project steps...
Found 1 steps
Getting latest version of package: nexuspwn.Web
Latest available version of package 'nexuspwn.Web' is '0.1.249'
Creating release: 1.0.0.13
Release created successfully!
Successfully scheduled release '1.0.0.13' for deployment to environment 'Staging'
```
