### PR TITLE
Patching logger to use a ConsoleLogger on a non windows platform.

### DIFF
--- a/source/OctopusTools/Diagnostics/Logger.cs
+++ b/source/OctopusTools/Diagnostics/Logger.cs
@@ -4,53 +4,33 @@ using log4net;
 using log4net.Appender;
 using log4net.Config;
 using log4net.Core;
+using System.Collections.Generic;
 
 namespace OctopusTools.Diagnostics
 {
     public static class Logger
     {
-        const string LoggingConfiguration =
-            @"<log4net>
-  <root>
-    <level value='DEBUG' />
-    <appender-ref ref='TraceAppender' />
-    <appender-ref ref='ConsoleAppender' />
-  </root>
+		public static string LoggingConfiguration 
+		{
+			get {
+				using (var reader = new System.IO.StreamReader(typeof(Logger).Assembly.GetManifestResourceStream(GetLoggingFileName())))
+				{
+					return reader.ReadToEnd();
+				}
+			}
+		}
 
-  <logger name='Octopus'>
-    <level value='DEBUG' />
-  </logger>
- 
-  <!-- For unit tests -->
-  <appender name='TraceAppender' type='log4net.Appender.TraceAppender'>
-    <layout type='log4net.Layout.PatternLayout'>
-      <conversionPattern value='%message%newline' />
-    </layout>
-  </appender>
-
-  <!-- When running interactively -->
-  <appender name='ConsoleAppender' type='log4net.Appender.ColoredConsoleAppender'>
-    <mapping>
-      <level value='ERROR' />
-      <foreColor value='Red, HighIntensity' />
-    </mapping>
-    <mapping>
-      <level value='WARN' />
-      <foreColor value='Yellow, HighIntensity' />
-    </mapping>
-    <mapping>
-      <level value='Info' />
-      <foreColor value='White, HighIntensity' />
-    </mapping>
-    <mapping>
-      <level value='Debug' />
-      <foreColor value='White' />
-    </mapping>
-    <layout type='log4net.Layout.PatternLayout'>
-      <conversionPattern value='%message%newline' />
-    </layout>
-  </appender>
-</log4net>";
+		private static string GetLoggingFileName()
+		{
+			switch (Environment.OSVersion.Platform) {
+			case PlatformID.MacOSX:
+			case PlatformID.Unix:
+				return "logging-unix.config";
+			default:
+				return "logging.config";
+			}
+		}
+	
 
         public static ILog Default
         {
@@ -81,7 +61,8 @@ namespace OctopusTools.Diagnostics
                 document.LoadXml(LoggingConfiguration);
 
                 Log = LogManager.GetLogger("Octopus");
-                XmlConfigurator.Configure(Log.Logger.Repository, (XmlElement) document.GetElementsByTagName("log4net")[0]);
+
+				XmlConfigurator.Configure(Log.Logger.Repository, (XmlElement) document.GetElementsByTagName("log4net")[0]);
             }
         }
 

--- a/source/OctopusTools/OctopusTools.csproj
+++ b/source/OctopusTools/OctopusTools.csproj
@@ -38,6 +38,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Properties\Icon.ico</ApplicationIcon>
+    <RequireRestoreConsent Condition=" '$(OS)' != 'Windows_NT'">false</RequireRestoreConsent>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac">
@@ -58,14 +59,6 @@
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\packages\Microsoft.Web.Xdt.1.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Core, Version=2.7.41101.299, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NuGet.Core.2.7.2\lib\net40-Client\NuGet.Core.dll</HintPath>
-    </Reference>
     <Reference Include="Octopus.Client, Version=2.4.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Octopus.Client.2.4.1\lib\net40\Octopus.Client.dll</HintPath>
@@ -73,10 +66,6 @@
     <Reference Include="Octopus.Platform, Version=2.4.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Octopus.Client.2.4.1\lib\net40\Octopus.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="Sprache, Version=1.10.0.36, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Sprache.1.10.0.36\lib\net40\Sprache.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -96,6 +85,15 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Core">
+      <HintPath>..\packages\NuGet.Core.2.7.2\lib\net40-Client\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Sprache">
+      <HintPath>..\packages\Sprache.1.10.0.36\lib\net40\Sprache.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">
@@ -153,6 +151,14 @@
   <ItemGroup>
     <Content Include="Properties\Icon.ico" />
   </ItemGroup>
+<ItemGroup>
+  <EmbeddedResource Include="logging.config">
+    <LogicalName>logging.config</LogicalName>
+  </EmbeddedResource>
+  <EmbeddedResource Include="logging-unix.config">
+    <LogicalName>logging-unix.config</LogicalName>
+  </EmbeddedResource>
+</ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
@@ -160,7 +166,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/source/OctopusTools/logging-unix.config
+++ b/source/OctopusTools/logging-unix.config
@@ -1,0 +1,25 @@
+﻿<log4net>
+  <root>
+    <level value='DEBUG' />
+    <appender-ref ref='TraceAppender' />
+    <appender-ref ref='ConsoleAppender' />
+  </root>
+
+  <logger name='Octopus'>
+    <level value='DEBUG' />
+  </logger>
+ 
+  <!-- For unit tests -->
+  <appender name='TraceAppender' type='log4net.Appender.TraceAppender'>
+    <layout type='log4net.Layout.PatternLayout'>
+      <conversionPattern value='%message%newline' />
+    </layout>
+  </appender>
+
+  <!-- When running interactively -->
+  <appender name='ConsoleAppender' type='log4net.Appender.ConsoleAppender'>
+    <layout type='log4net.Layout.PatternLayout'>
+      <conversionPattern value='%message%newline' />
+    </layout>
+  </appender>
+</log4net>

--- a/source/OctopusTools/logging.config
+++ b/source/OctopusTools/logging.config
@@ -1,0 +1,41 @@
+﻿<log4net>
+  <root>
+    <level value='DEBUG' />
+    <appender-ref ref='TraceAppender' />
+    <appender-ref ref='ConsoleAppender' />
+  </root>
+
+  <logger name='Octopus'>
+    <level value='DEBUG' />
+  </logger>
+ 
+  <!-- For unit tests -->
+  <appender name='TraceAppender' type='log4net.Appender.TraceAppender'>
+    <layout type='log4net.Layout.PatternLayout'>
+      <conversionPattern value='%message%newline' />
+    </layout>
+  </appender>
+
+  <!-- When running interactively -->
+  <appender name='ConsoleAppender' type='log4net.Appender.ColoredConsoleAppender'>
+    <mapping>
+      <level value='ERROR' />
+      <foreColor value='Red, HighIntensity' />
+    </mapping>
+    <mapping>
+      <level value='WARN' />
+      <foreColor value='Yellow, HighIntensity' />
+    </mapping>
+    <mapping>
+      <level value='Info' />
+      <foreColor value='White, HighIntensity' />
+    </mapping>
+    <mapping>
+      <level value='Debug' />
+      <foreColor value='White' />
+    </mapping>
+    <layout type='log4net.Layout.PatternLayout'>
+      <conversionPattern value='%message%newline' />
+    </layout>
+  </appender>
+</log4net>


### PR DESCRIPTION
I was not able to run Octo.exe on OSX because of an issue with the ColoredConsoleAppender in log4net. I was able to move the configuration out to separate embedded files and loading a regular ConsoleAppender when on a non windows environment. I was also able to patch the project file so that it will build in Xamarin Studio.
- Updated Logger to pull log4net configuration from an embedded resource file
- Updated project file to auto restore nuget packages on non-windows platforms
- Created separate logging config files

Original error message:

```
log4net:ERROR Could not create Appender [ConsoleAppender] of type [log4net.Appender.ColoredConsoleAppender]. Reported error follows.
System.EntryPointNotFoundException: GetConsoleOutputCP
  at (wrapper managed-to-native) log4net.Appender.ColoredConsoleAppender:GetConsoleOutputCP ()
  at log4net.Appender.ColoredConsoleAppender.ActivateOptions () [0x00000] in <filename unknown>:0
  at log4net.Repository.Hierarchy.XmlHierarchyConfigurator.ParseAppender (System.Xml.XmlElement appenderElement) [0x00000] in <filename unknown>:0
log4net:ERROR Appender named [ConsoleAppender] not found.
Exit code: -1
```
