### PR TITLE
define package-specific versions when creating release

### DIFF
--- a/source/OctopusTools.Tests/OctopusTools.Tests.csproj
+++ b/source/OctopusTools.Tests/OctopusTools.Tests.csproj
@@ -54,8 +54,10 @@
     <Compile Include="..\Solution Items\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Commands\CreateReleaseCommandFixture.cs" />
     <Compile Include="Commands\DeploymentWatcherFixture.cs" />
     <Compile Include="Commands\HelpCommandFixture.cs" />
+    <Compile Include="Extensions\PackageConstraintsExtensionsFixture.cs" />
     <Compile Include="Helpers\TestCommandExtensions.cs" />
     <Compile Include="Util\UriExtensionsFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/source/OctopusTools/Extensions/PackageConstraintExtensions.cs
+++ b/source/OctopusTools/Extensions/PackageConstraintExtensions.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+public static class PackageConstraintExtensions
+{
+    const string NugetPackageIdRegexPattern = "^[a-z0-9]+([_.-][a-z0-9]+)*$";
+
+    public static string[] GetPackageIdAndVersion(string value)
+    {
+        if (!IsValidPackageConstraint(value))
+        {
+            throw new ArgumentException("'"+value+"' does not use expected format of : {PackageId}:{Version}");
+        }
+
+        var constraintSpecs = value.Split(':');
+        
+        return new string[]{
+            constraintSpecs[0].Trim(),
+            constraintSpecs[1].Trim()
+            };
+    }
+
+
+    public static bool IsValidPackageConstraint(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Contains(" ") 
+            || !value.Contains(":") || value.Split(':').Length != 2 || !IsValidVersionString(value.Split(':')[1]))
+        {
+            return false;
+        }
+        
+        var constraintSpecs = value.Split(':');
+
+        if (!IsValidNugetPackageId(constraintSpecs[0]))
+        {
+            return false;
+        }
+        if (!IsValidVersionString(constraintSpecs[1]))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    public static bool IsValidNugetPackageId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return Regex.IsMatch(value.ToLower(), NugetPackageIdRegexPattern);
+    }
+
+    public static bool IsValidVersionString(string value)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var versionComponents = value.Split('.');
+            foreach (var s in versionComponents)
+            {
+                int.Parse(s);
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            return false;
+        }
+    }
+
+}

--- a/source/OctopusTools/OctopusTools.csproj
+++ b/source/OctopusTools/OctopusTools.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Commands\IDeploymentWatcher.cs" />
     <Compile Include="Extensions\DeploymentExtensions.cs" />
     <Compile Include="Extensions\EnvironmentExtensions.cs" />
+    <Compile Include="Extensions\PackageConstraintExtensions.cs" />
     <Compile Include="Extensions\ProjectExtensions.cs" />
     <Compile Include="Infrastructure\CommandException.cs" />
     <Compile Include="Infrastructure\CommandLineArgsProvider.cs" />

--- a/source/octopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/octopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -1,0 +1,52 @@
+﻿using log4net;
+using NSubstitute;
+using NUnit.Framework;
+using OctopusTools.Client;
+using OctopusTools.Commands;
+using OctopusTools.Model;
+
+namespace OctopusTools.Tests.Commands
+{
+    [TestFixture]
+    public class CreateReleaseCommandFixture
+    {
+        private CreateReleaseCommand createCommand;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var sessionFactory = Substitute.For<IOctopusSessionFactory>();
+            var log = Substitute.For<ILog>();
+            var deploymentWatcher = Substitute.For<IDeploymentWatcher>();
+            createCommand = new CreateReleaseCommand(sessionFactory, log, deploymentWatcher);
+        }
+
+
+        [Test]
+        public void ShouldCreateDictionaryUponParsingVersionConstraints()
+        {
+            createCommand.ParsePackageConstraint("packageIdA:1.0.0");
+            createCommand.ParsePackageConstraint("packageIdB:2.0.0");
+            createCommand.ParsePackageConstraint("packageIdC:1.0.0");
+
+            Assert.IsTrue(createCommand.PackageVersionNumberOverrides.ContainsKey("packageIdA"));
+            Assert.IsTrue(createCommand.PackageVersionNumberOverrides.ContainsKey("packageIdB"));
+            Assert.IsTrue(createCommand.PackageVersionNumberOverrides.ContainsKey("packageIdC"));
+
+            Assert.That(createCommand.PackageVersionNumberOverrides["packageIdA"].Equals("1.0.0"));
+            Assert.That(createCommand.PackageVersionNumberOverrides["packageIdB"].Equals("2.0.0"));
+            Assert.That(createCommand.PackageVersionNumberOverrides["packageIdC"].Equals("1.0.0"));
+        }
+
+        [Test]
+        public void ShouldLetPackageSpecificVersionConstraintOverridePackageVersion()
+        {
+            createCommand.PackageVersionNumber = "4.2.1";
+            createCommand.ParsePackageConstraint("packageA:1.0.0");
+            Step step = Substitute.For<Step>();
+            step.NuGetPackageId = "packageA";
+
+            Assert.AreEqual("1.0.0", createCommand.GetPackageVersionForStep(step));
+        }
+    }
+}

--- a/source/octopusTools.Tests/Extensions/PackageConstraintsExtensionsFixture.cs
+++ b/source/octopusTools.Tests/Extensions/PackageConstraintsExtensionsFixture.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace OctopusTools.Tests.Extensions
+{
+    [TestFixture]
+    public class PackageConstraintsExtensionsFixture
+    {
+
+        [Test]
+        public void ShouldReturnFalseForInvalidVersionStrings()
+        {
+            string[] stringsToTest = {"","  ","a","a.b","1,000","1.0.3-alpha","1.0. "};
+            foreach (var s in stringsToTest)
+            {
+                Assert.IsFalse(PackageConstraintExtensions.IsValidVersionString(s));    
+            }
+        }
+
+        [Test]
+        public void ShouldReturnTrueForValidVersionStrings()
+        {
+            string[] stringsToTest = {"0","0.1","1.0.0","0.0.0.0","1.2"};
+            foreach (var s in stringsToTest)
+            {
+                Assert.IsTrue(PackageConstraintExtensions.IsValidVersionString(s));
+            }
+
+        }
+
+        [Test]
+        public void ShouldReturnFalseForInvalidNugetPackageIds()
+        {
+            // http://nuget.codeplex.com/wikipage?title=Package%20Id%20Specification&IsNewlyCreatedPage=true
+            string[] stringsToTest = { "hello._there","i.am.not.valid.","_neitherami","bad..id",""," " };
+            foreach (var s in stringsToTest)
+            {
+                Assert.IsFalse(PackageConstraintExtensions.IsValidNugetPackageId(s));
+            }
+        }
+
+        [Test]
+        public void ShouldReturnTrueForValidNugetPackageIds()
+        {
+            // http://nuget.codeplex.com/wikipage?title=Package%20Id%20Specification&IsNewlyCreatedPage=true
+            string[] stringsToTest = { "hello","i.am.a.valid.id","nuget-core_is.cool","123.456.789","newsletters" };
+            foreach (var s in stringsToTest)
+            {
+                Assert.IsTrue(PackageConstraintExtensions.IsValidNugetPackageId(s));
+            }
+        }
+        
+        [Test]
+        public void ShouldThrowArgumentExceptionForInvalidPackageConstraint()
+        {
+            string[] stringsToTest = {"package name:1.0",""," ","packageName:1.0:2.0","packageA:1.0;packageB:2.0"};
+            foreach (var s in stringsToTest)
+            {
+                Assert.Throws<ArgumentException>(delegate
+                                                                             {
+                                                                                 PackageConstraintExtensions.
+                                                                                     GetPackageIdAndVersion(s);
+                                                                             });
+            }
+        }
+
+        [Test]
+        public void ShouldReturnTokensForValidPackageConstraint()
+        {
+            string[] stringsToTest = { "packageName:1", "packageName:1.02.4.0"};
+            foreach (var s in stringsToTest)
+            {
+                var tokens = PackageConstraintExtensions.GetPackageIdAndVersion(s);
+                Assert.IsTrue(tokens.Length==2);
+                Assert.IsFalse(string.IsNullOrWhiteSpace(tokens[0]));
+                Assert.IsFalse(string.IsNullOrWhiteSpace(tokens[1]));
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
Octo.exe create-release has option "packageversion", which assembles a release in which all packages share that version number.

To handle situations where a release candidate might deploy multiple packages, I added option "packageversionoverride", which can be defined multiple times and populates a dictionary (key: packageID; value: versionNumber).

Sample use: 
for project "MyProject" whose deployment steps include installing packages "LibraryA", "LibraryB" :
Octo.exe create-release --project="MyProject" --packageversionoverride="LibraryA:1.0.3" --packageversionoverride="LibraryB:2.0.1" ...

When Octo.exe assembles the release, for each step it first consults the packageversionoverride dictionary for a version number (my change); then the packageversion option for a version number; and then resorts to the most recent package. 

Would you please consider incorporating these changes in the master?

Thanks for your time.
