### PR TITLE
First prototype of Octopus.Client.Declarative

### DIFF
--- a/source/Octopus.Client/Declarative/ApplyAction.cs
+++ b/source/Octopus.Client/Declarative/ApplyAction.cs
@@ -1,0 +1,8 @@
+﻿namespace Octopus.Client.Declarative
+{
+    public enum ApplyAction
+    {
+        Detect,
+        Commit
+    }
+}

--- a/source/Octopus.Client/Declarative/ConfigurationResult.cs
+++ b/source/Octopus.Client/Declarative/ConfigurationResult.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace Octopus.Client.Declarative
+{
+    public class ConfigurationResult
+    {
+        public ConfigurationResult(IEnumerable<Difference> differences)
+        {
+            Differences = new List<Difference>(differences);
+        }
+
+        public IReadOnlyCollection<Difference> Differences { get; }
+
+        public bool WereDifferencesDetected()
+        {
+            return Differences.Count > 0;
+        }
+    }
+}

--- a/source/Octopus.Client/Declarative/DeclarativeResource.cs
+++ b/source/Octopus.Client/Declarative/DeclarativeResource.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Octopus.Client.Repositories.Async;
+using Octopus.Client.Serialization;
+
+namespace Octopus.Client.Declarative
+{
+    public abstract class DeclarativeResource : IDeclarativeResource
+    {
+        static readonly JsonSerializerSettings JsonSettings = JsonSerialization.GetDefaultSerializerSettings();
+
+        Task IDeclarativeResource.Apply(IOctopusAsyncRepository repository, IApplyContext context)
+        {
+            return Apply(repository, context);
+        }
+
+        protected abstract Task Apply(IOctopusAsyncRepository repository, IApplyContext context);
+        
+        protected async Task CreateOrModify<R, T>(IApplyContext context, R collection, string name, Action<T> callback) where R : IFindByName<T>, ICreate<T>, IModify<T> where T : new()
+        {
+            var item = await collection.FindByName(name);
+            if (item != null)
+            {
+                var serializer = JsonSerializer.Create(JsonSettings);
+                var before = JToken.FromObject(item, serializer);
+
+                callback(item);
+
+                var after = JToken.FromObject(item, serializer);
+
+                if (!JToken.DeepEquals(before, after))
+                {
+                    context.ReportDifference(this, "Modified");
+                    await collection.Modify(item);
+                }
+            }
+            else
+            {
+                context.ReportDifference(this, "New resource");
+
+                item = new T();
+                callback(item);
+                await collection.Create(item);
+            }
+        }
+    }
+}

--- a/source/Octopus.Client/Declarative/Difference.cs
+++ b/source/Octopus.Client/Declarative/Difference.cs
@@ -1,0 +1,17 @@
+﻿namespace Octopus.Client.Declarative
+{
+    public class Difference
+    {
+        public Difference(string summary)
+        {
+            Summary = summary;
+        }
+
+        public string Summary { get; }
+
+        public override string ToString()
+        {
+            return Summary;
+        }
+    }
+}

--- a/source/Octopus.Client/Declarative/IApplyContext.cs
+++ b/source/Octopus.Client/Declarative/IApplyContext.cs
@@ -1,0 +1,8 @@
+﻿namespace Octopus.Client.Declarative
+{
+    public interface IApplyContext
+    {
+        ApplyAction Action { get; }
+        void ReportDifference(IDeclarativeResource resource, string reason);
+    }
+}

--- a/source/Octopus.Client/Declarative/IDeclarativeResource.cs
+++ b/source/Octopus.Client/Declarative/IDeclarativeResource.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Octopus.Client.Declarative
+{
+    public interface IDeclarativeResource
+    {
+        Task Apply(IOctopusAsyncRepository repository, IApplyContext context);
+    }
+}

--- a/source/Octopus.Client/Declarative/OctopusConfiguration.cs
+++ b/source/Octopus.Client/Declarative/OctopusConfiguration.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Octopus.Client.Declarative
+{
+    public class OctopusConfiguration
+    {
+        readonly IList<IDeclarativeResource> resources = new List<IDeclarativeResource>();
+        
+        public OctopusConfiguration Ensure<T>() where T : IDeclarativeResource, new()
+        {
+            resources.Add(new T());
+            return this;
+        }
+
+        public OctopusConfiguration Ensure<T>(T instance) where T : IDeclarativeResource
+        {
+            resources.Add(instance);
+            return this;
+        }
+        
+        public async Task<ConfigurationResult> Apply(IOctopusAsyncRepository repository)
+        {
+            var context = new ApplyContext {Action = ApplyAction.Commit};
+            await ProcessChanges(repository, context);
+            return new ConfigurationResult(context.Differences);
+        }
+
+        public async Task<ConfigurationResult> Test(IOctopusAsyncRepository repository)
+        {
+            var context = new ApplyContext { Action = ApplyAction.Detect };
+            await ProcessChanges(repository, context);
+            return new ConfigurationResult(context.Differences);
+        }
+
+        async Task ProcessChanges(IOctopusAsyncRepository repository, ApplyContext context)
+        {
+            foreach (var resource in resources)
+            {
+                await resource.Apply(repository, context);
+            }
+        }
+
+        class ApplyContext : IApplyContext
+        {
+            public ApplyAction Action { get; set; }
+
+            public List<Difference> Differences { get; } = new List<Difference>();
+
+            public void ReportDifference(IDeclarativeResource resource, string reason)
+            {
+                Differences.Add(new Difference(reason));
+            }
+        }
+    }
+}

--- a/source/Octopus.Client/Declarative/ScriptStepTemplate.cs
+++ b/source/Octopus.Client/Declarative/ScriptStepTemplate.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Octopus.Client.Model;
+using Octopus.Client.Model.DeploymentProcess;
+using Octopus.Client.Repositories.Async;
+using Octopus.Client.Util;
+
+namespace Octopus.Client.Declarative
+{
+    public class ScriptStepTemplate : DeclarativeResource
+    {
+        public string Name { get; set; }
+        public ScriptTarget ScriptTarget { get; set; }
+        public ScriptSyntax Syntax { get; set; }
+        public string Body { get; set; }
+
+        public string FromFile(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName)) throw new ArgumentNullException(nameof(fileName));
+            var found = FileFinder.ResolveFileRelativeToType(fileName, GetType());
+            if (found == null)
+                throw new FileNotFoundException(fileName);
+
+            return File.ReadAllText(found);
+        }
+
+        protected override async Task Apply(IOctopusAsyncRepository repository, IApplyContext context)
+        {
+            await CreateOrModify<IActionTemplateRepository, ActionTemplateResource>(context, repository.ActionTemplates, Name, template =>
+            {
+                template.Name = Name;
+                template.ActionType = "Octopus.Script";
+                template.Properties["Octopus.Action.Script.Syntax"] = Syntax.ToString();
+                template.Properties["Octopus.Action.Script.RunOnServer"] = ScriptTarget == ScriptTarget.Server ? "true" : "false";
+                template.Properties["Octopus.Action.Script.ScriptSource"] = "Inline";
+                template.Properties["Octopus.Action.Script.ScriptBody"] = Body;
+            });
+        }
+    }
+}

--- a/source/Octopus.Client/Util/FileFinder.cs
+++ b/source/Octopus.Client/Util/FileFinder.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Octopus.Client.Logging.LogProviders;
+
+namespace Octopus.Client.Util
+{
+    internal static class FileFinder
+    {
+        public static string ResolveFileRelativeToType(string filename, Type type)
+        {
+            var bestMatch = Path.GetFullPath(filename);
+            if (File.Exists(bestMatch))
+                return bestMatch;
+
+            var assembly = type.GetAssemblyPortable();
+            var root = GetAssemblyLocation(assembly);
+            bestMatch = Path.Combine(root, filename);
+            if (File.Exists(bestMatch))
+                return bestMatch;
+
+            var namespaceSegments = type.Namespace?.Split('.');
+            if (namespaceSegments == null)
+                return null;
+
+            var namespaceStack = new Stack<string>(namespaceSegments);
+            while (namespaceStack.Count > 0)
+            {
+                filename = Path.Combine(namespaceStack.Pop(), filename);
+                var full = Path.GetFullPath(filename);
+                if (File.Exists(full))
+                    return full;
+            }
+            return null;
+        }
+
+        static string GetAssemblyLocation(Assembly assembly)
+        {
+            var codeBase = assembly.CodeBase;
+            var uri = new UriBuilder(codeBase);
+            var path = Uri.UnescapeDataString(uri.Path);
+            return Path.GetDirectoryName(path);
+        }
+    }
+}


### PR DESCRIPTION
(Don't merge, just a prototype)

This pull request is a prototype of a new way to define Octopus resources in a "declarative" style, making it easier for Octopus users to version control important parts of their Octopus configuration. The declarative layer builds on top of the standard REST API, and provides two key capabilities:

 - A way to declare resources (right now, just step templates)
 - A way to detect drift

Users can create a C# console application, import the `Octopus.Client` package, and start using declarative versions of the templates. Here's a project:

![2017-02-16 20_54_58-octopusdsl - microsoft visual studio](https://cloud.githubusercontent.com/assets/47085/23018605/5580f9a0-f48a-11e6-8aeb-13cfb788d6e6.png)

The `HelloWorldScriptTemplate` class looks like this:

```csharp
public class HelloWorldScriptTemplate : ScriptStepTemplate
{
    public HelloWorldScriptTemplate()
    {
        Name = "Hello world";
        Body = FromFile("HelloWorld.ps1");
    }
}
```

The PowerShell script is stored in a file next to the class. 

`Program.cs` simply runs the configuration:

```csharp
class Program
{
    static void Main(string[] args)
    {
        var configuration = new OctopusConfiguration()
            .Ensure<HelloWorldScriptTemplate>();

        ApplyConfiguration(configuration).Wait();
    }

    static async Task ApplyConfiguration(OctopusConfiguration configuration)
    {
        var client = await OctopusAsyncClient.Create(new OctopusServerEndpoint("https://octopus", "API-XYZ"));
        var repository = new OctopusAsyncRepository(client);
        var result = await configuration.Apply(repository);

        if (result.WereDifferencesDetected())
        {
            Console.WriteLine("Differences found: ");
            foreach (var difference in result.Differences)
            {
                Console.WriteLine(" - " + difference.Summary);
            }
        }
        else
        {
            Console.WriteLine("No changes");
        }
    }
}
```

When the application runs, it uses the Octopus REST API to create or modify the resource. Instead of `configuration.Apply`, you can also call `configuration.Test` to detect the drift. 