### PR TITLE
Add create and modify behavior to user roles repository

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.approved.txt
@@ -3592,6 +3592,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IFindByName<UserRoleResource>
     Octopus.Client.Repositories.IPaginate<UserRoleResource>
     Octopus.Client.Repositories.IGet<UserRoleResource>
+    Octopus.Client.Repositories.ICreate<UserRoleResource>
+    Octopus.Client.Repositories.IModify<UserRoleResource>
   {
   }
   interface IVariableSetRepository

--- a/source/Octopus.Client/Repositories/IUserRolesRepository.cs
+++ b/source/Octopus.Client/Repositories/IUserRolesRepository.cs
@@ -3,7 +3,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
 {
-    public interface IUserRolesRepository : IFindByName<UserRoleResource>, IGet<UserRoleResource>
+    public interface IUserRolesRepository : IFindByName<UserRoleResource>, IGet<UserRoleResource>, ICreate<UserRoleResource>, IModify<UserRoleResource>
     {
     }
 }


### PR DESCRIPTION
I'm extending https://github.com/Suremaker/OctopusProjectBuilder to support user roles and teams, and I'm currently having to drop down to the client for create and modification.

I'd like to be able to do these operations through the repository instead.

The only role that can't be modified is the built-in system administrator role, this is handled by the API.

I've added signatures to public surface area test, however it's failing on master head relating to subscriptions.