### PR TITLE
Detect illegal path characters in folder arguments

### DIFF
--- a/source/Octo/Commands/CreateReleaseCommand.cs
+++ b/source/Octo/Commands/CreateReleaseCommand.cs
@@ -33,7 +33,7 @@ namespace Octopus.Cli.Commands
             options.Add("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelName = v);
             options.Add("package=", "[Optional] Version number to use for a package in the release. Format: --package={StepName}:{Version}", v => versionResolver.Add(v));
-            options.Add("packagesFolder=", "[Optional] A folder containing NuGet packages from which we should get versions.", v => versionResolver.AddFolder(v));
+            options.Add("packagesFolder=", "[Optional] A folder containing NuGet packages from which we should get versions.", v => {v.CheckForIllegalPathCharacters("packagesFolder"); versionResolver.AddFolder(v);});
             options.Add("releasenotes=", "[Optional] Release Notes for the new release.", v => ReleaseNotes = v);
             options.Add("releasenotesfile=", "[Optional] Path to a file that contains Release Notes for the new release.", ReadReleaseNotesFromFile);
             options.Add("ignoreexisting", "[Optional, Flag] Don't create this release if there is already one with the same version number.", v => IgnoreIfAlreadyExists = true);

--- a/source/Octo/Commands/PackCommand.cs
+++ b/source/Octo/Commands/PackCommand.cs
@@ -50,8 +50,8 @@ namespace Octopus.Cli.Commands
             basic.Add("id=", "The ID of the package; e.g. MyCompany.MyApp", v => id = v);
             basic.Add("format=", "Package format. Options are: NuPkg, Zip. Defaults to NuPkg, though we recommend Zip going forward.", fmt => packageBuilder = SelectFormat(fmt));
             basic.Add("version=", "[Optional] The version of the package; must be a valid SemVer; defaults to a timestamp-based version", v => version = string.IsNullOrWhiteSpace(v) ? null : new SemanticVersion(v));
-            basic.Add("outFolder=", "[Optional] The folder into which the generated NUPKG file will be written; defaults to '.'", v => outFolder = v);
-            basic.Add("basePath=", "[Optional] The root folder containing files and folders to pack; defaults to '.'", v => basePath = v);
+            basic.Add("outFolder=", "[Optional] The folder into which the generated NUPKG file will be written; defaults to '.'", v => { v.CheckForIllegalPathCharacters(nameof(outFolder)); outFolder = v;});
+            basic.Add("basePath=", "[Optional] The root folder containing files and folders to pack; defaults to '.'", v => { v.CheckForIllegalPathCharacters(nameof(basePath)); basePath = v;});
 
             packageBuilder = SelectFormat("nupkg");
         }

--- a/source/Octo/Util/StringExtensions.cs
+++ b/source/Octo/Util/StringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Octopus.Cli.Infrastructure;
 
 namespace Octopus.Cli.Util
 {
@@ -13,6 +14,14 @@ namespace Octopus.Cli.Util
         public static string NewlineSeperate(this IEnumerable<object> items)
         {
             return string.Join(Environment.NewLine, items);
+        }
+
+        public static void CheckForIllegalPathCharacters(this string path, string name)
+        {
+            if (path.IndexOfAny(System.IO.Path.GetInvalidPathChars()) >= 0)
+            {
+                throw new CommandException($"Argument {name} has a value of {path} which contains invalid path characters. If your path has a trailing backslash either remove it or escape it correctly by using \\\\");
+            }
         }
     }
 }


### PR DESCRIPTION
If you pass a filepath to Octo.exe with a trailing backslash, it is easy to forget to escape it properly. Try to detect that and show a warning.

See also https://github.com/OctopusDeploy/OctoTFS/pull/74

Closes OctopusDeploy/Issues#2663