### PR TITLE
GetOctopusCertificate backwards-compatibility

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3526,6 +3526,7 @@ Octopus.Client.Repositories.Async
   {
     Task Archive(Octopus.Client.Model.CertificateResource)
     Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
+    Task<CertificateConfigurationResource> GetOctopusCertificate()
     Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String)
     Task UnArchive(Octopus.Client.Model.CertificateResource)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3931,6 +3931,7 @@ Octopus.Client.Repositories
   {
     void Archive(Octopus.Client.Model.CertificateResource)
     Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
+    Octopus.Client.Model.CertificateConfigurationResource GetOctopusCertificate()
     Octopus.Client.Model.CertificateResource Replace(Octopus.Client.Model.CertificateResource, String, String)
     void UnArchive(Octopus.Client.Model.CertificateResource)
   }
@@ -4370,6 +4371,7 @@ Octopus.Client.Repositories.Async
   {
     Task Archive(Octopus.Client.Model.CertificateResource)
     Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
+    Task<CertificateConfigurationResource> GetOctopusCertificate()
     Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String)
     Task UnArchive(Octopus.Client.Model.CertificateResource)
   }

--- a/source/Octopus.Client/Repositories/Async/CertificateRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/CertificateRepository.cs
@@ -37,6 +37,14 @@ namespace Octopus.Client.Repositories.Async
         /// Unarchive a certificate. This makes the certificate again available for selection as the value of a variable.
         /// </summary>
         Task UnArchive(CertificateResource certificate);
+
+        // For backwards compatibility.  
+        // The CertificateRepository was renamed to CertificateConfigurationRepository when the Certificates feature was 
+        // implemented. This method avoids breaking existing scripts and code.  
+        /// <summary>
+        /// Returns details of the certificate used by Octopus for communications.
+        /// </summary>
+        Task<CertificateConfigurationResource> GetOctopusCertificate();
     }
 
     class CertificateRepository : BasicRepository<CertificateResource>, ICertificateRepository
@@ -65,6 +73,11 @@ namespace Octopus.Client.Repositories.Async
         public Task UnArchive(CertificateResource certificate)
         {
             return Client.Post(certificate.Link("Unarchive"));
+        }
+
+        public Task<CertificateConfigurationResource> GetOctopusCertificate()
+        {
+            return Client.Repository.CertificateConfiguration.GetOctopusCertificate();
         }
     }
 }

--- a/source/Octopus.Client/Repositories/CertificateRepository.cs
+++ b/source/Octopus.Client/Repositories/CertificateRepository.cs
@@ -37,6 +37,14 @@ namespace Octopus.Client.Repositories
         /// Unarchive a certificate. This makes the certificate again available for selection as the value of a variable.
         /// </summary>
         void UnArchive(CertificateResource certificate);
+
+        // For backwards compatibility.  
+        // The CertificateRepository was renamed to CertificateConfigurationRepository when the Certificates feature was 
+        // implemented. This method avoids breaking existing scripts and code.  
+        /// <summary>
+        /// Returns details of the certificate used by Octopus for communications.
+        /// </summary>
+        CertificateConfigurationResource GetOctopusCertificate();
     }
     
     class CertificateRepository : BasicRepository<CertificateResource>, ICertificateRepository
@@ -65,6 +73,11 @@ namespace Octopus.Client.Repositories
         public void UnArchive(CertificateResource certificate)
         {
             Client.Post(certificate.Link("Unarchive"));
+        }
+
+        public CertificateConfigurationResource GetOctopusCertificate()
+        {
+            return new OctopusRepository(Client).CertificateConfiguration.GetOctopusCertificate();
         }
     }
 }


### PR DESCRIPTION
Added `GetOctopusCertificate` method to `CertificateRepository` to avoid breaking existing scripts and code

Connects to https://github.com/OctopusDeploy/Issues/issues/3427