### PR TITLE
Pad month/day values with 0 if less than 10

### DIFF
--- a/source/Octo/Commands/PackCommand.cs
+++ b/source/Octo/Commands/PackCommand.cs
@@ -78,7 +78,9 @@ namespace Octopus.Cli.Commands
             if (version == null)
             {
                 var now = DateTime.Now;
-                version = new SemanticVersion(now.Year, now.Month, now.Day, now.Hour*10000 + now.Minute*100 + now.Second);
+                version = new SemanticVersion(
+                    $"{now.Year}.{now.Month.ToString("D2")}.{now.Day.ToString("D2")}.{now.Hour*10000 + now.Minute*100 + now.Second}"
+                );
             }
 
             if (authors.All(string.IsNullOrWhiteSpace))


### PR DESCRIPTION
Previously dates like `08/09/2016` would create a package version `2016.9.8.nnnnn`, now we would generate package version `2016.09.08.nnnnn`.

Fixes OctopusDeploy/Issues#2838
