### PR TITLE
Fixed the reporting of progress when using the deploy-release command

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -113,7 +113,6 @@ Task("__Build")
 });
 
 Task("__Test")
-    .WithCriteria(false)
     .Does(() =>
 {
     GetFiles("**/*Tests/project.json")

--- a/source/Octo/Commands/TaskOutputProgressPrinter.cs
+++ b/source/Octo/Commands/TaskOutputProgressPrinter.cs
@@ -20,7 +20,7 @@ namespace Octopus.Cli.Commands
 
             if (details.ActivityLogs != null)
             {
-                foreach (var item in details.ActivityLogs)
+                foreach (var item in details.ActivityLogs.SelectMany(a => a.Children))
                 {
                     if (log.ServiceMessagesEnabled())
                     {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2659,6 +2659,7 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
   {
     .ctor()
+    Octopus.Client.Model.ActivityElement ActivityLog { get; set; }
     IList<ActivityElement> ActivityLogs { get; set; }
     Octopus.Client.Model.TaskProgress Progress { get; set; }
     Octopus.Client.Model.TaskResource Task { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3058,6 +3058,7 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
   {
     .ctor()
+    Octopus.Client.Model.ActivityElement ActivityLog { get; set; }
     IList<ActivityElement> ActivityLogs { get; set; }
     Octopus.Client.Model.TaskProgress Progress { get; set; }
     Octopus.Client.Model.TaskResource Task { get; set; }

--- a/source/Octopus.Client.Tests/Repositories/Async/TaskRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/TaskRepositoryTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Client.Model;
+using Octopus.Client.Repositories.Async;
+
+namespace Octopus.Client.Tests.Repositories.Async
+{
+    public class TaskRepositoryTests
+    {
+
+        [Test]
+        public void WaitForCompletionReportsProgress_ActionOverload()
+        {
+            var client = Substitute.For<IOctopusAsyncClient>();
+            var repository = new TaskRepository(client);
+            var taskResource = new TaskResource {Links = new LinkCollection() {{"Self", ""}}, State = TaskState.Queued};
+
+            client.Get<TaskResource>(Arg.Any<string>()).Returns(c => Task.FromResult(taskResource));
+
+            var callbackCount = 0;
+
+            Action<TaskResource[]> action = t =>
+            {
+                t[0].Should().Be(taskResource);
+                callbackCount++;
+                taskResource = new TaskResource()
+                {
+                    State = callbackCount > 3 ? TaskState.Success : TaskState.Executing
+                };
+            };
+
+
+            var wait = repository.WaitForCompletion(taskResource, pollIntervalSeconds: 1, timeoutAfterMinutes:1, interval: action);
+            wait.Wait(TimeSpan.FromSeconds(30));
+
+            callbackCount.Should().BeGreaterThan(3);
+        }
+
+        [Test]
+        public void WaitForCompletionReportsProgress_TaskOverload()
+        {
+            var client = Substitute.For<IOctopusAsyncClient>();
+            var repository = new TaskRepository(client);
+            var taskResource = new TaskResource {Links = new LinkCollection() {{"Self", ""}}, State = TaskState.Queued };
+
+            client.Get<TaskResource>(Arg.Any<string>()).Returns(c => Task.FromResult(taskResource));
+
+            var callbackCount = 0;
+
+            Func<TaskResource[], Task> func = t => Task.Run(() =>
+            {
+                t[0].Should().Be(taskResource);
+                callbackCount++;
+                taskResource = new TaskResource()
+                {
+                    State = callbackCount > 3 ? TaskState.Success : TaskState.Executing
+                };
+            });
+
+
+            var wait = repository.WaitForCompletion(new [] { taskResource }, pollIntervalSeconds: 1, timeoutAfterMinutes: 1, interval: func);
+            wait.Wait(TimeSpan.FromSeconds(30));
+
+            callbackCount.Should().BeGreaterThan(3);
+        }
+    }
+}

--- a/source/Octopus.Client/Model/TaskDetailsResource.cs
+++ b/source/Octopus.Client/Model/TaskDetailsResource.cs
@@ -1,11 +1,34 @@
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Octopus.Client.Model
 {
     public class TaskDetailsResource : Resource
     {
+        private ActivityElement activityLog;
+
         public TaskResource Task { get; set; }
+
         public IList<ActivityElement> ActivityLogs { get; set; }
+
+        /// <summary>
+        /// Returned by Pre 3.4 servers
+        /// Sets the ActivityLogs property as well if it does not already have a value
+        /// </summary>
+        [Obsolete("Use ActivityLogs property")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ActivityElement ActivityLog
+        {
+            get { return activityLog; }
+            set
+            {
+                activityLog = value;
+                if (ActivityLogs == null && activityLog != null)
+                    ActivityLogs = new List<ActivityElement>() {activityLog};
+            }
+        }
+
         public TaskProgress Progress { get; set; }
     }
 }


### PR DESCRIPTION
 When we changed `TaskDetails.ActivityLog` to `ActivityLogs` (3.4.0ish) we no longer checked the progress of the children (ie each steps). Instead only checked the overall process. Therefore the log was only printed once the whole task has finished instead of when each step finished.

Tested on Latest server and 3.2.2.

Fixes #131

