### PR TITLE
Correction for Gathering ProjectGroup Projects

### DIFF
--- a/source/Octopus.Client/OctopusRepository.cs
+++ b/source/Octopus.Client/OctopusRepository.cs
@@ -1083,7 +1083,7 @@ namespace Octopus.Client
             {
                 var resources = new List<ProjectResource>();
 
-                Client.Paginate<ProjectResource>(projectGroup.Link("ProjectGroups"), new {}, page =>
+                Client.Paginate<ProjectResource>(projectGroup.Link("Projects"), new {}, page =>
                 {
                     resources.AddRange(page.Items);
                     return true;

--- a/source/Octopus.Client/Repositories/Async/ProjectGroupRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectGroupRepository.cs
@@ -24,7 +24,7 @@ namespace Octopus.Client.Repositories.Async
         {
             var resources = new List<ProjectResource>();
 
-            await Client.Paginate<ProjectResource>(projectGroup.Link("ProjectGroups"), new { }, page =>
+            await Client.Paginate<ProjectResource>(projectGroup.Link("Projects"), new { }, page =>
             {
                 resources.AddRange(page.Items);
                 return true;


### PR DESCRIPTION
The Link that is called on the projectGroupResource does not eixist.

The actual link it should be pulling is Projects.
This is directly pulled from the API in 3.6.0

``` JSON
{
  "Id": "ProjectGroups-1",
  "Name": "Active Clients",
  "Description": "Active clients.",
  "EnvironmentIds": [],
  "RetentionPolicyId": null,
  "Links": {
    "Self": "/api/projectgroups/ProjectGroups-1",
    "Projects": "/api/projectgroups/ProjectGroups-1/projects"
  }
}  
```