### PR TITLE
pack: --verbose flag for files in package logging

### DIFF
--- a/source/Octo/Commands/IPackageBuilder.cs
+++ b/source/Octo/Commands/IPackageBuilder.cs
@@ -5,6 +5,6 @@ namespace Octopus.Cli.Commands
 {
     public interface IPackageBuilder
     {
-        void BuildPackage(string basePath, IList<string> includes, ManifestMetadata metadata, string outFolder, bool overwrite);
+        void BuildPackage(string basePath, IList<string> includes, ManifestMetadata metadata, string outFolder, bool overwrite, bool verboseInfo);
     }
 }

--- a/source/Octo/Commands/NuGetPackageBuilder.cs
+++ b/source/Octo/Commands/NuGetPackageBuilder.cs
@@ -18,12 +18,18 @@ namespace Octopus.Cli.Commands
             this.log = log;
         }
 
-        public void BuildPackage(string basePath, IList<string> includes, ManifestMetadata metadata, string outFolder, bool overwrite)
+        public void BuildPackage(string basePath, IList<string> includes, ManifestMetadata metadata, string outFolder, bool overwrite, bool verboseInfo)
         {
             var nugetPkgBuilder = new PackageBuilder();
 
-            nugetPkgBuilder.PopulateFiles(basePath, includes.Select(i => new ManifestFile { Source = i }));
+            var manifestFiles = includes.Select(i => new ManifestFile {Source = i}).ToList();
+            nugetPkgBuilder.PopulateFiles(basePath, manifestFiles);
             nugetPkgBuilder.Populate(metadata);
+
+            if (verboseInfo)
+            {
+                nugetPkgBuilder.Files.ToList().ForEach(f => log.Information("Adding file: {Path}", f.Path));
+            }
 
             var filename = metadata.Id + "." + metadata.Version + ".nupkg";
             var output = Path.Combine(outFolder, filename);

--- a/source/Octo/Commands/NuGetPackageBuilder.cs
+++ b/source/Octo/Commands/NuGetPackageBuilder.cs
@@ -28,7 +28,10 @@ namespace Octopus.Cli.Commands
 
             if (verboseInfo)
             {
-                nugetPkgBuilder.Files.ToList().ForEach(f => log.Information("Adding file: {Path}", f.Path));
+                foreach(var file in nugetPkgBuilder.Files)
+                {
+                    log.Information($"Added file: {file.Path}");
+                }
             }
 
             var filename = metadata.Id + "." + metadata.Version + ".nupkg";

--- a/source/Octo/Commands/PackCommand.cs
+++ b/source/Octo/Commands/PackCommand.cs
@@ -24,6 +24,7 @@ namespace Octopus.Cli.Commands
         string id;
         string outFolder;
         bool overwrite;
+        bool verbose;
         string releaseNotes, releaseNotesFile;
         string title;
         SemanticVersion version;
@@ -48,10 +49,11 @@ namespace Octopus.Cli.Commands
             
             var basic = optionGroups.For("Basic options");
             basic.Add("id=", "The ID of the package; e.g. MyCompany.MyApp", v => id = v);
-            basic.Add("format=", "Package format. Options are: NuPkg, Zip. Defaults to NuPkg, though we recommend Zip going forward.", fmt => packageBuilder = SelectFormat(fmt));
+            basic.Add("format=", "Package format. Options are: NuPkg, Zip. Defaults to NuPkg, though we recommend Zip going forward", fmt => packageBuilder = SelectFormat(fmt));
             basic.Add("version=", "[Optional] The version of the package; must be a valid SemVer; defaults to a timestamp-based version", v => version = string.IsNullOrWhiteSpace(v) ? null : new SemanticVersion(v));
             basic.Add("outFolder=", "[Optional] The folder into which the generated NUPKG file will be written; defaults to '.'", v => { v.CheckForIllegalPathCharacters(nameof(outFolder)); outFolder = v;});
             basic.Add("basePath=", "[Optional] The root folder containing files and folders to pack; defaults to '.'", v => { v.CheckForIllegalPathCharacters(nameof(basePath)); basePath = v;});
+            basic.Add("verbose", "[Optional] verbose output", v => verbose = true);
 
             packageBuilder = SelectFormat("nupkg");
         }
@@ -127,9 +129,10 @@ namespace Octopus.Cli.Commands
                 if (!string.IsNullOrWhiteSpace(title))
                     metadata.Title = title;
 
-                log.Information("Packing {PackageId:l} version {Version}...", id, version);
+                log.Information($"{(verbose ? "Verbose logging" : "")}");
+                log.Information("Packing {id:l} version {Version}...", id, version);
 
-                packageBuilder.BuildPackage(basePath, includes, metadata, outFolder, overwrite);
+                packageBuilder.BuildPackage(basePath, includes, metadata, outFolder, overwrite, verbose);
 
                 log.Information("Done.");
             });

--- a/source/Octo/Commands/PackCommand.cs
+++ b/source/Octo/Commands/PackCommand.cs
@@ -129,7 +129,9 @@ namespace Octopus.Cli.Commands
                 if (!string.IsNullOrWhiteSpace(title))
                     metadata.Title = title;
 
-                log.Information($"{(verbose ? "Verbose logging" : "")}");
+                
+                if (verbose)
+                    log.Information("Verbose logging");
                 log.Information("Packing {id:l} version {Version}...", id, version);
 
                 packageBuilder.BuildPackage(basePath, includes, metadata, outFolder, overwrite, verbose);

--- a/source/Octo/Commands/ZipPackageBuilder.cs
+++ b/source/Octo/Commands/ZipPackageBuilder.cs
@@ -20,7 +20,7 @@ namespace Octopus.Cli.Commands
             this.log = log;
         }
 
-        public void BuildPackage(string basePath, IList<string> includes, ManifestMetadata metadata, string outFolder, bool overwrite)
+        public void BuildPackage(string basePath, IList<string> includes, ManifestMetadata metadata, string outFolder, bool overwrite, bool verboseInfo)
         {
             var filename = metadata.Id + "." + metadata.Version + ".zip";
             var output = fileSystem.GetFullPath(Path.Combine(outFolder, filename));
@@ -47,7 +47,11 @@ namespace Octopus.Cli.Commands
 
                         var relativePath = UseCrossPlatformDirectorySeparator(
                             fullFilePath.Substring(basePathLength).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-                        log.Debug("Adding file: {Path}", relativePath);
+
+                        if (verboseInfo)
+                            log.Information("Adding file: {Path}", relativePath);
+                        else
+                            log.Debug("Adding file: {Path}", relativePath);
 
                         var entry = archive.CreateEntry(relativePath, CompressionLevel.Optimal);
                         entry.LastWriteTime = new DateTimeOffset(new FileInfo(file).LastWriteTime);

--- a/source/Octo/Commands/ZipPackageBuilder.cs
+++ b/source/Octo/Commands/ZipPackageBuilder.cs
@@ -6,6 +6,7 @@ using NuGet.Common;
 using NuGet.Packaging;
 using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Util;
+using Serilog.Events;
 
 namespace Octopus.Cli.Commands
 {
@@ -32,6 +33,7 @@ namespace Octopus.Cli.Commands
 
             fileSystem.EnsureDirectoryExists(outFolder);
 
+            var logLevel = verboseInfo ? LogEventLevel.Verbose : LogEventLevel.Debug;
             var basePathLength = fileSystem.GetFullPath(basePath).Length;
             using (var stream = fileSystem.OpenFile(output, FileAccess.Write))
             using (var archive = new ZipArchive(stream, ZipArchiveMode.Create))
@@ -48,10 +50,7 @@ namespace Octopus.Cli.Commands
                         var relativePath = UseCrossPlatformDirectorySeparator(
                             fullFilePath.Substring(basePathLength).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
 
-                        if (verboseInfo)
-                            log.Information("Adding file: {Path}", relativePath);
-                        else
-                            log.Debug("Adding file: {Path}", relativePath);
+                        log.Write(logLevel, "Added file: {relativePath}");
 
                         var entry = archive.CreateEntry(relativePath, CompressionLevel.Optimal);
                         entry.LastWriteTime = new DateTimeOffset(new FileInfo(file).LastWriteTime);


### PR DESCRIPTION
pack command takes --verbose, will log out more info to start with all
the files added to ZIP and NuPkg

Fixes: https://github.com/OctopusDeploy/Issues/issues/3171

Taks:
 - [x] octo.exe support of --versbose flag

Will come later:
 - VSTS extension supporting changes
 - Team City extension supporting changes (java)