### PR TITLE
Update to allow forcing a specific package version for a release created from octo.exe

### DIFF
--- a/source/OctopusTools/Commands/CreateReleaseCommand.cs
+++ b/source/OctopusTools/Commands/CreateReleaseCommand.cs
@@ -18,6 +18,7 @@ namespace OctopusTools.Commands
         public string ProjectName { get; set; }
         public IList<string> DeployToEnvironmentNames { get; set; }
         public string VersionNumber { get; set; }
+		public string PackageVersionNumber { get; set; }
         public string ReleaseNotes { get; set; }
         public bool Force { get; set; }
 
@@ -29,6 +30,7 @@ namespace OctopusTools.Commands
                 options.Add("project=", "Name of the project", v => ProjectName = v);
                 options.Add("deployto=", "[Optional] Environment to automatically deploy to, e.g., Production", v => DeployToEnvironmentNames.Add(v));
                 options.Add("version=", "Version number to use for the new release.", v => VersionNumber = v);
+				options.Add("packageversion=", "Version number of the package to use for this release.", v => PackageVersionNumber = v);
                 options.Add("force", "Whether to force redeployment of already installed packages (flag, default false).", v => Force = true);
                 options.Add("releasenotes=", "Release Notes for the new release.", v => ReleaseNotes = v);
                 return options;
@@ -48,11 +50,20 @@ namespace OctopusTools.Commands
             Log.Debug("Finding steps for project...");
             var steps = Session.FindStepsForProject(project);
 
-            Log.Debug("Getting latest package versions for each step...");
+            Log.Debug("Getting package versions for each step...");
             var selected = new List<SelectedPackage>();
             foreach (var step in steps)
             {
-                var version = Session.GetLatestPackageForStep(step);
+				SelectedPackage version;
+				if (string.IsNullOrEmpty(PackageVersionNumber))
+				{
+					version = Session.GetLatestPackageForStep(step);	
+				}
+				else
+				{
+					version = Session.GetPackageForStep(step, PackageVersionNumber);	
+				}
+				
                 Log.DebugFormat("{0} - latest: {1}", step.Description, version.NuGetPackageVersion);
                 selected.Add(version);
             }

--- a/source/OctopusTools/Extensions/ProjectExtensions.cs
+++ b/source/OctopusTools/Extensions/ProjectExtensions.cs
@@ -26,6 +26,19 @@ public static class ProjectExtensions
         return session.List<Step>(project.Link("Steps"));
     }
 
+	public static SelectedPackage GetPackageForStep(this IOctopusSession session, Step step, string version)
+	{
+		var versions = session.List<PackageVersion>(step.Link("AvailablePackageVersions"));
+
+		var latest = versions.Where(s => (s.Version == version)).First();
+		if (latest == null)
+		{
+			throw new Exception("There are no available packages named '{0}'");
+		}
+
+		return new SelectedPackage { StepId = step.Id, NuGetPackageVersion = latest.Version };
+	}
+
     public static SelectedPackage GetLatestPackageForStep(this IOctopusSession session, Step step)
     {
         var versions = session.List<PackageVersion>(step.Link("AvailablePackageVersions"));


### PR DESCRIPTION
I will need the ability to create releases that don't use the latest version of a package.  I added a command line parameter to accept the packageversion that you want to use.
