### PR TITLE
Add zip version parsing to release creation process

### DIFF
--- a/source/Octo.Tests/Commands/PackageVersionResolverFixture.cs
+++ b/source/Octo.Tests/Commands/PackageVersionResolverFixture.cs
@@ -118,9 +118,10 @@ namespace Octopus.Cli.Tests.Commands
         [TestCase("acme.web-1.0.0.0.0", "", "", false)]
         public void CanParseIdAndVersion(string input, string expectedPackageId, string expectedVersion, bool canParse)
         {
-            fileSystem.Files[$@"c:\temp\{input}.zip"] = "";
+            var filename = Path.Combine("temp", $"{input}.zip");
+            fileSystem.Files[filename] = "";
 
-            resolver.AddFolder(@"c:\temp\");
+            resolver.AddFolder(Path.GetDirectoryName(filename));
 
             var result = resolver.ResolveVersion(expectedPackageId);
             if (canParse)

--- a/source/Octo.Tests/Util/FakeOctopusFileSystem.cs
+++ b/source/Octo.Tests/Util/FakeOctopusFileSystem.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Octopus.Cli.Util;
+
+namespace Octopus.Cli.Tests.Util
+{
+    public class FakeOctopusFileSystem : IOctopusFileSystem
+    {
+
+        public Dictionary<string, string> Files { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        public HashSet<string> Deleted { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+
+        public bool FileExists(string path)
+        {
+            return Files.ContainsKey(path);
+        }
+
+        public bool DirectoryExists(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool DirectoryIsEmpty(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void DeleteFile(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void DeleteFile(string path, DeletionOptions options)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void DeleteDirectory(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void DeleteDirectory(string path, DeletionOptions options)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IEnumerable<string> EnumerateDirectories(string parentDirectoryPath)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IEnumerable<string> EnumerateDirectoriesRecursively(string parentDirectoryPath)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IEnumerable<string> EnumerateFiles(string parentDirectoryPath, params string[] searchPatterns)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IEnumerable<string> EnumerateFilesRecursively(string parentDirectoryPath, params string[] searchPatterns)
+        {
+            return searchPatterns
+                .SelectMany(pattern => FindFilesEmulator(pattern, Files.Keys.ToArray()))
+                .Distinct();
+        }
+
+        public long GetFileSize(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ReadFile(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void AppendToFile(string path, string contents)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void OverwriteFile(string path, string contents)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Stream OpenFile(string path, FileAccess access = FileAccess.ReadWrite, FileShare share = FileShare.Read)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Stream OpenFile(string path, FileMode mode = FileMode.OpenOrCreate, FileAccess access = FileAccess.ReadWrite,
+            FileShare share = FileShare.Read)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Stream CreateTemporaryFile(string extension, out string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string CreateTemporaryDirectory()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void CopyDirectory(string sourceDirectory, string targetDirectory, int overwriteFileRetryAttempts = 3)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void CopyDirectory(string sourceDirectory, string targetDirectory, CancellationToken cancel,
+            int overwriteFileRetryAttempts = 3)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public ReplaceStatus CopyFile(string sourceFile, string destinationFile, int overwriteFileRetryAttempts = 3)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void EnsureDirectoryExists(string directoryPath)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void EnsureDiskHasEnoughFreeSpace(string directoryPath)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string GetFullPath(string relativeOrAbsoluteFilePath)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void OverwriteAndDelete(string originalFile, string temporaryReplacement)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void WriteAllBytes(string filePath, byte[] data)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string RemoveInvalidFileNameChars(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void MoveFile(string sourceFile, string destinationFile)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public ReplaceStatus Replace(string path, Stream stream, int overwriteRetryAttempts = 3)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool EqualHash(Stream first, Stream second)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ReadAllText(string scriptFile)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string[] FindFilesEmulator(string pattern, string[] names)
+        {
+            List<string> matches = new List<string>();
+            Regex regex = FindFilesPatternToRegex.Convert(pattern);
+            foreach (string s in names)
+            {
+                if (regex.IsMatch(s))
+                {
+                    matches.Add(s);
+                }
+            }
+            return matches.ToArray();
+        }
+
+        internal static class FindFilesPatternToRegex
+        {
+            private static Regex HasQuestionMarkRegEx = new Regex(@"\?", RegexOptions.Compiled);
+            private static Regex IllegalCharactersRegex = new Regex("[" + @"\/:<>|" + "\"]", RegexOptions.Compiled);
+            private static Regex CatchExtentionRegex = new Regex(@"^\s*.+\.([^\.]+)\s*$", RegexOptions.Compiled);
+            private static string NonDotCharacters = @"[^.]*";
+            public static Regex Convert(string pattern)
+            {
+                if (pattern == null)
+                {
+                    throw new ArgumentNullException();
+                }
+                pattern = pattern.Trim();
+                if (pattern.Length == 0)
+                {
+                    throw new ArgumentException("Pattern is empty.");
+                }
+                if (IllegalCharactersRegex.IsMatch(pattern))
+                {
+                    throw new ArgumentException("Pattern contains illegal characters.");
+                }
+                bool hasExtension = CatchExtentionRegex.IsMatch(pattern);
+                bool matchExact = false;
+                if (HasQuestionMarkRegEx.IsMatch(pattern))
+                {
+                    matchExact = true;
+                }
+                else if (hasExtension)
+                {
+                    matchExact = CatchExtentionRegex.Match(pattern).Groups[1].Length != 3;
+                }
+                string regexString = Regex.Escape(pattern);
+                regexString = "^" + Regex.Replace(regexString, @"\\\*", ".*");
+                regexString = Regex.Replace(regexString, @"\\\?", ".");
+                if (!matchExact && hasExtension)
+                {
+                    regexString += NonDotCharacters;
+                }
+                regexString += "$";
+                Regex regex = new Regex(regexString, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                return regex;
+            }
+        }
+    }
+}

--- a/source/Octo/Commands/PackageVersionResolver.cs
+++ b/source/Octo/Commands/PackageVersionResolver.cs
@@ -17,14 +17,12 @@ namespace Octopus.Cli.Commands
 {
     public class PackageVersionResolver : IPackageVersionResolver
     {
-        static readonly string[] SupportedZipExtensions = { ".zip", ".tgz", ".tar.gz", ".tar.Z", ".tar.bz2", ".tar.bz", ".tbz", ".tar" };
-        static readonly string[] SupportedZipPatterns = SupportedZipExtensions.Select(s => "*" + s).ToArray();
+        static readonly string[] SupportedZipFilePatterns = { "*.zip", "*.tgz", "*.tar.gz", "*.tar.Z", "*.tar.bz2", "*.tar.bz", "*.tbz", "*.tar" };
 
-        readonly Serilog.ILogger log;
+        readonly ILogger log;
         private readonly IOctopusFileSystem fileSystem;
         readonly IDictionary<string, string> stepNameToVersion = new Dictionary<string, string>(StringComparer.CurrentCultureIgnoreCase);
         string defaultVersion;
-        readonly Regex zipNameRegex = new Regex(@"(?<Name>.+?)\.(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?\.zip$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
 
         public PackageVersionResolver(Serilog.ILogger log, IOctopusFileSystem fileSystem)
         {
@@ -45,7 +43,7 @@ namespace Octopus.Cli.Commands
                     Add(packageIdentity.Id, packageIdentity.Version.ToString());
                 }
             }
-            foreach (var file in fileSystem.EnumerateFilesRecursively(folderPath, SupportedZipPatterns))
+            foreach (var file in fileSystem.EnumerateFilesRecursively(folderPath, SupportedZipFilePatterns))
             {
                 log.Debug("Package file: {File:l}", file);
 


### PR DESCRIPTION
Resolves https://github.com/OctopusDeploy/Issues/issues/3148

In the server we support `<id>-<version>.zip` as well as `<id>.<version>.zip` in different places, but not at the same time. Need to check which is right (or both).