### PR TITLE
Automatically create the outFolder if it doesn't exist. Resolves #1186

### DIFF
--- a/source/OctopusTools/Commands/PackCommand.cs
+++ b/source/OctopusTools/Commands/PackCommand.cs
@@ -126,6 +126,8 @@ namespace OctopusTools.Commands
 
             log.InfoFormat("Saving {0} to {1}...", filename, outFolder);
 
+            fileSystem.EnsureDirectoryExists(outFolder);
+
             using (var outStream = fileSystem.OpenFile(output, FileMode.Create))
                 package.Save(outStream);
 


### PR DESCRIPTION
See issue #1186
https://github.com/OctopusDeploy/Issues/issues/1186
