### PR TITLE
Deprecate NewSmtpPassword

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2695,6 +2695,7 @@ Octopus.Client.Model
     String SendEmailFrom { get; set; }
     String SmtpHost { get; set; }
     String SmtpLogin { get; set; }
+    Octopus.Client.Model.SensitiveValue SmtpPassword { get; set; }
     Nullable<Int32> SmtpPort { get; set; }
   }
   class SquidAttribute

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3091,6 +3091,7 @@ Octopus.Client.Model
     String SendEmailFrom { get; set; }
     String SmtpHost { get; set; }
     String SmtpLogin { get; set; }
+    Octopus.Client.Model.SensitiveValue SmtpPassword { get; set; }
     Nullable<Int32> SmtpPort { get; set; }
   }
   class SquidAttribute

--- a/source/Octopus.Client/Model/SmtpConfigurationResource.cs
+++ b/source/Octopus.Client/Model/SmtpConfigurationResource.cs
@@ -20,8 +20,12 @@ namespace Octopus.Client.Model
         [Writeable]
         public bool EnableSsl { get; set; }
 
+        [Writeable]
+        public SensitiveValue SmtpPassword { get; set; }
+
         [NotReadable]
         [Writeable]
+        [Obsolete("Use 'SmtpPassword' instead. Will be removed in version 5.0.0.", false)]
         public string NewSmtpPassword { get; set; }
     }
 }


### PR DESCRIPTION
The API for SMTP password configuration has been changed to use `SensitiveValue` to be more consistent with usage in other areas. The change is still backwards compatible however the new will still be honoured but will be dropped in 5.x.