### PR TITLE
Added --forcepackagedownload for create-release

### DIFF
--- a/source/OctopusTools/Commands/CreateReleaseCommand.cs
+++ b/source/OctopusTools/Commands/CreateReleaseCommand.cs
@@ -30,6 +30,7 @@ namespace OctopusTools.Commands
         public string VersionNumber { get; set; }
         public string ReleaseNotes { get; set; }
         public bool Force { get; set; }
+        public bool ForcePackageDownload { get; set; }
         public bool WaitForDeployment { get; set; }
         public TimeSpan DeploymentTimeout { get; set; }
         public TimeSpan DeploymentStatusCheckSleepCycle { get; set; }
@@ -47,6 +48,7 @@ namespace OctopusTools.Commands
                 options.Add("packagesFolder=", "[Optional] A folder containing NuGet packages from which we should get versions.", v => versionResolver.AddFolder(v));
                 options.Add("forceversion", "Ignored (obsolete).", v => {});
                 options.Add("force", "Whether to force redeployment of already installed packages (flag, default false).", v => Force = true);
+                options.Add("forcepackagedownload", "Whether to force downloading of already installed packages (flag, default false).", v => ForcePackageDownload = true);
                 options.Add("releasenotes=", "Release Notes for the new release.", v => ReleaseNotes = v);
                 options.Add("releasenotesfile=", "Path to a file that contains Release Notes for the new release.", ReadReleaseNotesFromFile);
                 options.Add("waitfordeployment", "Whether to wait synchronously for deployment to finish.", v => WaitForDeployment = true );
@@ -99,7 +101,7 @@ namespace OctopusTools.Commands
             Log.ServiceMessage("setParameter", new { name = "octo.releaseNumber", value = release.Version });
 
             if (environments == null || environments.Count <= 0) return;
-            var linksToDeploymentTasks = Session.GetDeployments(release, environments, Force, Log).ToList();
+            var linksToDeploymentTasks = Session.GetDeployments(release, environments, Force, ForcePackageDownload, Log).ToList();
 
             if (WaitForDeployment)
             {

--- a/source/OctopusTools/Commands/DeployReleaseCommand.cs
+++ b/source/OctopusTools/Commands/DeployReleaseCommand.cs
@@ -25,6 +25,7 @@ namespace OctopusTools.Commands
         public IList<string> DeployToEnvironmentNames { get; set; }
         public string VersionNumber { get; set; }
         public bool Force { get; set; }
+        public bool ForcePackageDownload { get; set; }
         public bool WaitForDeployment { get; set; }
         public TimeSpan DeploymentTimeout { get; set; }
         public TimeSpan DeploymentStatusCheckSleepCycle { get; set; }
@@ -38,6 +39,7 @@ namespace OctopusTools.Commands
                 options.Add("deployto=", "Environment to deploy to, e.g., Production", v => DeployToEnvironmentNames.Add(v));
                 options.Add("releaseNumber=|version=", "Version number of the release to deploy.", v => VersionNumber = v);
                 options.Add("force", "Whether to force redeployment of already installed packages (flag, default false).", v => Force = true);
+                options.Add("forcepackagedownload", "Whether to force downloading of already installed packages (flag, default false).", v => ForcePackageDownload = true);
                 options.Add("waitfordeployment", "Whether to wait synchronously for deployment to finish.", v => WaitForDeployment = true);
                 options.Add("deploymenttimeout=", "[Optional] Specifies maximum time (timespan format) that deployment can take (default 00:10:00)", v => DeploymentTimeout = TimeSpan.Parse(v));
                 options.Add("deploymentchecksleepcycle=", "[Optional] Specifies how much time (timespan format) should elapse between deployment status checks (default 00:00:10)", v => DeploymentStatusCheckSleepCycle = TimeSpan.Parse(v));
@@ -61,7 +63,7 @@ namespace OctopusTools.Commands
             var release = Session.GetRelease(project, VersionNumber);
 
             if (environments == null || environments.Count <= 0) return;
-            var linksToDeploymentTasks = Session.GetDeployments(release, environments, Force, Log).ToList();
+            var linksToDeploymentTasks = Session.GetDeployments(release, environments, Force, ForcePackageDownload, Log).ToList();
 
             if (WaitForDeployment)
             {

--- a/source/OctopusTools/Extensions/DeploymentExtensions.cs
+++ b/source/OctopusTools/Extensions/DeploymentExtensions.cs
@@ -8,22 +8,23 @@ using log4net;
 public static class DeploymentExtensions
 // ReSharper restore CheckNamespace
 {
-    public static Deployment DeployRelease(this IOctopusSession session, Release release, DeploymentEnvironment environment, bool forceRedeploymentOfExistingPackages = false)
+    public static Deployment DeployRelease(this IOctopusSession session, Release release, DeploymentEnvironment environment, bool forceRedeploymentOfExistingPackages = false, bool forceDownloadOfPackages = false)
     {
         var deployment = new Deployment();
         deployment.EnvironmentId = environment.Id;
         deployment.ReleaseId = release.Id;
         deployment.ForceRedeployment = forceRedeploymentOfExistingPackages;
+        deployment.ForcePackageDownload = forceDownloadOfPackages;
 
         return session.Create(release.Link("Deployments"), deployment);
     }
 
-    public static IEnumerable<string> GetDeployments(this IOctopusSession session, Release release, IEnumerable<DeploymentEnvironment> environments, bool force, ILog log)
+    public static IEnumerable<string> GetDeployments(this IOctopusSession session, Release release, IEnumerable<DeploymentEnvironment> environments, bool force, bool forceDownloadOfPackages, ILog log)
     {
         var linksToDeploymentTasks = new List<string>();
         foreach (var environment in environments)
         {
-            var deployment = session.DeployRelease(release, environment, force);
+            var deployment = session.DeployRelease(release, environment, force, forceDownloadOfPackages);
             var linkToTask = deployment.Link("Task");
             linksToDeploymentTasks.Add(linkToTask);
 

--- a/source/OctopusTools/Model/Deployment.cs
+++ b/source/OctopusTools/Model/Deployment.cs
@@ -8,6 +8,7 @@ namespace OctopusTools.Model
         public string ReleaseId { get; set; }
         public string EnvironmentId { get; set; }
         public bool ForceRedeployment { get; set; }
+        public bool ForcePackageDownload { get; set; }
         public string Name { get; set; }
     }
 }


### PR DESCRIPTION
Hi there,

I posted to the support forum about the ability to force the octopus deploy server to re-download packages from the nuget server via the command line tool octo.exe (http://help.octopusdeploy.com/discussions/problems/5069-re-download-packages-from-the-nuget-server-from-commandline)

I've noticed that since the release of version 1.5.0.1647 that the server now responds to the ForcePackageDownload flag. This is my crack at adding this functionality into the octo.exe command line tool. Please be gentle as this is my first pull request :-)

Regards,
Graham.
