### PR TITLE
Use original path to get response location

### DIFF
--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -555,7 +555,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                             ? await ReadResponse<TResponseResource>(response).ConfigureAwait(false)
                             : default(TResponseResource);
 
-                        var locationHeader = response.Headers.Location?.ToString();
+                        var locationHeader = response.Headers.Location?.OriginalString;
                         var octopusResponse = new OctopusResponse<TResponseResource>(request, response.StatusCode,
                             locationHeader, resource);
                         ReceivedOctopusResponse?.Invoke(octopusResponse);


### PR DESCRIPTION
On mono `/path` will result in `file:///path` if ToString() is used.

Fixes OctopusDeploy/Issues#3474