### PR TITLE
Added support to filter/search project releases

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3762,7 +3762,7 @@ Octopus.Client.Repositories.Async
     Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource)
     Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
     Task SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4168,7 +4168,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<ChannelResource> GetChannels(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ProgressionResource GetProgression(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ReleaseResource GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> GetTriggers(Octopus.Client.Model.ProjectResource)
     void SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
   }
@@ -4612,7 +4612,7 @@ Octopus.Client.Repositories.Async
     Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource)
     Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
     Task SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
   }

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -10,14 +10,7 @@ namespace Octopus.Client.Repositories.Async
 
     public interface IProjectRepository : IFindByName<ProjectResource>, IGet<ProjectResource>, ICreate<ProjectResource>, IModify<ProjectResource>, IDelete<ProjectResource>, IGetAll<ProjectResource>
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="project"></param>
-        /// <param name="skip">Number of records to skip</param>
-        /// <param name="take">Number of records to take (First supported in Server 3.14.15)</param>
-        /// <returns></returns>
-        Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null);
+        Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string filter = null);
         Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project);
         Task<ReleaseResource> GetReleaseByVersion(ProjectResource project, string version);
         Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource project);
@@ -35,9 +28,9 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null)
+        public Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string filter = null)
         {
-            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take });
+            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, filter });
         }
 
         public Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project)

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -10,7 +9,7 @@ namespace Octopus.Client.Repositories.Async
 
     public interface IProjectRepository : IFindByName<ProjectResource>, IGet<ProjectResource>, ICreate<ProjectResource>, IModify<ProjectResource>, IDelete<ProjectResource>, IGetAll<ProjectResource>
     {
-        Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string filter = null);
+        Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null);
         Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project);
         Task<ReleaseResource> GetReleaseByVersion(ProjectResource project, string version);
         Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource project);
@@ -28,9 +27,9 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string filter = null)
+        public Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null)
         {
-            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, filter });
+            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, searchByVersion });
         }
 
         public Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project) 

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -33,7 +33,7 @@ namespace Octopus.Client.Repositories.Async
             return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, filter });
         }
 
-        public Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project)
+        public Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project) 
         {
             return Client.ListAll<ReleaseResource>(project.Link("Releases"));
         }

--- a/source/Octopus.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectRepository.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Octopus.Client.Editors;
@@ -8,7 +7,7 @@ namespace Octopus.Client.Repositories
 {
     public interface IProjectRepository : IFindByName<ProjectResource>, IGet<ProjectResource>, ICreate<ProjectResource>, IModify<ProjectResource>, IDelete<ProjectResource>, IGetAll<ProjectResource>
     {
-        ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null, string filter = null);
+        ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null);
         IReadOnlyList<ReleaseResource> GetAllReleases(ProjectResource project);
         ReleaseResource GetReleaseByVersion(ProjectResource project, string version);
         ResourceCollection<ChannelResource> GetChannels(ProjectResource project);
@@ -26,9 +25,9 @@ namespace Octopus.Client.Repositories
         {
         }
 
-        public ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null, string filter = null)
+        public ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null)
         {
-            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, filter });
+            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, searchByVersion });
         }
 
         public IReadOnlyList<ReleaseResource> GetAllReleases(ProjectResource project)

--- a/source/Octopus.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectRepository.cs
@@ -8,14 +8,7 @@ namespace Octopus.Client.Repositories
 {
     public interface IProjectRepository : IFindByName<ProjectResource>, IGet<ProjectResource>, ICreate<ProjectResource>, IModify<ProjectResource>, IDelete<ProjectResource>, IGetAll<ProjectResource>
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="project"></param>
-        /// <param name="skip">Number of records to skip</param>
-        /// <param name="take">Number of records to take (First supported in Server 3.14.159)</param>
-        /// <returns></returns>
-        ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null);
+        ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null, string filter = null);
         IReadOnlyList<ReleaseResource> GetAllReleases(ProjectResource project);
         ReleaseResource GetReleaseByVersion(ProjectResource project, string version);
         ResourceCollection<ChannelResource> GetChannels(ProjectResource project);
@@ -33,9 +26,9 @@ namespace Octopus.Client.Repositories
         {
         }
 
-        public ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null)
+        public ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null, string filter = null)
         {
-            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take });
+            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, filter });
         }
 
         public IReadOnlyList<ReleaseResource> GetAllReleases(ProjectResource project)


### PR DESCRIPTION
Project releases can now be searched via a version filter.  This is related to OctopusDeploy/Issues#3533

Tests:
- Updated existing tests only.  Adding API test in Octopus E2E Tests for better coverage.