### PR TITLE
continous deployment feature

### DIFF
--- a/source/OctopusTools/Extensions/ProjectExtensions.cs
+++ b/source/OctopusTools/Extensions/ProjectExtensions.cs
@@ -72,8 +72,16 @@ public static class ProjectExtensions
     public static Release GetRelease(this IOctopusSession session, Project project, string version)
     {
         var releases = session.List<Release>(project.Link("Releases"));
-
-        var release = releases.FirstOrDefault(x => string.Equals(x.Version, version, StringComparison.InvariantCultureIgnoreCase));
+        Release release;
+        if (version.Equals("latest", StringComparison.InvariantCultureIgnoreCase))
+        {
+            release = releases.OrderByDescending(r=>r.Assembled).FirstOrDefault();
+            Console.WriteLine("found version "+release.Version);   
+        }
+        else
+        {
+            release = releases.FirstOrDefault(x => string.Equals(x.Version, version, StringComparison.InvariantCultureIgnoreCase));
+        }
         if (release == null)
         {
             throw new ArgumentException(string.Format("A release named '{0}' for project '{1}' could not be found.", version, project.Name));


### PR DESCRIPTION
The following features are needed to support continuous deployment. Allowing to schedule a deployment with the latest release that was created.  This typically happens from the build (TeamCity), after the build, tests and local UI test, we deploy to a development environment and run some additional tests. After all ui tests successfully complete we deploy the latest version to QA.  This has realistic data and a battery of tests that exercise the system with all the data is executed.  It that passes we then execute a deployment using the deployFrom specifying the Environment from which the version number should be pull to deploy to the pre-production/production environments.

Modified the parameter --version of the deploy-release command to accept latest as a token for the most recently created release.
--version=latest

Added the parameter --deployFrom to the deploy-release command, which accepts the Environment Name from which to pull the release from.

deployFrom=environment
