### PR TITLE
Fixed PackagesFolder not finding .nupkg files

### DIFF
--- a/source/Octo/Commands/PackageVersionResolver.cs
+++ b/source/Octo/Commands/PackageVersionResolver.cs
@@ -33,7 +33,7 @@ namespace Octopus.Cli.Commands
         public void AddFolder(string folderPath)
         {
             log.Debug("Using package versions from folder: {FolderPath:l}", folderPath);
-            foreach (var file in fileSystem.EnumerateFilesRecursively(folderPath, ".nupkg"))
+            foreach (var file in fileSystem.EnumerateFilesRecursively(folderPath, "*.nupkg"))
             {
                 log.Debug("Package file: {File:l}", file);
 


### PR DESCRIPTION
octo.exe --packagesfolder is not currently recognizing nuget packages. Adding an asterisk to allow packages to be recognized.