### PR TITLE
OctopusAsyncClient ctor initializes the Repository too early

### DIFF
--- a/source/Octopus.Client.Tests/Repositories/OctopusAsyncRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/OctopusAsyncRepositoryTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using NSubstitute;
 using Octopus.Client.Extensions;
+using Octopus.Client.Model;
 
 namespace Octopus.Client.Tests.Repositories
 {
@@ -11,7 +12,9 @@ namespace Octopus.Client.Tests.Repositories
         [Test]
         public void AllPropertiesAreNotNull()
         {
-            var repository = new OctopusAsyncRepository(Substitute.For<IOctopusAsyncClient>());
+            var client = Substitute.For<IOctopusAsyncClient>();
+            client.RootDocument.Returns(new RootResource());
+            var repository = new OctopusAsyncRepository(client);
             var nullPropertiesQ = from p in typeof(OctopusAsyncRepository).GetTypeInfo().GetProperties()
                 where p.GetMethod.Invoke(repository, new object[0]) == null
                 select p.Name;

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -35,7 +35,8 @@ namespace Octopus.Client
         private readonly bool ignoreSslErrors = false;
         bool ignoreSslErrorMessageLogged = false;
 
-        protected OctopusAsyncClient(OctopusServerEndpoint serverEndpoint, OctopusClientOptions options, bool addCertificateCallback)
+        // Use the Create method to instantiate
+        private OctopusAsyncClient(OctopusServerEndpoint serverEndpoint, OctopusClientOptions options, bool addCertificateCallback)
         {
             options = options ?? new OctopusClientOptions();
 

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -38,7 +38,7 @@ namespace Octopus.Client
         protected OctopusAsyncClient(OctopusServerEndpoint serverEndpoint, OctopusClientOptions options, bool addCertificateCallback)
         {
             options = options ?? new OctopusClientOptions();
-            
+
             this.serverEndpoint = serverEndpoint;
             cookieOriginUri = BuildCookieUri(serverEndpoint);
             var handler = new HttpClientHandler

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -38,8 +38,7 @@ namespace Octopus.Client
         protected OctopusAsyncClient(OctopusServerEndpoint serverEndpoint, OctopusClientOptions options, bool addCertificateCallback)
         {
             options = options ?? new OctopusClientOptions();
-            Repository = new OctopusAsyncRepository(this);
-
+            
             this.serverEndpoint = serverEndpoint;
             cookieOriginUri = BuildCookieUri(serverEndpoint);
             var handler = new HttpClientHandler
@@ -132,6 +131,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
             try
             {
                 client.RootDocument = await client.EstablishSession().ConfigureAwait(false);
+                client.Repository = new OctopusAsyncRepository(client);
                 return client;
             }
             catch
@@ -197,7 +197,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
             return response.ResponseResource;
         }
 
-        public IOctopusAsyncRepository Repository { get; }
+        public IOctopusAsyncRepository Repository { get; private set; }
 
         /// <summary>
         /// Fetches a collection of resources from the server using the HTTP GET verb. The collection itself will usually be

--- a/source/Octopus.Client/Repositories/Async/CertificateConfigurationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/CertificateConfigurationRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
@@ -21,10 +22,13 @@ namespace Octopus.Client.Repositories.Async
 
         static string DetermineCollectionLinkName(IOctopusAsyncClient client)
         {
+            if (client.RootDocument == null)
+                throw new NullReferenceException("The client root document is null");
+
             // For backwards compatibility. 
             // In Octopus 3.11, what was Certificates was moved to CertificatesConfiguration, to make room for the certificates feature.
             // This allows pre-3.11 clients to still work.
-            return client.RootDocument == null || client.RootDocument.Links.ContainsKey("CertificateConfiguration")
+            return client.RootDocument.Links.ContainsKey("CertificateConfiguration")
                 ? "CertificateConfiguration"
                 : "Certificates";
         }


### PR DESCRIPTION
The Repository needs to be initialized after establish session, which has to be done in the factory method (Create).
This means the user cannot create a client via OctopusAsyncClient ctor.

Fixed #178