### PR TITLE
Add support for anti-forgery token using cookie-to-header pattern

### DIFF
--- a/source/Octopus.Client.Tests/Integration/OctopusClient/AntiforgeryTokenTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/AntiforgeryTokenTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nancy;
+using Nancy.Cookies;
+using NUnit.Framework;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Tests.Integration.OctopusClient
+{
+    public class AntiforgeryTokenTests : HttpIntegrationTestBase
+    {
+        private static readonly string InstanceId = Guid.NewGuid().ToString("N");
+        private static readonly string AuthCookieValue = "54321";
+        private static readonly string AntiforgeryCookieValue = "12345";
+
+        public AntiforgeryTokenTests()
+        {
+            Get(TestRootPath, p =>
+            {
+                var antiforgeryHeaderValue = Request.Headers[ApiConstants.AntiforgeryTokenHttpHeaderName]?.FirstOrDefault();
+
+                return Response.AsJson(new TestDto {AntiforgeryTokenValue = antiforgeryHeaderValue})
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithCookie(new NancyCookie(
+                        ApiConstants.AuthenticationCookiePrefix + InstanceId,
+                        AuthCookieValue,
+                        httpOnly: true,
+                        secure: Request.Url.IsSecure,
+                        expires: DateTime.UtcNow.AddDays(1)))
+                    .WithCookie(new NancyCookie(
+                        ApiConstants.AntiforgeryTokenCookiePrefix + InstanceId,
+                        AntiforgeryCookieValue,
+                        httpOnly: false,
+                        secure: Request.Url.IsSecure,
+                        expires: DateTime.UtcNow.AddDays(1)));
+            });
+        }
+
+        [Test]
+        public async Task AsyncClient_ShouldCopyAntiforgeryCookieToHeader()
+        {
+            // Simulate getting the auth and antiforgery cookies
+            var firstResponse = await Client.Get<TestDto>(TestRootPath);
+            firstResponse.AntiforgeryTokenValue.Should()
+                .BeNullOrWhiteSpace("The antiforgery cookie hasn't been sent, so we shouln't copy anyhthing to the header yet.");
+
+            // Prove we copy the antiforgery cookie value to the header if it exists
+            var secondResponse = await Client.Get<TestDto>(TestRootPath);
+            secondResponse.AntiforgeryTokenValue.Should()
+                .Be(AntiforgeryCookieValue, $"The antiforgery cookie should have been copied to the {ApiConstants.AntiforgeryTokenHttpHeaderName} header.");
+        }
+
+#if SYNC_CLIENT
+        [Test]
+        public void SyncClient_ShouldCopyAntiforgeryCookieToHeader()
+        {
+            var client = new Client.OctopusClient(new OctopusServerEndpoint(HostBaseUri + TestRootPath));
+            
+            // Simulate getting the auth and antiforgery cookies
+            var firstResponse = client.Get<TestDto>(TestRootPath);
+            firstResponse.AntiforgeryTokenValue.Should()
+                .BeNullOrWhiteSpace("The antiforgery cookie hasn't been sent, so we shouln't copy anyhthing to the header yet.");
+
+            // Prove we copy the antiforgery cookie value to the header if it exists
+            var secondResponse = client.Get<TestDto>(TestRootPath);
+            secondResponse.AntiforgeryTokenValue.Should()
+                .Be(AntiforgeryCookieValue, $"The antiforgery cookie should have been copied to the {ApiConstants.AntiforgeryTokenHttpHeaderName} header.");
+        }
+#endif
+
+        public class TestDto
+        {
+            public string AntiforgeryTokenValue { get; set; }
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -692,7 +692,10 @@ Octopus.Client.Model
   }
   class ApiConstants
   {
+    static System.String AntiforgeryTokenCookiePrefix
+    static System.String AntiforgeryTokenHttpHeaderName
     static System.String ApiKeyHttpHeaderName
+    static System.String AuthenticationCookiePrefix
     static System.Int32 DefaultClientRequestTimeout
     static System.String SupportedApiSchemaVersionMax
     static System.String SupportedApiSchemaVersionMin

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1082,7 +1082,10 @@ Octopus.Client.Model
   }
   class ApiConstants
   {
+    static System.String AntiforgeryTokenCookiePrefix
+    static System.String AntiforgeryTokenHttpHeaderName
     static System.String ApiKeyHttpHeaderName
+    static System.String AuthenticationCookiePrefix
     static System.Int32 DefaultClientRequestTimeout
     static System.String SupportedApiSchemaVersionMax
     static System.String SupportedApiSchemaVersionMin

--- a/source/Octopus.Client/Model/ApiConstants.cs
+++ b/source/Octopus.Client/Model/ApiConstants.cs
@@ -4,9 +4,12 @@ namespace Octopus.Client.Model
 {
     public class ApiConstants
     {
-        public const int DefaultClientRequestTimeout = 1000*60*10;
-        public const string SupportedApiSchemaVersionMin = "3.0.0";
-        public const string SupportedApiSchemaVersionMax = "3.0.99";
-        public const string ApiKeyHttpHeaderName = "X-Octopus-ApiKey";
+        public static readonly int DefaultClientRequestTimeout = 1000 * 60 * 10;
+        public static readonly string SupportedApiSchemaVersionMin = "3.0.0";
+        public static readonly string SupportedApiSchemaVersionMax = "3.0.99";
+        public static readonly string AuthenticationCookiePrefix = "OctopusIdentificationToken";
+        public static readonly string ApiKeyHttpHeaderName = "X-Octopus-ApiKey";
+        public static readonly string AntiforgeryTokenCookiePrefix = "Octopus-Csrf-Token";
+        public static readonly string AntiforgeryTokenHttpHeaderName = "X-Octopus-Csrf-Token";
     }
 }

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -464,7 +464,7 @@ namespace Octopus.Client
                 .SingleOrDefault(c => c.Name.StartsWith(ApiConstants.AntiforgeryTokenCookiePrefix));
             if (antiforgeryCookie != null)
             {
-                //webRequest.Headers[ApiConstants.AntiforgeryTokenHttpHeaderName] = antiforgeryCookie.Value;
+                webRequest.Headers[ApiConstants.AntiforgeryTokenHttpHeaderName] = antiforgeryCookie.Value;
             }
 
             var requestHandler = SendingOctopusRequest;


### PR DESCRIPTION
Based on this recommendation: https://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-Header_Token

See related Octopus PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/847

> If there is an anti-forgery cookie in the response, copy its value to the correct header for any outbound requests

# Compatibility concerns

> Customers will only need a newer Client version if they upgrade their Octopus Server and are using Username Password credentials

1. Customers using API Keys will not be affected - API Key authenticated requests are not subject to anti-forgery token validation.
2. Older servers don't send the anti-forgery cookie so it can't/won't be copied to any outgoing requests
3. Newer servers will require anti-forgery header if the client uses an auth cookie session, and will make recommendations if the anti-forgery header is missing

I think this approach should cover 99% of cases:
1. Most customers should be using API Keys for automation - no change
2. Those customers who use username/password just need to grab the latest client
3. Those using raw HTTP will need to implement their own cookie-to-header copy