### PR TITLE
Created a new "octo pack" command.

### DIFF
--- a/source/OctopusTools/Commands/PackCommand.cs
+++ b/source/OctopusTools/Commands/PackCommand.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using log4net;
+using NuGet;
+using Octopus.Platform.Util;
+using OctopusTools.Infrastructure;
+
+namespace OctopusTools.Commands
+{
+    [Command("pack", Description = "Creates a NUPKG from files on disk, without a .NUSPEC or .CSPROJ")]
+    public class PackCommand : ICommand
+    {
+        readonly OptionSet options;
+        readonly ILog log;
+        readonly IOctopusFileSystem fileSystem;
+
+        readonly IList<string> authors = new List<string>();  
+        string id, version, description, title, releaseNotes, releaseNotesFile, outFolder, basePath;
+        readonly IList<string> includes = new List<string>();
+        bool overwrite;
+
+        public PackCommand(ILog log, IOctopusFileSystem fileSystem)
+        {
+            this.log = log;
+            this.fileSystem = fileSystem;
+
+            options = new OptionSet
+            {
+                { "id=", "The ID of the package; e.g. MyCompany.MyApp", v => id = v },
+                { "overwrite", "[Optional] Allow an existing package file of the same ID/version to be overwritten", v => overwrite = true },
+                { "include=", "[Optional, Multiple] Add a file pattern to include, relative to the base path e.g. /bin/*.dll - if none are specified, defaults to **", v => includes.Add(v) },
+                { "basePath=", "[Optional] The root folder containing files and folders to pack; defaults to '.'", v => basePath = v },
+                { "outFolder=", "[Optional] The folder into which the generated NUPKG file will be written; defaults to '.'", v => outFolder = v },
+                { "version=", "[Optional] The version of the package; must be a valid SemVer; defaults to a timestamp-based version", v => version = v },
+                { "author=", "[Optional, Multiple] Add an author to the package metadata; defaults to the current user", v => authors.Add(v) },
+                { "title=", "[Optional] The title of the package", v => title = v },
+                { "description=", "[Optional] A description of the package; defaults to a generic description", v => description = v },
+                { "releaseNotes=", "[Optional] Release notes for this version of the package", v => releaseNotes = v },
+                { "releaseNotesFile=", "[Optional] A file containing release notes for this version of the package", v => releaseNotesFile = v }
+            };
+        }
+
+        public void GetHelp(TextWriter writer)
+        {
+            options.WriteOptionDescriptions(writer);
+        }
+
+        public void Execute(string[] commandLineArguments)
+        {
+            options.Parse(commandLineArguments);
+
+            if (string.IsNullOrWhiteSpace(id))
+                throw new CommandException("An ID is required");
+
+            if (includes.All(string.IsNullOrWhiteSpace))
+                includes.Add("**");
+
+            if (string.IsNullOrWhiteSpace(basePath))
+                basePath = Path.GetFullPath(Environment.CurrentDirectory);
+
+            if (string.IsNullOrWhiteSpace(outFolder))
+                outFolder = Path.GetFullPath(Environment.CurrentDirectory);
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                var now = DateTime.Now;
+                version = new SemanticVersion(now.Year, now.Month, now.Day, now.Hour * 10000 + now.Hour * 100 + now.Second).ToString();
+            }
+
+            if (authors.All(string.IsNullOrWhiteSpace))
+                authors.Add(Environment.UserName + "@" + Environment.UserDomainName);
+
+            if (string.IsNullOrWhiteSpace(description))
+                description = "A deployment package created from files on disk.";
+
+            string allReleaseNotes = null;
+            if (!string.IsNullOrWhiteSpace(releaseNotesFile))
+            {
+                if (!File.Exists(releaseNotesFile))
+                    log.WarnFormat("The release notes file '{0}' could not be found", releaseNotesFile);
+                else
+                    allReleaseNotes = fileSystem.ReadFile(releaseNotesFile);
+            }
+
+            if (!string.IsNullOrWhiteSpace(releaseNotes))
+            {
+                if (allReleaseNotes != null)
+                    allReleaseNotes += Environment.NewLine + releaseNotes;
+                else
+                    allReleaseNotes = releaseNotes;
+            }
+
+            var metadata = new ManifestMetadata
+            {
+                Id = id,
+                Authors = string.Join(", ", authors),
+                Description = description,
+                Version = version
+            };
+
+            if (!string.IsNullOrWhiteSpace(allReleaseNotes))
+                metadata.ReleaseNotes = allReleaseNotes;
+
+            if (!string.IsNullOrWhiteSpace(title))
+                metadata.Title = title;
+
+            log.InfoFormat("Packing {0} version {1}...", id, version);
+
+            var package = new PackageBuilder();
+
+            package.PopulateFiles(basePath, includes.Select(i => new ManifestFile { Source = i }));
+            package.Populate(metadata);
+
+            var filename = metadata.Id + "." + metadata.Version + ".nupkg";
+            var output = Path.Combine(outFolder, filename);
+
+            if (fileSystem.FileExists(output) && !overwrite)
+                throw new CommandException("The package file already exists and --overwrite was not specified");
+
+            log.InfoFormat("Saving {0} to {1}...", filename, outFolder);
+
+            using (var outStream = fileSystem.OpenFile(output, FileMode.Create))
+                package.Save(outStream);
+
+            log.InfoFormat("Done.");
+        }
+    }
+}

--- a/source/OctopusTools/OctopusTools.csproj
+++ b/source/OctopusTools/OctopusTools.csproj
@@ -69,6 +69,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
@@ -105,6 +106,7 @@
     <Compile Include="Commands\CreateEnvironmentCommand.cs" />
     <Compile Include="Commands\CreateProjectCommand.cs" />
     <Compile Include="Commands\DeploymentCommandBase.cs" />
+    <Compile Include="Commands\PackCommand.cs" />
     <Compile Include="Commands\PromoteReleaseCommand.cs" />
     <Compile Include="Infrastructure\CommandAttribute.cs" />
     <Compile Include="Commands\CreateReleaseCommand.cs" />
@@ -151,14 +153,14 @@
   <ItemGroup>
     <Content Include="Properties\Icon.ico" />
   </ItemGroup>
-<ItemGroup>
-  <EmbeddedResource Include="logging.config">
-    <LogicalName>logging.config</LogicalName>
-  </EmbeddedResource>
-  <EmbeddedResource Include="logging-unix.config">
-    <LogicalName>logging-unix.config</LogicalName>
-  </EmbeddedResource>
-</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="logging.config">
+      <LogicalName>logging.config</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="logging-unix.config">
+      <LogicalName>logging-unix.config</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />

--- a/source/OctopusTools/Program.cs
+++ b/source/OctopusTools/Program.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Autofac;
 using Autofac.Features.ResolveAnything;
 using Octopus.Client.Exceptions;
+using Octopus.Platform.Util;
 using OctopusTools.Commands;
 using OctopusTools.Diagnostics;
 using OctopusTools.Infrastructure;
@@ -49,6 +50,7 @@ namespace OctopusTools
             builder.RegisterType<PackageVersionResolver>().As<IPackageVersionResolver>();
             builder.RegisterType<OctopusRepositoryFactory>().As<IOctopusRepositoryFactory>();
             builder.RegisterAssemblyTypes(typeof(Program).Assembly).Where(t => typeof(ICommand).IsAssignableFrom(t)).AsSelf().As<ICommand>();
+            builder.RegisterType<OctopusPhysicalFileSystem>().As<IOctopusFileSystem>();
             return builder.Build();
         }
 


### PR DESCRIPTION
Introduces `octo pack` for generating _.nupkg_ files without NuGet.exe or NuSpecs.

```
octo.exe pack --id=MyPackage
```

Will pack the current directory into a .NUPKG written to the current directory, with a generated version number

```
octo.exe pack --id=MyPackage --version=1.2.3 --author=nick --author=henrik --description="Awesome package" --releaseNotesFile=rn.xml --basePath=dist --outFolder=some/publish --include=**/*.js --include=*.html
```

Complete options:

```
Usage: Octo pack [<options>]

Where [<options>] is any of:

      --id=VALUE             The ID of the package; e.g. MyCompany.MyApp
      --overwrite            [Optional] Allow an existing package file of the
                               same ID/version to be overwritten
      --include=VALUE        [Optional, Multiple] Add a file pattern to
                               include, relative to the base path e.g. /bin/-
                               *.dll - if none are specified, defaults to **
      --basePath=VALUE       [Optional] The root folder containing files and
                               folders to pack; defaults to '.'
      --outFolder=VALUE      [Optional] The folder into which the generated
                               NUPKG file will be written; defaults to '.'
      --version=VALUE        [Optional] The version of the package; must be a
                               valid SemVer; defaults to a timestamp-based
                               version
      --author=VALUE         [Optional, Multiple] Add an author to the
                               package metadata; defaults to the current user
      --title=VALUE          [Optional] The title of the package
      --description=VALUE    [Optional] A description of the package;
                               defaults to a generic description
      --releaseNotes=VALUE   [Optional] Release notes for this version of the
                               package
      --releaseNotesFile=VALUE
                             [Optional] A file containing release notes for
                               this version of the package
```
