### PR TITLE
New CreateRelease option

### DIFF
--- a/source/OctopusTools/Commands/CreateReleaseCommand.cs
+++ b/source/OctopusTools/Commands/CreateReleaseCommand.cs
@@ -29,6 +29,7 @@ namespace OctopusTools.Commands
         public string VersionNumber { get; set; }
         public string PackageVersionNumber { get; set; }
         public string ReleaseNotes { get; set; }
+		public bool ForceVersion { get; set; }
         public bool Force { get; set; }
         public bool WaitForDeployment { get; set; }
         public TimeSpan DeploymentTimeout { get; set; }
@@ -45,6 +46,7 @@ namespace OctopusTools.Commands
                 options.Add("version=", "Version number to use for the new release.", v => VersionNumber = v);
                 options.Add("packageversion=", "Version number of the package to use for this release.", v => PackageVersionNumber = v);
                 options.Add("packageversionoverride=", "[Optional] Version number to use for a package in the release.", ParsePackageConstraint);
+				options.Add("forceversion", "Take the version from the packageversion option and do not check for existence first.", v => ForceVersion = true);
                 options.Add("force", "Whether to force redeployment of already installed packages (flag, default false).", v => Force = true);
                 options.Add("releasenotes=", "Release Notes for the new release.", v => ReleaseNotes = v);
                 options.Add("releasenotesfile=", "Path to a file that contains Release Notes for the new release.", ReadReleaseNotesFromFile);
@@ -94,7 +96,7 @@ namespace OctopusTools.Commands
             }
             if (!string.IsNullOrEmpty(PackageVersionNumber))
             {
-                return PackageVersionNumber;
+				return PackageVersionNumber;
             }
 
             return null;
@@ -117,12 +119,18 @@ namespace OctopusTools.Commands
             var selected = new List<SelectedPackage>();
             foreach (var step in steps)
             {
-
-                SelectedPackage version;
+				SelectedPackage version;
                 var packageVersionConstraint = GetPackageVersionForStep(step);
                 if (packageVersionConstraint != null)
                 {
-                    version = Session.GetPackageForStep(step, packageVersionConstraint);
+					if (ForceVersion)
+					{
+						version = new SelectedPackage { StepId = step.Id, NuGetPackageVersion = packageVersionConstraint };
+					}
+					else
+					{
+						version = Session.GetPackageForStep(step, packageVersionConstraint);
+					}
                 }
                 else
                 {


### PR DESCRIPTION
Hi Paul,

You're probably aware from talking to Bruce Keen that we get some performance problems when talking to the nuget feed, so I added an option which allows me to bypass loading the feed if you know precisely which version of a package you want.

This allows me to create a release virtually instantaneously, so I'm very happy about this :-D

I'll be using this tool now in my continuous-deployment program, so that I can constantly monitor the team city feeds for new versions and auto-deploy releases via octopus :-)

Thanks for a great product!

Richard
