### PR TITLE
Fixing release snapshot repository to await properly

### DIFF
--- a/source/Octopus.Client/Repositories/Async/ReleaseRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ReleaseRepository.cs
@@ -56,10 +56,10 @@ namespace Octopus.Client.Repositories.Async
             return Client.Get<DeploymentPreviewResource>(promotionTarget.Link("Preview"));
         }
 
-        public Task<ReleaseResource> SnapshotVariables(ReleaseResource release)
+        public async Task<ReleaseResource> SnapshotVariables(ReleaseResource release)
         {
-            Client.Post(release.Link("SnapshotVariables"));
-            return Get(release.Id);
+            await Client.Post(release.Link("SnapshotVariables"));
+            return await Get(release.Id);
         }
 
         public Task<ReleaseResource> Create(ReleaseResource resource, bool ignoreChannelRules = false)


### PR DESCRIPTION
This fixes a bug in the Releases async repository where it was not awaiting properly.

If you called this method with another call to deploy a release straight afterwards, there was a high risk the release would be deployed with the wrong variables snapshot (ie. octo.exe and the deploy-release command).