### PR TITLE
Backwards compatibility change for certificates

### DIFF
--- a/source/Octopus.Client/Repositories/Async/CertificateConfigurationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/CertificateConfigurationRepository.cs
@@ -10,13 +10,23 @@ namespace Octopus.Client.Repositories.Async
 
     class CertificateConfigurationRepository : BasicRepository<CertificateConfigurationResource>, ICertificateConfigurationRepository
     {
-        public CertificateConfigurationRepository(IOctopusAsyncClient client) : base(client, "CertificateConfiguration")
+        public CertificateConfigurationRepository(IOctopusAsyncClient client) : base(client, DetermineCollectionLinkName(client))
         {
         }
 
         public Task<CertificateConfigurationResource> GetOctopusCertificate()
         {
             return Get("certificate-global");
+        }
+
+        static string DetermineCollectionLinkName(IOctopusAsyncClient client)
+        {
+            // For backwards compatibility. 
+            // In Octopus 3.11, what was Certificates was moved to CertificatesConfiguration, to make room for the certificates feature.
+            // This allows pre-3.11 clients to still work.
+            return client.RootDocument == null || client.RootDocument.Links.ContainsKey("CertificateConfiguration")
+                ? "CertificateConfiguration"
+                : "Certificates";
         }
     }
 }

--- a/source/Octopus.Client/Repositories/CertificateConfigurationRepository.cs
+++ b/source/Octopus.Client/Repositories/CertificateConfigurationRepository.cs
@@ -10,13 +10,24 @@ namespace Octopus.Client.Repositories
 
     class CertificateConfigurationRepository : BasicRepository<CertificateConfigurationResource>, ICertificateConfigurationRepository
     {
-        public CertificateConfigurationRepository(IOctopusClient client) : base(client, "CertificateConfiguration")
+        public CertificateConfigurationRepository(IOctopusClient client) : base(client, DetermineCollectionLinkName(client))
         {
         }
 
         public CertificateConfigurationResource GetOctopusCertificate()
         {
             return Get("certificate-global");
+        }
+
+        static string DetermineCollectionLinkName(IOctopusClient client)
+        {
+            // For backwards compatibility. 
+            // In Octopus 3.11, what was Certificates was moved to CertificatesConfiguration, to make room for the certificates feature.
+            // This allows pre-3.11 clients to still work.
+            // The null check is just for tests.
+            return client.RootDocument == null || client.RootDocument.Links.ContainsKey("CertificateConfiguration")
+                ? "CertificateConfiguration"
+                : "Certificates";
         }
     }
 }


### PR DESCRIPTION
Registering a 3.11 polling-tentacle against a pre-3.11 server would fail without this change, as the "CertificateConfiguration" link didn't exist on the RootResource.