### PR TITLE
Isolate anti-forgery token by InstallationId

### DIFF
--- a/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
+++ b/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
@@ -30,6 +30,7 @@ namespace Octopus.Client.Tests.Integration
     {
         public static readonly string HostBaseUri = "http://foo.localtest.me:17358";
         public static readonly string HostBaseSslUri = "https://localhost:17359";
+        protected static readonly Guid InstallationId = Guid.NewGuid();
         public static readonly byte[] SharedBytes = { 34, 56, 255, 0, 8 };
         static IWebHost currentHost;
 
@@ -88,6 +89,7 @@ namespace Octopus.Client.Tests.Integration
                  new RootResource()
                  {
                      ApiVersion = "3.0.0",
+                     InstallationId = InstallationId,
                      Links = new LinkCollection()
                      {
                          { "CurrentUser",$"{TestRootPath}/api/users/me" }

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/AntiforgeryTokenTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/AntiforgeryTokenTests.cs
@@ -11,7 +11,6 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
 {
     public class AntiforgeryTokenTests : HttpIntegrationTestBase
     {
-        private static readonly string InstanceId = Guid.NewGuid().ToString("N");
         private static readonly string AuthCookieValue = "54321";
         private static readonly string AntiforgeryCookieValue = "12345";
 
@@ -24,13 +23,13 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
                 return Response.AsJson(new TestDto {AntiforgeryTokenValue = antiforgeryHeaderValue})
                     .WithStatusCode(HttpStatusCode.OK)
                     .WithCookie(new NancyCookie(
-                        ApiConstants.AuthenticationCookiePrefix + InstanceId,
+                        $"{ApiConstants.AuthenticationCookiePrefix}_{InstallationId}",
                         AuthCookieValue,
                         httpOnly: true,
                         secure: Request.Url.IsSecure,
                         expires: DateTime.UtcNow.AddDays(1)))
                     .WithCookie(new NancyCookie(
-                        ApiConstants.AntiforgeryTokenCookiePrefix + InstanceId,
+                        $"{ApiConstants.AntiforgeryTokenCookiePrefix}_{InstallationId}",
                         AntiforgeryCookieValue,
                         httpOnly: false,
                         secure: Request.Url.IsSecure,
@@ -57,6 +56,8 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
         public void SyncClient_ShouldCopyAntiforgeryCookieToHeader()
         {
             var client = new Client.OctopusClient(new OctopusServerEndpoint(HostBaseUri + TestRootPath));
+            // Force the root document to load
+            var rootDocument = client.RootDocument;
             
             // Simulate getting the auth and antiforgery cookies
             var firstResponse = client.Get<TestDto>(TestRootPath);

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2372,6 +2372,7 @@ Octopus.Client.Model
     String Application { get; set; }
     Boolean FormsLoginEnabled { get; set; }
     Boolean GuestLoginEnabled { get; set; }
+    Guid InstallationId { get; set; }
     Boolean IsEarlyAccessProgram { get; set; }
     String Version { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2767,6 +2767,7 @@ Octopus.Client.Model
     String Application { get; set; }
     Boolean FormsLoginEnabled { get; set; }
     Boolean GuestLoginEnabled { get; set; }
+    Guid InstallationId { get; set; }
     Boolean IsEarlyAccessProgram { get; set; }
     String Version { get; set; }
   }

--- a/source/Octopus.Client/Model/RootResource.cs
+++ b/source/Octopus.Client/Model/RootResource.cs
@@ -9,6 +9,7 @@ namespace Octopus.Client.Model
         public string Application { get; set; }
         public string Version { get; set; }
         public string ApiVersion { get; set; }
+        public Guid InstallationId { get; set; }
 
         [DefaultValue(false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Text;
-using System.Threading;
 using Newtonsoft.Json;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
@@ -516,13 +514,16 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                     message.Headers.Add("X-HTTP-Method-Override", request.Method);
                 }
 
-                var antiforgeryCookie = cookieContainer.GetCookies(cookieOriginUri)
-                    .Cast<Cookie>()
-                    .SingleOrDefault(c => c.Name.StartsWith(ApiConstants.AntiforgeryTokenCookiePrefix));
-
-                if (antiforgeryCookie != null)
+                if (RootDocument != null)
                 {
-                    message.Headers.Add(ApiConstants.AntiforgeryTokenHttpHeaderName, antiforgeryCookie.Value);
+                    var expectedCookieName = $"{ApiConstants.AntiforgeryTokenCookiePrefix}_{RootDocument.InstallationId}";
+                    var antiforgeryCookie = cookieContainer.GetCookies(cookieOriginUri)
+                        .Cast<Cookie>()
+                        .SingleOrDefault(c => string.Equals(c.Name, expectedCookieName));
+                    if (antiforgeryCookie != null)
+                    {
+                        message.Headers.Add(ApiConstants.AntiforgeryTokenHttpHeaderName, antiforgeryCookie.Value);
+                    }
                 }
 
                 var requestHandler = SendingOctopusRequest;

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -459,12 +459,16 @@ namespace Octopus.Client
                 webRequest.Method = "POST";
             }
 
-            var antiforgeryCookie = cookieContainer.GetCookies(cookieOriginUri)
-                .Cast<Cookie>()
-                .SingleOrDefault(c => c.Name.StartsWith(ApiConstants.AntiforgeryTokenCookiePrefix));
-            if (antiforgeryCookie != null)
+            if (rootDocument != null)
             {
-                webRequest.Headers[ApiConstants.AntiforgeryTokenHttpHeaderName] = antiforgeryCookie.Value;
+                var expectedCookieName = $"{ApiConstants.AntiforgeryTokenCookiePrefix}_{rootDocument.InstallationId}";
+                var antiforgeryCookie = cookieContainer.GetCookies(cookieOriginUri)
+                    .Cast<Cookie>()
+                    .SingleOrDefault(c => string.Equals(c.Name, expectedCookieName));
+                if (antiforgeryCookie != null)
+                {
+                    webRequest.Headers[ApiConstants.AntiforgeryTokenHttpHeaderName] = antiforgeryCookie.Value;
+                }
             }
 
             var requestHandler = SendingOctopusRequest;


### PR DESCRIPTION
In the rare-ish case where customers have multiple Octopus installations on the same domain (it does happen, quite a lot in our test environments too) we will end up with multiple cookies in the CookieCollection for that domain, and we were looking for the first match based on the common prefix. Quite often this would end up with the wrong anti-forgery cookie for that installation and fail validation. We should use the InstallationId to partition and find the correct anti-forgery cookie.

![image](https://cloud.githubusercontent.com/assets/1627582/23880286/72c3c29a-089e-11e7-9f61-10af50b25159.png)

This should be both backwards and forwards compatible. We haven't released any versions of Octopus Server with CSRF support yet, so there also shouldn't be any compatibility concerns there.

See related commit for Server and JS: https://github.com/OctopusDeploy/OctopusDeploy/pull/847/commits/67bc3f64f8e5ac16e3b307392a8849bb82ef212d