### PR TITLE
Only added the `{ids}` parameter if it didn't already exist.

### DIFF
--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -119,8 +120,12 @@ namespace Octopus.Client.Repositories.Async
                 if (actualIds.Length == 0) return new List<TResource>();
 
                 var resources = new List<TResource>();
+                var link = Client.RootDocument.Link(CollectionLinkName);
+                if (!Regex.IsMatch(link, @"\{\?.*\Wids\W"))
+                    link += "{?ids}";
+
                 await Client.Paginate<TResource>(
-                    Client.RootDocument.Link(CollectionLinkName) + "{?ids}",
+                    link,
                     new { ids = actualIds },
                     page =>
                     {

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Octopus.Client.Model;
+using System.Text.RegularExpressions;
 
 namespace Octopus.Client.Repositories
 {
@@ -124,8 +125,11 @@ namespace Octopus.Client.Repositories
             if (actualIds.Length == 0) return new List<TResource>();
 
             var resources = new List<TResource>();
+            var link = client.RootDocument.Link(CollectionLinkName);
+            if(!Regex.IsMatch(link, @"\{\?.*\Wids\W"))
+                link += "{?ids}";
             client.Paginate<TResource>(
-                client.RootDocument.Link(CollectionLinkName) + "{?ids}",
+                link,
                 new { ids = actualIds },
                 page =>
                 {


### PR DESCRIPTION
 Fixes #175