### PR TITLE
Fix for PackageId-based version overrides

### DIFF
--- a/source/Octo.Tests/Commands/PackageVersionResolverFixture.cs
+++ b/source/Octo.Tests/Commands/PackageVersionResolverFixture.cs
@@ -98,6 +98,27 @@ namespace Octopus.Cli.Tests.Commands
             Assert.Throws<CommandException>(() => resolver.Add("PackageA=1.FRED.9"));
         }
 
+        [Test]
+        public void ShouldPreferStepNameToPackageId()
+        {
+            resolver.Default("1.0.0");
+            resolver.Add("StepName", "1.1.0");
+            resolver.Add("PackageId", "1.2.0");
+
+            Assert.That(resolver.ResolveVersion("StepName"), Is.EqualTo("1.1.0"));
+            Assert.That(resolver.ResolveVersion("StepName", "PackageId"), Is.EqualTo("1.1.0"));
+        }
+
+        [Test]
+        public void ShouldPreferPackageIdToDefault()
+        {
+            resolver.Default("1.0.0");
+            resolver.Add("PackageId", "1.2.0");
+
+            Assert.That(resolver.ResolveVersion("StepName"), Is.EqualTo("1.0.0"));
+            Assert.That(resolver.ResolveVersion("StepName", "PackageId"), Is.EqualTo("1.2.0"));
+        }
+
 
         public static IEnumerable<TestCaseData> CanParseIdAndVersionData()
         {

--- a/source/Octo/Commands/IPackageVersionResolver.cs
+++ b/source/Octo/Commands/IPackageVersionResolver.cs
@@ -8,6 +8,6 @@ namespace Octopus.Cli.Commands
         void Add(string stepNameAndVersion);
         void Add(string stepName, string packageVersion);
         void Default(string packageVersion);
-        string ResolveVersion(string stepName);
+        string ResolveVersion(params string[] stepNameOrPackageIds);
     }
 }

--- a/source/Octo/Commands/PackageVersionResolver.cs
+++ b/source/Octo/Commands/PackageVersionResolver.cs
@@ -111,12 +111,15 @@ namespace Octopus.Cli.Commands
             }
         }
 
-        public string ResolveVersion(string stepName)
+        public string ResolveVersion(params string[] stepNameOrPackageIds)
         {
-            string version;
-            return stepNameToVersion.TryGetValue(stepName, out version)
-                ? version
-                : defaultVersion;
+            foreach (string stepNameOrPackageId in stepNameOrPackageIds)
+            {
+                string version;
+                if (stepNameToVersion.TryGetValue(stepNameOrPackageId, out version))
+                    return version;
+            }
+            return defaultVersion;
         }
 
         bool TryReadPackageIdentity(string packageFile, out PackageIdentity packageIdentity)

--- a/source/Octo/Commands/ReleasePlan.cs
+++ b/source/Octo/Commands/ReleasePlan.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands
                     p.PackageId,
                     p.FeedId,
                     p.IsResolvable,
-                    versionResolver.ResolveVersion(p.StepName) ?? versionResolver.ResolveVersion(p.PackageId)))
+                    versionResolver.ResolveVersion(p.StepName, p.PackageId)))
                 .ToArray();
         }
 


### PR DESCRIPTION
The current --package argument handling doesn't work as described in https://octopus.com/docs/api-and-integration/octo.exe-command-line/creating-releases. 

Specifically, if you
- provide a default `--packageversion=1.1.1` argument
- do NOT  provide a `--package=stepname:1.2.3` argument 
- provide a `--package=my.package.id:1.2.3` argument

In this case the default will be preferred over the packageid override.

This fix changes the fallback to stepname -> packageid -> default.