### PR TITLE
Remove extensibility package

### DIFF
--- a/source/Octopus.Client.Tests/Conventions/ClientConventions.cs
+++ b/source/Octopus.Client.Tests/Conventions/ClientConventions.cs
@@ -40,7 +40,7 @@ namespace Octopus.Client.Tests.Conventions
             .ToArray();
 
         private static readonly TypeInfo[] ResourceTypes = ExportedTypes
-            .Where(t => t.Name.EndsWith("Resource"))
+            .Where(t => !t.IsInterface && !t.IsAbstract && t.Name.EndsWith("Resource"))
             .ToArray();
 
         private static readonly TypeInfo[] RepositoryResourceTypes = ResourceTypes

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -541,6 +541,72 @@ Octopus.Client.Exceptions
     .ctor(String)
   }
 }
+Octopus.Client.Extensibility
+{
+  class Href
+    IEquatable<Href>
+  {
+    .ctor(String)
+    String AsString()
+    Boolean Equals(Octopus.Client.Extensibility.Href)
+    Boolean Equals(Object)
+    Int32 GetHashCode()
+    String ToString()
+  }
+  interface INamedResource
+  {
+    String Name { get; }
+  }
+  interface IResource
+  {
+    String Id { get; }
+    Octopus.Client.Extensibility.LinkCollection Links { get; set; }
+  }
+  class LinkCollection
+    IDictionary<String, Href>
+    ICollection<KeyValuePair<String, Href>>
+    IEnumerable<KeyValuePair<String, Href>>
+    IEnumerable
+    IDictionary
+    ICollection
+    IReadOnlyDictionary<String, Href>
+    IReadOnlyCollection<KeyValuePair<String, Href>>
+    ISerializable
+    IDeserializationCallback
+    Dictionary<String, Href>
+  {
+    .ctor()
+    Octopus.Client.Extensibility.LinkCollection Add(String, Octopus.Client.Extensibility.Href)
+    static Octopus.Client.Extensibility.LinkCollection Self(Octopus.Client.Extensibility.Href)
+  }
+}
+Octopus.Client.Extensibility.Attributes
+{
+  abstract class ApiPropertyAttribute
+    Attribute
+  {
+  }
+  class WriteableAttribute
+    Octopus.Client.Extensibility.Attributes.ApiPropertyAttribute
+  {
+    .ctor()
+  }
+  class WriteableOnCreateAttribute
+    Octopus.Client.Extensibility.Attributes.ApiPropertyAttribute
+  {
+    .ctor()
+  }
+}
+Octopus.Client.Extensibility.Extensions.Infrastructure.Configuration
+{
+  abstract class ExtensionConfigurationResource
+    Octopus.Client.Extensibility.IResource
+  {
+    String Id { get; set; }
+    Boolean IsEnabled { get; set; }
+    Octopus.Client.Extensibility.LinkCollection Links { get; set; }
+  }
+}
 Octopus.Client.Extensions
 {
   abstract class StringExtensions

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -935,6 +935,75 @@ Octopus.Client.Exceptions
     .ctor(String)
   }
 }
+Octopus.Client.Extensibility
+{
+  class Href
+    IEquatable<Href>
+  {
+    .ctor(String)
+    String AsString()
+    Boolean Equals(Octopus.Client.Extensibility.Href)
+    Boolean Equals(Object)
+    Int32 GetHashCode()
+    String ToString()
+  }
+  interface INamedResource
+  {
+    String Name { get; }
+  }
+  interface IResource
+  {
+    String Id { get; }
+    Octopus.Client.Extensibility.LinkCollection Links { get; set; }
+  }
+  class LinkCollection
+    IDictionary<String, Href>
+    ICollection<KeyValuePair<String, Href>>
+    IEnumerable<KeyValuePair<String, Href>>
+    IEnumerable
+    IDictionary
+    ICollection
+    IReadOnlyDictionary<String, Href>
+    IReadOnlyCollection<KeyValuePair<String, Href>>
+    ISerializable
+    IDeserializationCallback
+    Dictionary<String, Href>
+  {
+    .ctor()
+    Octopus.Client.Extensibility.LinkCollection Add(String, Octopus.Client.Extensibility.Href)
+    static Octopus.Client.Extensibility.LinkCollection Self(Octopus.Client.Extensibility.Href)
+  }
+}
+Octopus.Client.Extensibility.Attributes
+{
+  abstract class ApiPropertyAttribute
+    _Attribute
+    Attribute
+  {
+  }
+  class WriteableAttribute
+    _Attribute
+    Octopus.Client.Extensibility.Attributes.ApiPropertyAttribute
+  {
+    .ctor()
+  }
+  class WriteableOnCreateAttribute
+    _Attribute
+    Octopus.Client.Extensibility.Attributes.ApiPropertyAttribute
+  {
+    .ctor()
+  }
+}
+Octopus.Client.Extensibility.Extensions.Infrastructure.Configuration
+{
+  abstract class ExtensionConfigurationResource
+    Octopus.Client.Extensibility.IResource
+  {
+    String Id { get; set; }
+    Boolean IsEnabled { get; set; }
+    Octopus.Client.Extensibility.LinkCollection Links { get; set; }
+  }
+}
 Octopus.Client.Extensions
 {
   abstract class StringExtensions

--- a/source/Octopus.Client/Extensibility/Attributes/ApiPropertyAttribute.cs
+++ b/source/Octopus.Client/Extensibility/Attributes/ApiPropertyAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Octopus.Client.Extensibility.Attributes
+{
+    public abstract class ApiPropertyAttribute : Attribute
+    {
+    }
+}

--- a/source/Octopus.Client/Extensibility/Attributes/WriteableAttribute.cs
+++ b/source/Octopus.Client/Extensibility/Attributes/WriteableAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Octopus.Client.Extensibility.Attributes
+{
+    /// <summary>
+    /// Properties with this attribute will be persisted to the server when sent using a POST or PUT request.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class WriteableAttribute : ApiPropertyAttribute
+    {
+    }
+
+    /// <summary>
+    /// Properties with this attribute will be persisted to the server when sent using a POST request.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class WriteableOnCreateAttribute : ApiPropertyAttribute
+    {
+    }
+
+}

--- a/source/Octopus.Client/Extensibility/Extensions/Infrastructure/Configuration/ExtensionConfigurationResource.cs
+++ b/source/Octopus.Client/Extensibility/Extensions/Infrastructure/Configuration/ExtensionConfigurationResource.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public abstract class ExtensionConfigurationResource: IResource
+    {
+        public string Id { get; set; }
+
+        [DisplayName("Is Enabled")]
+        [Description("Whether or not this extension is enabled")]
+        [Required]
+        [Writeable]
+        public bool IsEnabled { get; set; }
+
+        public LinkCollection Links { get; set; }
+    }
+}

--- a/source/Octopus.Client/Extensibility/Href.cs
+++ b/source/Octopus.Client/Extensibility/Href.cs
@@ -1,0 +1,62 @@
+﻿using System;
+
+namespace Octopus.Client.Extensibility
+{
+    public class Href : IEquatable<Href>
+    {
+        readonly string link;
+
+        public Href(string link)
+        {
+            this.link = link;
+        }
+
+        public string AsString()
+        {
+            return link;
+        }
+
+        public bool Equals(Href other)
+        {
+            return string.Equals(link, other.link);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((Href)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (link != null ? link.GetHashCode() : 0);
+        }
+
+        public override string ToString()
+        {
+            return link;
+        }
+
+        public static bool operator ==(Href left, Href right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(Href left, Href right)
+        {
+            return !Equals(left, right);
+        }
+
+        public static implicit operator String(Href href)
+        {
+            return href.link;
+        }
+
+        public static implicit operator Href(string href)
+        {
+            return new Href(href);
+        }
+    }
+}

--- a/source/Octopus.Client/Extensibility/IResource.cs
+++ b/source/Octopus.Client/Extensibility/IResource.cs
@@ -1,0 +1,14 @@
+﻿namespace Octopus.Client.Extensibility
+{
+    public interface IResource
+    {
+        string Id { get; }
+
+        LinkCollection Links { get; set; }
+    }
+
+    public interface INamedResource
+    {
+        string Name { get; }
+    }
+}

--- a/source/Octopus.Client/Extensibility/LinkCollection.cs
+++ b/source/Octopus.Client/Extensibility/LinkCollection.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Octopus.Client.Extensibility
+{
+    public class LinkCollection : Dictionary<string, Href>
+    {
+        public LinkCollection()
+            : base(StringComparer.OrdinalIgnoreCase)
+        {
+        }
+
+        public new LinkCollection Add(string name, Href value)
+        {
+            base.Add(name, value);
+            return this;
+        }
+
+        public static LinkCollection Self(Href self)
+        {
+            return new LinkCollection().Add("Self", self);
+        }
+    }
+}

--- a/source/Octopus.Client/Octopus.Client.csproj
+++ b/source/Octopus.Client/Octopus.Client.csproj
@@ -53,7 +53,4 @@ This package contains the client library for the HTTP API in Octopus.</Descripti
     <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Octopus.Client.Extensibility" Version="3.0.1" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Moved everything that was in the Octopus.Client.Extensibility NuGet package back in to this library.

Was able to keep the same namespaces for all of the classes that moved, so consumers only need to drop the reference to the 2nd NuGet package. Or can go back to just grabbing the single Dll.

Tweaked the tests too, as the check for the resource objects all being in the Model namespace should only apply to the derived classes, not the IResource interface or abstract base classes.