### PR TITLE
Fix list-latestDeployments

### DIFF
--- a/source/Octo/Commands/ListLatestDeploymentsCommand.cs
+++ b/source/Octo/Commands/ListLatestDeploymentsCommand.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using NuGet.Packaging;
 using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Repositories;
 using Octopus.Cli.Util;
@@ -29,37 +28,75 @@ namespace Octopus.Cli.Commands
         protected override async Task Execute()
         {
             var projectsFilter = new string[0];
+            var projectsById = new Dictionary<string, string>();
             if (projects.Count > 0)
             {
                 Log.Debug("Loading projects...");
                 var projectResources = await Repository.Projects.FindByNames(projects.ToArray()).ConfigureAwait(false);
                 projectsFilter = projectResources.Select(p => p.Id).ToArray();
+                projectsById = projectResources.ToDictionary(p => p.Id, p => p.Name);
+            }
+            else
+            {
+                projectsById = (await Repository.Projects.FindAll().ConfigureAwait(false)).ToDictionary(p => p.Id, p => p.Name);
             }
 
+            var environmentsById = await LoadEnvironments();
+
+            Log.Debug("Loading dashboard...");
+            var dashboardItems =
+                await
+                    Repository.Dashboards.GetDynamicDashboard(projectsFilter,
+                            environments.Count > 0 ? environmentsById.Keys.ToArray() : new string[] {})
+                        .ConfigureAwait(false);
+
+            Log.Debug("Loading deployments...");
+            var deployments =
+                await Repository.Deployments.Get(dashboardItems.Items.Select(d => d.DeploymentId).ToArray()).ConfigureAwait(false);
+
+            var deploymentsById = deployments.ToDictionary(p => p.Id, p => p);
+
+            foreach (var item in dashboardItems.Items)
+            {
+                await LogDeploymentInfo(deploymentsById[item.DeploymentId], environmentsById, projectsById).ConfigureAwait(false);
+            }
+        }
+
+        async Task<IDictionary<string, string>> LoadProjects()
+        {
+            Log.Debug("Loading projects...");
+
+            if (projects.Any())
+            {
+                var projectResources = Repository.Projects.FindByNames(projects.ToArray()).ConfigureAwait(false);
+                return (await projectResources).ToDictionary(p => p.Id, p => p.Name);
+            }
+
+            var allProjects = Repository.Projects.FindAll().ConfigureAwait(false);
+            return (await allProjects).ToDictionary(p => p.Id, p => p.Name);
+        }
+
+        async Task<IDictionary<string, string>> LoadEnvironments()
+        {
             Log.Debug("Loading environments...");
             var environmentResources = environments.Count > 0
                 ? Repository.Environments.FindByNames(environments.ToArray())
                 : Repository.Environments.FindAll();
 
-            var environmentsById = (await environmentResources.ConfigureAwait(false)).ToDictionary(p => p.Id, p => p.Name);
-
-            var deployments = await Repository.Deployments.FindAll(projectsFilter, environments.Count > 0 ? environmentsById.Keys.ToArray() : new string[] { }).ConfigureAwait(false);
-
-            foreach (var deployment in deployments.Items)
-            {
-                await LogDeploymentInfo(deployment, environmentsById).ConfigureAwait(false);
-            }
+            return (await environmentResources.ConfigureAwait(false)).ToDictionary(p => p.Id, p => p.Name);
         }
 
-        public async Task LogDeploymentInfo(DeploymentResource deployment, Dictionary<string, string> environmentsById)
+        public async Task LogDeploymentInfo(DeploymentResource deployment, IDictionary<string, string> environmentsById, IDictionary<string, string> projectedById)
         {
             var nameOfDeploymentEnvironment = environmentsById[deployment.EnvironmentId];
+            var nameOfDeploymentProject = projectedById[deployment.ProjectId];
             var task = Repository.Tasks.Get(deployment.Link("Task")).ConfigureAwait(false);
             var release = Repository.Releases.Get(deployment.Link("Release")).ConfigureAwait(false);
 
             var propertiesToLog = new List<string>();
             propertiesToLog.AddRange(FormatTaskPropertiesAsStrings(await task));
             propertiesToLog.AddRange(FormatReleasePropertiesAsStrings(await release));
+            Log.Information(" - Project: {Project:l}", nameOfDeploymentProject);
             Log.Information(" - Environment: {Environment:l}", nameOfDeploymentEnvironment);
             foreach (var property in propertiesToLog)
             {

--- a/source/Octo/Commands/ListLatestDeploymentsCommand.cs
+++ b/source/Octo/Commands/ListLatestDeploymentsCommand.cs
@@ -100,6 +100,13 @@ namespace Octopus.Cli.Commands
                 var nameOfDeploymentTenant = tenantsById[dashboardItem.TenantId];
                 Log.Information(" - Tenant: {Tenant:l}", nameOfDeploymentTenant);
             }
+
+            if (!string.IsNullOrEmpty(dashboardItem.ChannelId))
+            {
+                var channel = await Repository.Channels.Get(dashboardItem.ChannelId).ConfigureAwait(false);
+                Log.Information(" - Channel: {Channel:l}", channel.Name);
+            }
+
             Log.Information("   Date: {$Date:l}", dashboardItem.QueueTime);
             Log.Information("   Duration: {Duration:l}", dashboardItem.Duration);
 


### PR DESCRIPTION
The `list-latestDeployments` will show the latest deployment for each environment/project/tenant.

```
Handshaking with Octopus server: http://localhost:8065
Handshake successful. Octopus version: 0.0.0-local; API version: 3.0.0
Authenticated as: admin <null>
Loading projects...
Loading environments...
Loading dashboard...
Loading deployments...
 - Project: A multi tenant project
 - Environment: Production
   Date: 24/11/2016 12:52:30 PM +10:00
   Duration: 2 seconds
   State: Success
   Version: 0.0.5
   Assembled: 24/11/2016 12:52:25 PM +10:00
   Package Versions:
   Release Notes:

 - Project: A multi tenant project
 - Environment: Production
 - Tenant: Mo the Brewer
   Date: 24/11/2016 12:26:22 PM +10:00
   Duration: 2 seconds
   State: Success
   Version: 0.0.1
   Assembled: 24/11/2016 12:25:52 PM +10:00
   Package Versions:
   Release Notes:

 - Project: A multi tenant project
 - Environment: Production
 - Tenant: Bob the builder
   Date: 24/11/2016 12:26:08 PM +10:00
   Duration: 2 seconds
   State: Success
   Version: 0.0.1
   Assembled: 24/11/2016 12:25:52 PM +10:00
   Package Versions:
   Release Notes:

 - Project: Heal machine
 - Environment: Production
   Date: 24/11/2016 11:01:59 AM +10:00
   Duration: 23 seconds
   State: Success
   Version: 0.0.2
   Assembled: 24/11/2016 11:01:56 AM +10:00
   Package Versions:
   Release Notes:

 - Project: Provision Tentacle
 - Environment: Production
   Date: 23/11/2016 9:12:12 AM +10:00
   Duration: 9 seconds
   State: Success
   Version: 0.0.1
   Assembled: 23/11/2016 9:12:08 AM +10:00
   Package Versions:
   Release Notes:
```

Fixes OctopusDeploy/Issues#2992