### PR TITLE
Add document types to Events.List

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -48,4 +48,4 @@
 
 *.sln text eol=crlf merge=union 
 
-*.approved.* binary
+*.approved.* -text

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1466,6 +1466,7 @@ Octopus.Client.Model
   class EventNotificationSubscriptionFilter
   {
     .ctor()
+    IList<String> DocumentTypes { get; set; }
     IList<String> Environments { get; set; }
     IList<String> EventCategories { get; set; }
     IList<String> EventGroups { get; set; }
@@ -3626,7 +3627,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<EventResource>
   {
     Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean)
-    Task<ResourceCollection<EventResource>> List(Int32, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>)
+    Task<ResourceCollection<EventResource>> List(Int32, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String)
   }
   interface IFeaturesConfigurationRepository
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1859,6 +1859,7 @@ Octopus.Client.Model
   class EventNotificationSubscriptionFilter
   {
     .ctor()
+    IList<String> DocumentTypes { get; set; }
     IList<String> Environments { get; set; }
     IList<String> EventCategories { get; set; }
     IList<String> EventGroups { get; set; }
@@ -4031,7 +4032,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<EventResource>
   {
     Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, String, String, Boolean)
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -4472,7 +4473,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<EventResource>
   {
     Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean)
-    Task<ResourceCollection<EventResource>> List(Int32, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>)
+    Task<ResourceCollection<EventResource>> List(Int32, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String)
   }
   interface IFeaturesConfigurationRepository
   {

--- a/source/Octopus.Client/Model/EventNotificationSubscription.cs
+++ b/source/Octopus.Client/Model/EventNotificationSubscription.cs
@@ -46,6 +46,7 @@ namespace Octopus.Client.Model
             this.EventCategories = new List<string>();
             this.Tenants = new List<string>();
             this.Tags = new List<string>();
+            this.DocumentTypes = new List<string>();
         }
 
         public IList<string> Users { get; set; }
@@ -55,5 +56,6 @@ namespace Octopus.Client.Model
         public IList<string> EventCategories { get; set; }
         public IList<string> Tenants { get; set; }
         public IList<string> Tags { get; set; }
+        public IList<string> DocumentTypes { get; set; }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/EventRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/EventRepository.cs
@@ -27,7 +27,8 @@ namespace Octopus.Client.Repositories.Async
             string tenants = null,
             string tags = null,
             long? fromAutoId = null,
-            long? toAutoId = null);
+            long? toAutoId = null,
+            string documentTypes = null);
     }
 
     class EventRepository : BasicRepository<EventResource>, IEventRepository
@@ -67,7 +68,8 @@ namespace Octopus.Client.Repositories.Async
             string tenants = null,
             string tags = null,
             long? fromAutoId = null,
-            long? toAutoId = null)
+            long? toAutoId = null,
+            string documentTypes = null)
         {
             return Client.List<EventResource>(Client.RootDocument.Link("Events"), new
             {
@@ -86,7 +88,8 @@ namespace Octopus.Client.Repositories.Async
                 tenants = tenants,
                 tags = tags,
                 fromAutoId = fromAutoId,
-                toAutoId = toAutoId
+                toAutoId = toAutoId,
+                documentTypes = documentTypes
             });
         }
     }

--- a/source/Octopus.Client/Repositories/EventRepository.cs
+++ b/source/Octopus.Client/Repositories/EventRepository.cs
@@ -24,7 +24,8 @@ namespace Octopus.Client.Repositories
             string tenants = null,
             string tags = null,
             long? fromAutoId = null,
-            long? toAutoId = null);
+            long? toAutoId = null,
+            string documentTypes = null);
     }
     
     class EventRepository : BasicRepository<EventResource>, IEventRepository
@@ -63,7 +64,8 @@ namespace Octopus.Client.Repositories
             string tenants = null,
             string tags = null,
             long? fromAutoId = null,
-            long? toAutoId = null)
+            long? toAutoId = null,
+            string documentTypes = null)
         {
             return Client.List<EventResource>(Client.RootDocument.Link("Events"), new
             {
@@ -82,7 +84,8 @@ namespace Octopus.Client.Repositories
                 tenants = tenants,
                 tags = tags,
                 fromAutoId = fromAutoId,
-                toAutoId = toAutoId
+                toAutoId = toAutoId,
+                documentTypes = documentTypes
             });
         }
     }


### PR DESCRIPTION
Also changed *.approved.* files in gitattributes from binary (which is a macro for -text -diff) to just -text. This means your git program will show diffs for them, which is pretty handy.

I added doc types to the end of the argument list, which I assume is the right way to go so we don't break things for people?