### PR TITLE
Fix Octo.exe project import problem if channel has version rule

### DIFF
--- a/source/Octo/Importers/ProjectImporter.cs
+++ b/source/Octo/Importers/ProjectImporter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Serilog;
 using Octopus.Cli.Commands;
@@ -173,20 +171,14 @@ namespace Octopus.Cli.Importers
             }
         }
 
-        private async Task MapChannelsToAction(DeploymentProcessResource importedDeploymentProcess, Dictionary<string, ChannelResource> importedChannels, Dictionary<string, ReferenceCollection> oldActionChannels)
+        async Task MapChannelsToAction(DeploymentProcessResource importedDeploymentProcess, IDictionary<string, ChannelResource> importedChannels, IDictionary<string, ReferenceCollection> oldActionChannels)
         {
             foreach (var step in importedDeploymentProcess.Steps)
             {
                 foreach (var action in step.Actions)
                 {
-                    var oldChannelIds = oldActionChannels[action.Id];
-                    var newChannelIds = new List<string>();
-                    Log.Debug("Updating IDs of Channels");
-                    foreach (var oldChannelId in oldChannelIds)
-                    {
-                        newChannelIds.Add(importedChannels[oldChannelId].Id);
-                    }
-                    action.Channels.AddRange(newChannelIds);
+                    Log.Debug("Setting action channels");
+                    action.Channels.AddRange(oldActionChannels[action.Id].Select(oldChannelId =>  importedChannels[oldChannelId].Id));
                 }
             }
             await Repository.DeploymentProcesses.Modify(importedDeploymentProcess).ConfigureAwait(false);

--- a/source/Octo/Importers/ProjectImporter.cs
+++ b/source/Octo/Importers/ProjectImporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Serilog;
 using Octopus.Cli.Commands;
@@ -141,13 +142,18 @@ namespace Octopus.Cli.Importers
                 Log.Debug("Beginning import of project '{Project:l}'", validatedImportSettings.Project.Name);
 
                 var importedProject = await ImportProject(validatedImportSettings.Project, validatedImportSettings.ProjectGroupId, validatedImportSettings.LibraryVariableSets).ConfigureAwait(false);
+
+                var oldActionChannels = validatedImportSettings.DeploymentProcess.Steps.SelectMany(s => s.Actions).ToDictionary(x => x.Id, x => x.Channels.Clone());
+
+                var importeDeploymentProcess = await ImportDeploymentProcess(validatedImportSettings.DeploymentProcess, importedProject, validatedImportSettings.Environments, validatedImportSettings.Feeds, validatedImportSettings.Templates).ConfigureAwait(false);
+
                 var importedChannels =
                     (await ImportProjectChannels(validatedImportSettings.Channels.ToList(), importedProject, validatedImportSettings.ChannelLifecycles).ConfigureAwait(false))
                         .ToDictionary(k => k.Key, v => v.Value);
 
                 await MapReleaseCreationStrategyChannel(importedProject, importedChannels);
 
-                await ImportDeploymentProcess(validatedImportSettings.DeploymentProcess, importedProject, validatedImportSettings.Environments, validatedImportSettings.Feeds, validatedImportSettings.Templates, importedChannels).ConfigureAwait(false);
+                await MapChannelsToAction(importeDeploymentProcess, importedChannels, oldActionChannels);
 
                 await ImportVariableSets(validatedImportSettings.VariableSet, importedProject, validatedImportSettings.Environments, validatedImportSettings.Machines, importedChannels, validatedImportSettings.ScopeValuesUsed).ConfigureAwait(false);
 
@@ -165,6 +171,25 @@ namespace Octopus.Cli.Importers
                     }
                 }
             }
+        }
+
+        private async Task MapChannelsToAction(DeploymentProcessResource importedDeploymentProcess, Dictionary<string, ChannelResource> importedChannels, Dictionary<string, ReferenceCollection> oldActionChannels)
+        {
+            foreach (var step in importedDeploymentProcess.Steps)
+            {
+                foreach (var action in step.Actions)
+                {
+                    var oldChannelIds = oldActionChannels[action.Id];
+                    var newChannelIds = new List<string>();
+                    Log.Debug("Updating IDs of Channels");
+                    foreach (var oldChannelId in oldChannelIds)
+                    {
+                        newChannelIds.Add(importedChannels[oldChannelId].Id);
+                    }
+                    action.Channels.AddRange(newChannelIds);
+                }
+            }
+            await Repository.DeploymentProcesses.Modify(importedDeploymentProcess).ConfigureAwait(false);
         }
 
         Task MapReleaseCreationStrategyChannel(ProjectResource importedProject, Dictionary<string, ChannelResource> channelMap)
@@ -395,12 +420,11 @@ namespace Octopus.Cli.Importers
             return variables;
         }
 
-        async Task ImportDeploymentProcess(DeploymentProcessResource deploymentProcess,
+        async Task<DeploymentProcessResource> ImportDeploymentProcess(DeploymentProcessResource deploymentProcess,
             ProjectResource importedProject,
             IDictionary<string, EnvironmentResource> environments,
             IDictionary<string, FeedResource> nugetFeeds,
-            IDictionary<string, ActionTemplateResource> actionTemplates,
-            IDictionary<string, ChannelResource> channels)
+            IDictionary<string, ActionTemplateResource> actionTemplates)
         {
             Log.Debug("Importing the Projects Deployment Process");
             var existingDeploymentProcess = await Repository.DeploymentProcesses.Get(importedProject.DeploymentProcessId).ConfigureAwait(false);
@@ -433,21 +457,14 @@ namespace Octopus.Cli.Importers
                     action.Environments.Clear();
                     action.Environments.AddRange(newEnvironmentIds);
 
-                    var oldChannelIds = action.Channels;
-                    var newChannelIds = new List<string>();
-                    Log.Debug("Updating IDs of Channels");
-                    foreach (var oldChannelId in oldChannelIds)
-                    {
-                        newChannelIds.Add(channels[oldChannelId].Id);
-                    }
+                    // Make sure source channels are clear, will be added later
                     action.Channels.Clear();
-                    action.Channels.AddRange(newChannelIds);
                 }
             }
             existingDeploymentProcess.Steps.Clear();
             existingDeploymentProcess.Steps.AddRange(steps);
 
-            await Repository.DeploymentProcesses.Modify(existingDeploymentProcess).ConfigureAwait(false);
+            return await Repository.DeploymentProcesses.Modify(existingDeploymentProcess).ConfigureAwait(false);
         }
 
         async Task<IReadOnlyList<KeyValuePair<string, ChannelResource>>> ImportProjectChannels(List<ChannelResource> channels, ProjectResource importedProject, IDictionary<string, LifecycleResource> channelLifecycles)


### PR DESCRIPTION
Fixes OctopusDeploy/Issues#4037
## Issue
If a project channel has a version rule, it will fail on import when using `Import` command from `Octo.exe`

## Why
Channel version rule requires a `Package Step`, however project importer imports the `Channels` before the `DeploymentProcess`, when Octopus Server try to save the Channel, it looks for the referenced `Package Step` which isn't imported yet and throw exception

## Resolution
Change the import order to save `DeploymentProcess` before `Channels`, then remap the new channel ids back to the newly imported actions

## Tests
- Import a project with channel version rule which is not in the target server
Expect output: Project, Channels and Deployment process imported successfully
- Import a project with channel version rule which exists in the target server
Expect output: Project, Channels and Deployment process imported successfully with the new settings
