### PR TITLE
extra parameter to allow args to be passed in calls to Create

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3847,7 +3847,7 @@ Octopus.Client.Repositories.Async
   }
   interface ICreate`1
   {
-    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource)
+    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object)
   }
   interface IDashboardConfigurationRepository
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4260,7 +4260,7 @@ Octopus.Client.Repositories
   }
   interface ICreate`1
   {
-    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource)
+    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object)
   }
   interface IDashboardConfigurationRepository
   {
@@ -4715,7 +4715,7 @@ Octopus.Client.Repositories.Async
   }
   interface ICreate`1
   {
-    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource)
+    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object)
   }
   interface IDashboardConfigurationRepository
   {

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -23,9 +23,9 @@ namespace Octopus.Client.Repositories.Async
 
             public IOctopusAsyncClient Client { get; }
 
-            public Task<TResource> Create(TResource resource)
+            public Task<TResource> Create(TResource resource, object pathParameters = null)
             {
-                return Client.Create(Client.RootDocument.Link(CollectionLinkName), resource);
+                return Client.Create(Client.RootDocument.Link(CollectionLinkName), resource, pathParameters);
             }
 
             public Task<TResource> Modify(TResource resource)

--- a/source/Octopus.Client/Repositories/Async/ICreate.cs
+++ b/source/Octopus.Client/Repositories/Async/ICreate.cs
@@ -5,6 +5,6 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ICreate<TResource>
     {
-        Task<TResource> Create(TResource resource);
+        Task<TResource> Create(TResource resource, object pathParameters = null);
     }
 }

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -27,9 +27,9 @@ namespace Octopus.Client.Repositories
             get { return client; }
         }
 
-        public TResource Create(TResource resource)
+        public TResource Create(TResource resource, object pathParameters = null)
         {
-            return client.Create(client.RootDocument.Link(CollectionLinkName), resource);
+            return client.Create(client.RootDocument.Link(CollectionLinkName), resource, pathParameters);
         }
 
         public TResource Modify(TResource resource)

--- a/source/Octopus.Client/Repositories/ICreate.cs
+++ b/source/Octopus.Client/Repositories/ICreate.cs
@@ -4,6 +4,6 @@ namespace Octopus.Client.Repositories
 {
     public interface ICreate<TResource>
     {
-        TResource Create(TResource resource);
+        TResource Create(TResource resource, object pathParameters = null);
     }
 }


### PR DESCRIPTION
In order to clone a project through the API you have to be able to pass `clone` as a Url parameter in the POST. The BasicRepository didn't have support for doing that.

Tested using LINQPad and the following

```
	var octopusUrl = "http://localhost:8065";
	var apiKey = "API-zzzzzzzzzzzzzzzzzzz";

	var endpoint = new OctopusServerEndpoint(octopusUrl, apiKey);
	var repository = new OctopusRepository(endpoint);
	
	var project = new ProjectResource
	{
		Name = "Cloned Project",
		Slug = "cloned-project",
		ProjectGroupId = "ProjectGroups-z",
		LifecycleId = "Lifecycles-zz"
	};
		
	repository.Projects.Create(project, new { clone = "Projects-zzz"});

```