### PR TITLE
Correction to GetProjects Link

### DIFF
--- a/source/Octopus.Client/Repositories/Async/ProjectGroupRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectGroupRepository.cs
@@ -24,7 +24,7 @@ namespace Octopus.Client.Repositories.Async
         {
             var resources = new List<ProjectResource>();
 
-            await Client.Paginate<ProjectResource>(projectGroup.Link("ProjectGroups"), new { }, page =>
+            await Client.Paginate<ProjectResource>(projectGroup.Link("Projects"), new { }, page =>
             {
                 resources.AddRange(page.Items);
                 return true;


### PR DESCRIPTION
Now using the appropriate link to get the projects associated to a project group.