### PR TITLE
Renaming StepName property to ActionName

### DIFF
--- a/source/Octo/Commands/ApiCommand.cs
+++ b/source/Octo/Commands/ApiCommand.cs
@@ -209,7 +209,7 @@ namespace Octopus.Cli.Commands
 
             foreach (var package in packages)
             {
-                var packageVersionAsString = package.StepName + " " + package.Version;
+                var packageVersionAsString = package.ActionName + " " + package.Version;
 
                 if (packageVersionsAsString.Contains(packageVersionAsString))
                 {

--- a/source/Octo/Commands/ReleasePlan.cs
+++ b/source/Octo/Commands/ReleasePlan.cs
@@ -43,11 +43,12 @@ namespace Octopus.Cli.Commands
                     }).ToArray();
             packageSteps = releaseTemplate.Packages.Select(
                 p => new ReleasePlanItem(
-                    p.StepName,
+                    p.ActionName,
                     p.PackageId,
                     p.FeedId,
                     p.IsResolvable,
-                    versionResolver.ResolveVersion(p.StepName, p.PackageId))).ToArray();
+                    versionResolver.ResolveVersion(p.ActionName, p.PackageId)))
+                .ToArray();
         }
 
         public ProjectResource Project { get; }
@@ -81,7 +82,7 @@ namespace Octopus.Cli.Commands
 
         public List<SelectedPackage> GetSelections()
         {
-            return PackageSteps.Select(x => new SelectedPackage {StepName = x.StepName, Version = x.Version}).ToList();
+            return PackageSteps.Select(x => new SelectedPackage {ActionName = x.ActionName, Version = x.Version}).ToList();
         }
 
         public string GetHighestVersionNumber()
@@ -110,7 +111,7 @@ namespace Octopus.Cli.Commands
                 return result.ToString();
             }
 
-            var nameColumnWidth = Width("Name", packageSteps.Select(s => s.StepName));
+            var nameColumnWidth = Width("Name", packageSteps.Select(s => s.ActionName));
             var versionColumnWidth = Width("Version", packageSteps.Select(s => s.Version));
             var sourceColumnWidth = Width("Source", packageSteps.Select(s => s.VersionSource));
             var rulesColumnWidth = Width("Version rules", packageSteps.Select(s => s.ChannelVersionRuleTestResult?.ToSummaryString()));
@@ -123,7 +124,7 @@ namespace Octopus.Cli.Commands
                 var item = packageSteps[i];
                 result.AppendFormat(format,
                     i + 1,
-                    item.StepName,
+                    item.ActionName,
                     item.Version ?? "ERROR",
                     item.VersionSource,
                     item.ChannelVersionRuleTestResult?.ToSummaryString())
@@ -146,7 +147,7 @@ namespace Octopus.Cli.Commands
 
         public string GetActionVersionNumber(string packageStepName)
         {
-            var step = packageSteps.SingleOrDefault(s => s.StepName.Equals(packageStepName, StringComparison.OrdinalIgnoreCase));
+            var step = packageSteps.SingleOrDefault(s => s.ActionName.Equals(packageStepName, StringComparison.OrdinalIgnoreCase));
             if (step == null)
                 throw new CommandException("The step '" + packageStepName + "' is configured to provide the package version number but doesn't exist in the release plan.");
             if (string.IsNullOrWhiteSpace(step.Version))

--- a/source/Octo/Commands/ReleasePlanBuilder.cs
+++ b/source/Octo/Commands/ReleasePlanBuilder.cs
@@ -43,20 +43,20 @@ namespace Octopus.Cli.Commands
                 {
                     if (!unresolved.IsResolveable)
                     {
-                        log.Error("The version number for step '{Step:l}' cannot be automatically resolved because the feed or package ID is dynamic.", unresolved.StepName);
+                        log.Error("The version number for step '{Step:l}' cannot be automatically resolved because the feed or package ID is dynamic.", unresolved.ActionName);
                         continue;
                     }
 
                     if (!string.IsNullOrEmpty(versionPreReleaseTag))
-                        log.Debug("Finding latest package with pre-release '{Tag:l}' for step: {StepName:l}", versionPreReleaseTag, unresolved.StepName);
+                        log.Debug("Finding latest package with pre-release '{Tag:l}' for step: {StepName:l}", versionPreReleaseTag, unresolved.ActionName);
                     else
-                        log.Debug("Finding latest package for step: {StepName:l}", unresolved.StepName);
+                        log.Debug("Finding latest package for step: {StepName:l}", unresolved.ActionName);
 
                     var feed = await repository.Feeds.Get(unresolved.PackageFeedId).ConfigureAwait(false);
                     if (feed == null)
-                        throw new CommandException(string.Format("Could not find a feed with ID {0}, which is used by step: " + unresolved.StepName, unresolved.PackageFeedId));
+                        throw new CommandException(string.Format("Could not find a feed with ID {0}, which is used by step: " + unresolved.ActionName, unresolved.PackageFeedId));
 
-                    var filters = BuildChannelVersionFilters(unresolved.StepName, channel);
+                    var filters = BuildChannelVersionFilters(unresolved.ActionName, channel);
                     filters["packageId"] = unresolved.PackageId;
                     if (!string.IsNullOrWhiteSpace(versionPreReleaseTag))
                         filters["preReleaseTag"] = versionPreReleaseTag;
@@ -70,7 +70,7 @@ namespace Octopus.Cli.Commands
                     }
                     else
                     {
-                        log.Debug("Selected '{PackageId:l}' version '{Version:l}' for '{StepName:l}'", latestPackage.PackageId, latestPackage.Version, unresolved.StepName);
+                        log.Debug("Selected '{PackageId:l}' version '{Version:l}' for '{StepName:l}'", latestPackage.PackageId, latestPackage.Version, unresolved.ActionName);
                         unresolved.SetVersionFromLatest(latestPackage.Version);
                     }
                 }
@@ -82,7 +82,7 @@ namespace Octopus.Cli.Commands
                 foreach (var step in plan.PackageSteps)
                 {
                     // Note the rule can be null, meaning: anything goes
-                    var rule = channel.Rules.SingleOrDefault(r => r.Actions.Any(s => s.Equals(step.StepName, StringComparison.OrdinalIgnoreCase)));
+                    var rule = channel.Rules.SingleOrDefault(r => r.Actions.Any(s => s.Equals(step.ActionName, StringComparison.OrdinalIgnoreCase)));
                     var result = await versionRuleTester.Test(repository, rule, step.Version).ConfigureAwait(false);
                     step.SetChannelVersionRuleTestResult(result);
                 }

--- a/source/Octo/Commands/ReleasePlanItem.cs
+++ b/source/Octo/Commands/ReleasePlanItem.cs
@@ -1,12 +1,13 @@
+using System;
 using Octopus.Cli.Model;
 
 namespace Octopus.Cli.Commands
 {
     public class ReleasePlanItem
     {
-        public ReleasePlanItem(string stepName, string packageId, string packageFeedId, bool isResolveable, string userSpecifiedVersion)
+        public ReleasePlanItem(string actionName, string packageId, string packageFeedId, bool isResolveable, string userSpecifiedVersion)
         {
-            StepName = stepName;
+            ActionName = actionName;
             PackageId = packageId;
             PackageFeedId = packageFeedId;
             IsResolveable = isResolveable;
@@ -14,7 +15,7 @@ namespace Octopus.Cli.Commands
             VersionSource = string.IsNullOrWhiteSpace(Version) ? "Cannot resolve" : "User specified";
         }
 
-        public string StepName { get; }
+        public string ActionName { get; }
 
         public string PackageId { get; }
 

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2431,6 +2431,7 @@ Octopus.Client.Model
   class ReleaseTemplatePackage
   {
     .ctor()
+    String ActionName { get; set; }
     String FeedId { get; set; }
     String FeedName { get; set; }
     Boolean IsResolvable { get; set; }
@@ -2616,6 +2617,7 @@ Octopus.Client.Model
   {
     .ctor()
     .ctor(String, String)
+    String ActionName { get; set; }
     String StepName { get; set; }
     String Version { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2828,6 +2828,7 @@ Octopus.Client.Model
   class ReleaseTemplatePackage
   {
     .ctor()
+    String ActionName { get; set; }
     String FeedId { get; set; }
     String FeedName { get; set; }
     Boolean IsResolvable { get; set; }
@@ -3014,6 +3015,7 @@ Octopus.Client.Model
   {
     .ctor()
     .ctor(String, String)
+    String ActionName { get; set; }
     String StepName { get; set; }
     String Version { get; set; }
   }

--- a/source/Octopus.Client/Model/ReleaseTemplatePackage.cs
+++ b/source/Octopus.Client/Model/ReleaseTemplatePackage.cs
@@ -4,7 +4,14 @@ namespace Octopus.Client.Model
 {
     public class ReleaseTemplatePackage
     {
-        public string StepName { get; set; }
+        [Obsolete("Replaced by " + nameof(ActionName))]
+        public string StepName
+        {
+            get => ActionName;
+            set => ActionName = value;
+        }
+
+        public string ActionName { get; set; }
 
         [Obsolete("Replaced by PackageId")]
         public string NuGetPackageId

--- a/source/Octopus.Client/Model/SelectedPackage.cs
+++ b/source/Octopus.Client/Model/SelectedPackage.cs
@@ -8,13 +8,20 @@ namespace Octopus.Client.Model
         {
         }
 
-        public SelectedPackage(string stepName, string version)
+        public SelectedPackage(string actionName, string version)
         {
-            StepName = stepName;
+            ActionName = actionName;
             Version = version;
         }
 
-        public string StepName { get; set; }
+        [Obsolete("Replaced by " + nameof(ActionName))]
+        public string StepName
+        {
+            get => ActionName;
+            set => ActionName = value;
+        }
+
+        public string ActionName { get; set; }
         public string Version { get; set; }
     }
 }


### PR DESCRIPTION
As we're obsoleting a client facing property in `Octopus.Client`, I guess we should do a `major` version bump here or can we get away with a `minor` bump as the property is still available...

Related to OctopusDeploy/Issues#3424