### PR TITLE
Create user

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3831,7 +3831,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<UserResource>
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
+    Task<UserResource> Create(String, String, String, String)
     Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Task<UserResource> CreateServiceAccount(String, String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
     Task<UserResource> GetCurrent()
     Task<UserPermissionSetResource> GetPermissions(Octopus.Client.Model.UserResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3829,6 +3829,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<UserResource>
     Octopus.Client.Repositories.Async.IModify<UserResource>
     Octopus.Client.Repositories.Async.IDelete<UserResource>
+    Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
     Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -3846,6 +3847,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<UserRoleResource>
     Octopus.Client.Repositories.Async.IPaginate<UserRoleResource>
     Octopus.Client.Repositories.Async.IGet<UserRoleResource>
+    Octopus.Client.Repositories.Async.ICreate<UserRoleResource>
+    Octopus.Client.Repositories.Async.IModify<UserRoleResource>
   {
   }
   interface IVariableSetRepository

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4231,6 +4231,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<UserResource>
     Octopus.Client.Repositories.IModify<UserResource>
     Octopus.Client.Repositories.IDelete<UserResource>
+    Octopus.Client.Repositories.ICreate<UserResource>
   {
     Octopus.Client.Model.ApiKeyResource CreateApiKey(Octopus.Client.Model.UserResource, String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -4665,6 +4666,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<UserResource>
     Octopus.Client.Repositories.Async.IModify<UserResource>
     Octopus.Client.Repositories.Async.IDelete<UserResource>
+    Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
     Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -4682,6 +4684,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<UserRoleResource>
     Octopus.Client.Repositories.Async.IPaginate<UserRoleResource>
     Octopus.Client.Repositories.Async.IGet<UserRoleResource>
+    Octopus.Client.Repositories.Async.ICreate<UserRoleResource>
+    Octopus.Client.Repositories.Async.IModify<UserRoleResource>
   {
   }
   interface IVariableSetRepository

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4233,7 +4233,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<UserResource>
     Octopus.Client.Repositories.ICreate<UserResource>
   {
+    Octopus.Client.Model.UserResource Create(String, String, String, String)
     Octopus.Client.Model.ApiKeyResource CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
     Octopus.Client.Model.UserResource GetCurrent()
     Octopus.Client.Model.UserPermissionSetResource GetPermissions(Octopus.Client.Model.UserResource)
@@ -4668,7 +4670,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<UserResource>
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
+    Task<UserResource> Create(String, String, String, String)
     Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Task<UserResource> CreateServiceAccount(String, String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
     Task<UserResource> GetCurrent()
     Task<UserPermissionSetResource> GetPermissions(Octopus.Client.Model.UserResource)

--- a/source/Octopus.Client/Repositories/Async/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRepository.cs
@@ -9,7 +9,8 @@ namespace Octopus.Client.Repositories.Async
         IPaginate<UserResource>,
         IGet<UserResource>,
         IModify<UserResource>,
-        IDelete<UserResource>
+        IDelete<UserResource>,
+        ICreate<UserResource>
     {
         Task<UserResource> Register(RegisterCommand registerCommand);
         Task SignIn(LoginCommand loginCommand);

--- a/source/Octopus.Client/Repositories/Async/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRepository.cs
@@ -12,6 +12,8 @@ namespace Octopus.Client.Repositories.Async
         IDelete<UserResource>,
         ICreate<UserResource>
     {
+        Task<UserResource> Create(string username, string displayName, string password = null, string emailAddress = null);
+        Task<UserResource> CreateServiceAccount(string username, string displayName);
         Task<UserResource> Register(RegisterCommand registerCommand);
         Task SignIn(LoginCommand loginCommand);
         Task SignIn(string username, string password, bool rememberMe = false);
@@ -33,6 +35,30 @@ namespace Octopus.Client.Repositories.Async
             : base(client, "Users")
         {
             invitations = new InvitationRepository(client);
+        }
+
+        public Task<UserResource> Create(string username, string displayName, string password = null, string emailAddress = null)
+        {
+            return Create(new UserResource
+            {
+                Username = username,
+                DisplayName = displayName,
+                Password = password,
+                EmailAddress = emailAddress,
+                IsActive = true,
+                IsService = false
+            });
+        }
+
+        public Task<UserResource> CreateServiceAccount(string username, string displayName)
+        {
+            return Create(new UserResource
+            {
+                Username = username,
+                DisplayName = displayName,
+                IsActive = true,
+                IsService = true
+            });
         }
 
         public async Task<UserResource> Register(RegisterCommand registerCommand)

--- a/source/Octopus.Client/Repositories/Async/UserRolesRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRolesRepository.cs
@@ -3,7 +3,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
-    public interface IUserRolesRepository : IFindByName<UserRoleResource>, IGet<UserRoleResource>
+    public interface IUserRolesRepository : IFindByName<UserRoleResource>, IGet<UserRoleResource>, ICreate<UserRoleResource>, IModify<UserRoleResource>
     {
     }
 

--- a/source/Octopus.Client/Repositories/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/UserRepository.cs
@@ -11,6 +11,8 @@ namespace Octopus.Client.Repositories
         IDelete<UserResource>,
         ICreate<UserResource>
     {
+        UserResource Create(string username, string displayName, string password = null, string emailAddress = null);
+        UserResource CreateServiceAccount(string username, string displayName);
         UserResource Register(RegisterCommand registerCommand);
         void SignIn(LoginCommand loginCommand);
         void SignIn(string username, string password, bool rememberMe = false);
@@ -34,6 +36,29 @@ namespace Octopus.Client.Repositories
             invitations = new InvitationRepository(client);
         }
 
+        public UserResource Create(string username, string displayName, string password = null, string emailAddress = null)
+        {
+            return Create(new UserResource
+            {
+                Username = username,
+                DisplayName = displayName,
+                Password = password,
+                EmailAddress = emailAddress,
+                IsActive = true,
+                IsService = false
+            });
+        }
+
+        public UserResource CreateServiceAccount(string username, string displayName)
+        {
+            return Create(new UserResource
+            {
+                Username = username,
+                DisplayName = displayName,
+                IsActive = true,
+                IsService = true
+            });
+        }
         public UserResource Register(RegisterCommand registerCommand)
         {
             Client.Post(Client.RootDocument.Link("Register"), registerCommand);

--- a/source/Octopus.Client/Repositories/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/UserRepository.cs
@@ -8,7 +8,8 @@ namespace Octopus.Client.Repositories
         IPaginate<UserResource>,
         IGet<UserResource>,
         IModify<UserResource>,
-        IDelete<UserResource>
+        IDelete<UserResource>,
+        ICreate<UserResource>
     {
         UserResource Register(RegisterCommand registerCommand);
         void SignIn(LoginCommand loginCommand);


### PR DESCRIPTION
The ability to create users was missing from the basic repository (by omission I think), and have added some shortcut methods for creating valid user accounts for people and services.

Tested against Octopus 3.11.x but should be backwards and forwards compatible since there are no resource changes, and it's an additive API change.