### PR TITLE
Adding missing enum MachineScriptPolicyRunType.OnlyConnectivity

### DIFF
--- a/source/Octopus.Client/Model/MachineScriptPolicy.cs
+++ b/source/Octopus.Client/Model/MachineScriptPolicy.cs
@@ -5,6 +5,7 @@ namespace Octopus.Client.Model
     {
         InheritFromDefault = 0,
         Inline,
+        OnlyConnectivity
     }
 
     public class MachineScriptPolicy


### PR DESCRIPTION
Causes tentacle registrations to throw with the error below. I also did a quick check against the Octopus.Core.Resources namespace and a search in this repo for 'public enum' but found no other missing values 😄 

> 
> INFO  Connected sucessfully
> INFO  Registering the tentacle with the server at https://octopusserver/
> ERROR  ===============================================================================
> FATAL  Unable to process response from server: Error converting value "OnlyConnectivity" to type 'Octopus.Client.Model.MachineScriptPolicyRunType'. Path 'Items[0].MachineHealthCheckPolicy.SshEndpointHealthCheckPolicy.RunType', line 18, position 39.. Response content: {
>   "ItemType": "MachinePolicy",
> 