### PR TITLE
Fix unix octo start script so that it

### DIFF
--- a/BuildAssets/Octo
+++ b/BuildAssets/Octo
@@ -1,2 +1,11 @@
 #!/bin/bash
-dotnet Octo.dll
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+cd -P "$( dirname "$SOURCE" )"
+# LTTNG_UST_REGISTER_TIMEOUT=0 is there to work around a bug in docker that causes an assertion violation in dotnet on first launch
+# See https://github.com/dotnet/cli/issues/1582
+LTTNG_UST_REGISTER_TIMEOUT=0 dotnet Octo.dll $*


### PR DESCRIPTION
- can be called via symlinks from any location
- works in docker
- passes on the arguments