### PR TITLE
Adding migration models and repositories

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -66,6 +66,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.Async.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.Async.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.Async.IMigrationRepository Migrations { get; }
     Octopus.Client.Repositories.Async.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.Async.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.Async.IProjectRepository Projects { get; }
@@ -148,6 +149,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.Async.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.Async.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.Async.IMigrationRepository Migrations { get; }
     Octopus.Client.Repositories.Async.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.Async.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.Async.IProjectRepository Projects { get; }
@@ -3628,6 +3630,48 @@ Octopus.Client.Model.Forms
     Type GetNativeValueType()
   }
 }
+Octopus.Client.Model.Migrations
+{
+  class SpaceImportResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Boolean DeletePackageOnCompletion { get; set; }
+    String FailureCallbackUri { get; set; }
+    Boolean IsDryRun { get; set; }
+    Boolean IsEncryptedPackage { get; set; }
+    Boolean OverwriteExisting { get; set; }
+    String PackageId { get; set; }
+    String PackageVersion { get; set; }
+    String Password { get; set; }
+    String SuccessCallbackUri { get; set; }
+    String TaskId { get; set; }
+  }
+  class SpacePartialExportResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    String DestinationApiKey { get; set; }
+    String DestinationPackageFeed { get; set; }
+    Boolean EncryptPackage { get; set; }
+    String FailureCallbackUri { get; set; }
+    Boolean IgnoreCertificates { get; set; }
+    Boolean IgnoreDeployments { get; set; }
+    Boolean IgnoreMachines { get; set; }
+    Boolean IgnoreTenants { get; set; }
+    Boolean IncludeTaskLogs { get; set; }
+    String PackageId { get; set; }
+    String PackageVersion { get; set; }
+    String Password { get; set; }
+    List<String> Projects { get; set; }
+    String SuccessCallbackUri { get; set; }
+    String TaskId { get; set; }
+  }
+}
 Octopus.Client.Model.Triggers
 {
   class AutoDeployActionResource
@@ -4034,6 +4078,11 @@ Octopus.Client.Repositories.Async
   interface IMachineRoleRepository
   {
     Task<List<String>> GetAllRoleNames()
+  }
+  interface IMigrationRepository
+  {
+    Task<SpaceImportResource> SpaceImport(Octopus.Client.Model.Migrations.SpaceImportResource)
+    Task<SpacePartialExportResource> SpacePartialExport(Octopus.Client.Model.Migrations.SpacePartialExportResource)
   }
   interface IModify`1
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -73,6 +73,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.Async.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.Async.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.Async.IMigrationRepository Migrations { get; }
     Octopus.Client.Repositories.Async.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.Async.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.Async.IProjectRepository Projects { get; }
@@ -148,6 +149,7 @@ Octopus.Client
     Octopus.Client.Repositories.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.IMigrationRepository Migrations { get; }
     Octopus.Client.Repositories.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.IProjectRepository Projects { get; }
@@ -226,6 +228,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.Async.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.Async.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.Async.IMigrationRepository Migrations { get; }
     Octopus.Client.Repositories.Async.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.Async.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.Async.IProjectRepository Projects { get; }
@@ -321,6 +324,7 @@ Octopus.Client
     Octopus.Client.Repositories.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.IMigrationRepository Migrations { get; }
     Octopus.Client.Repositories.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.IProjectRepository Projects { get; }
@@ -4035,6 +4039,48 @@ Octopus.Client.Model.Forms
     Type GetNativeValueType()
   }
 }
+Octopus.Client.Model.Migrations
+{
+  class SpaceImportResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Boolean DeletePackageOnCompletion { get; set; }
+    String FailureCallbackUri { get; set; }
+    Boolean IsDryRun { get; set; }
+    Boolean IsEncryptedPackage { get; set; }
+    Boolean OverwriteExisting { get; set; }
+    String PackageId { get; set; }
+    String PackageVersion { get; set; }
+    String Password { get; set; }
+    String SuccessCallbackUri { get; set; }
+    String TaskId { get; set; }
+  }
+  class SpacePartialExportResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    String DestinationApiKey { get; set; }
+    String DestinationPackageFeed { get; set; }
+    Boolean EncryptPackage { get; set; }
+    String FailureCallbackUri { get; set; }
+    Boolean IgnoreCertificates { get; set; }
+    Boolean IgnoreDeployments { get; set; }
+    Boolean IgnoreMachines { get; set; }
+    Boolean IgnoreTenants { get; set; }
+    Boolean IncludeTaskLogs { get; set; }
+    String PackageId { get; set; }
+    String PackageVersion { get; set; }
+    String Password { get; set; }
+    List<String> Projects { get; set; }
+    String SuccessCallbackUri { get; set; }
+    String TaskId { get; set; }
+  }
+}
 Octopus.Client.Model.Triggers
 {
   class AutoDeployActionResource
@@ -4447,6 +4493,11 @@ Octopus.Client.Repositories
   interface IMachineRoleRepository
   {
     List<String> GetAllRoleNames()
+  }
+  interface IMigrationRepository
+  {
+    Octopus.Client.Model.Migrations.SpaceImportResource SpaceImport(Octopus.Client.Model.Migrations.SpaceImportResource)
+    Octopus.Client.Model.Migrations.SpacePartialExportResource SpacePartialExport(Octopus.Client.Model.Migrations.SpacePartialExportResource)
   }
   interface IModify`1
   {
@@ -4902,6 +4953,11 @@ Octopus.Client.Repositories.Async
   interface IMachineRoleRepository
   {
     Task<List<String>> GetAllRoleNames()
+  }
+  interface IMigrationRepository
+  {
+    Task<SpaceImportResource> SpaceImport(Octopus.Client.Model.Migrations.SpaceImportResource)
+    Task<SpacePartialExportResource> SpacePartialExport(Octopus.Client.Model.Migrations.SpacePartialExportResource)
   }
   interface IModify`1
   {

--- a/source/Octopus.Client/IOctopusAsyncRepository.cs
+++ b/source/Octopus.Client/IOctopusAsyncRepository.cs
@@ -15,15 +15,19 @@ namespace Octopus.Client
         /// </summary>
         IOctopusAsyncClient Client { get; }
 
-        IArtifactRepository Artifacts { get; }
+        IAccountRepository Accounts { get; }
         IActionTemplateRepository ActionTemplates { get; }
-        ICertificateRepository Certificates { get; }
-        ICertificateConfigurationRepository CertificateConfiguration { get; }
+        IArtifactRepository Artifacts { get; }
         IBackupRepository Backups { get; }
         IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
+        ICertificateConfigurationRepository CertificateConfiguration { get; }
+        ICertificateRepository Certificates { get; }
+        IChannelRepository Channels { get; }
         ICommunityActionTemplateRepository CommunityActionTemplates { get; }
+        IConfigurationRepository Configuration { get; }
         IDashboardConfigurationRepository DashboardConfigurations { get; }
         IDashboardRepository Dashboards { get; }
+        IDefectsRepository Defects { get; }
         IDeploymentProcessRepository DeploymentProcesses { get; }
         IDeploymentRepository Deployments { get; }
         IEnvironmentRepository Environments { get; }
@@ -33,30 +37,26 @@ namespace Octopus.Client
         IInterruptionRepository Interruptions { get; }
         ILibraryVariableSetRepository LibraryVariableSets { get; }
         ILifecyclesRepository Lifecycles { get; }
+        IMachinePolicyRepository MachinePolicies { get; }
         IMachineRepository Machines { get; }
         IMachineRoleRepository MachineRoles { get; }
-        IMachinePolicyRepository MachinePolicies { get; }
+        IMigrationRepository Migrations { get; }
+        IOctopusServerNodeRepository OctopusServerNodes { get; }
         IProjectGroupRepository ProjectGroups { get; }
         IProjectRepository Projects { get; }
-        IReleaseRepository Releases { get; }
+        IProjectTriggerRepository ProjectTriggers { get; }
         IProxyRepository Proxies { get; }
-        IServerStatusRepository ServerStatus { get; }
+        IReleaseRepository Releases { get; }
+        IRetentionPolicyRepository RetentionPolicies { get; }
         ISchedulerRepository Schedulers { get; }
+        IServerStatusRepository ServerStatus { get; }
         ISubscriptionRepository Subscriptions { get; }
+        ITagSetRepository TagSets { get; }
         ITaskRepository Tasks { get; }
         ITeamsRepository Teams { get; }
-        ITagSetRepository TagSets { get; }
         ITenantRepository Tenants { get; }
         IUserRepository Users { get; }
         IUserRolesRepository UserRoles { get; }
         IVariableSetRepository VariableSets { get; }
-        IChannelRepository Channels { get; }
-        IProjectTriggerRepository ProjectTriggers { get; }
-        IAccountRepository Accounts { get; }
-        IRetentionPolicyRepository RetentionPolicies { get; }
-        IDefectsRepository Defects { get; }
-        IOctopusServerNodeRepository OctopusServerNodes { get; }
-
-        IConfigurationRepository Configuration { get; }
     }
 }

--- a/source/Octopus.Client/IOctopusRepository.cs
+++ b/source/Octopus.Client/IOctopusRepository.cs
@@ -17,14 +17,15 @@ namespace Octopus.Client
         IOctopusClient Client { get; }
 
         IAccountRepository Accounts { get; }
-        IArtifactRepository Artifacts { get; }
         IActionTemplateRepository ActionTemplates { get; }
+        IArtifactRepository Artifacts { get; }
         IBackupRepository Backups { get; }
         IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
-        ICertificateRepository Certificates { get; }
         ICertificateConfigurationRepository CertificateConfiguration { get; }
+        ICertificateRepository Certificates { get; }
         IChannelRepository Channels { get; }
         ICommunityActionTemplateRepository CommunityActionTemplates {get; }
+        IConfigurationRepository Configuration { get; }
         IDashboardConfigurationRepository DashboardConfigurations { get; }
         IDashboardRepository Dashboards { get; }
         IDefectsRepository Defects { get; }
@@ -37,27 +38,27 @@ namespace Octopus.Client
         IInterruptionRepository Interruptions { get; }
         ILibraryVariableSetRepository LibraryVariableSets { get; }
         ILifecyclesRepository Lifecycles { get; }
+        IMachinePolicyRepository MachinePolicies { get; }
         IMachineRepository Machines { get; }
         IMachineRoleRepository MachineRoles { get; }
-        IMachinePolicyRepository MachinePolicies { get; }
+        IMigrationRepository Migrations { get; }
         IOctopusServerNodeRepository OctopusServerNodes { get; }
         IProjectGroupRepository ProjectGroups { get; }
         IProjectRepository Projects { get; }
-        IReleaseRepository Releases { get; }
+        IProjectTriggerRepository ProjectTriggers { get; }
         IProxyRepository Proxies { get; }
-        IServerStatusRepository ServerStatus { get; }
+        IReleaseRepository Releases { get; }
+        IRetentionPolicyRepository RetentionPolicies { get; }
         ISchedulerRepository Schedulers { get; }
+        IServerStatusRepository ServerStatus { get; }
         ISubscriptionRepository Subscriptions { get; }
+        ITagSetRepository TagSets { get; }
         ITaskRepository Tasks { get; }
         ITeamsRepository Teams { get; }
-        ITagSetRepository TagSets { get; }
         ITenantRepository Tenants { get; }
         IUserRepository Users { get; }
         IUserRolesRepository UserRoles { get; }
         IVariableSetRepository VariableSets { get; }
-        IProjectTriggerRepository ProjectTriggers { get; }
-        IRetentionPolicyRepository RetentionPolicies { get; }
-        IConfigurationRepository Configuration { get; }
     }
 }
 #endif

--- a/source/Octopus.Client/Model/Migrations/SpaceImportResource.cs
+++ b/source/Octopus.Client/Model/Migrations/SpaceImportResource.cs
@@ -1,0 +1,27 @@
+﻿using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.Migrations
+{
+    public class SpaceImportResource : Resource
+    {
+        [Writeable]
+        public string PackageId { get; set; }
+        [Writeable]
+        public string PackageVersion { get; set; }
+        [Writeable]
+        public string Password { get; set; }
+        [Writeable]
+        public bool IsEncryptedPackage { get; set; }
+        [Writeable]
+        public bool IsDryRun { get; set; }
+        [Writeable]
+        public bool OverwriteExisting { get; set; }
+        [Writeable]
+        public bool DeletePackageOnCompletion { get; set; }
+        [Writeable]
+        public string SuccessCallbackUri { get; set; }
+        [Writeable]
+        public string FailureCallbackUri { get; set; }
+        public string TaskId { get; set; }
+    }
+}

--- a/source/Octopus.Client/Model/Migrations/SpacePartialExportResource.cs
+++ b/source/Octopus.Client/Model/Migrations/SpacePartialExportResource.cs
@@ -1,0 +1,38 @@
+﻿using Octopus.Client.Extensibility.Attributes;
+using System.Collections.Generic;
+
+namespace Octopus.Client.Model.Migrations
+{
+    public class SpacePartialExportResource : Resource
+    {
+        [Writeable]
+        public string PackageId { get; set; }
+        [Writeable]
+        public string PackageVersion { get; set; }
+        [Writeable]
+        public string Password { get; set; }
+        [Writeable]
+        public List<string> Projects { get; set; }
+        [Writeable]
+        public bool IgnoreCertificates { get; set; }
+        [Writeable]
+        public bool IgnoreMachines { get; set; }
+        [Writeable]
+        public bool IgnoreDeployments { get; set; }
+        [Writeable]
+        public bool IgnoreTenants { get; set; }
+        [Writeable]
+        public bool IncludeTaskLogs { get; set; }
+        [Writeable]
+        public bool EncryptPackage { get; set; }
+        [Writeable]
+        public string DestinationApiKey { get; set; }
+        [Writeable]
+        public string DestinationPackageFeed { get; set; }
+        [Writeable]
+        public string SuccessCallbackUri { get; set; }
+        [Writeable]
+        public string FailureCallbackUri { get; set; }
+        public string TaskId { get; set; }
+    }
+}

--- a/source/Octopus.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Client/OctopusAsyncRepository.cs
@@ -29,134 +29,96 @@ namespace Octopus.Client
         public OctopusAsyncRepository(IOctopusAsyncClient client)
         {
             this.Client = client;
-            Feeds = new FeedRepository(client);
-            Backups = new BackupRepository(client);
+
+            Accounts = new AccountRepository(client);
             ActionTemplates = new ActionTemplateRepository(client);
+            Artifacts = new ArtifactRepository(client);
+            Backups = new BackupRepository(client);
+            BuiltInPackageRepository = new BuiltInPackageRepositoryRepository(client);
+            CertificateConfiguration = new CertificateConfigurationRepository(client);
+            Certificates = new CertificateRepository(client);
+            Channels = new ChannelRepository(client);
             CommunityActionTemplates = new CommunityActionTemplateRepository(client);
-            Machines = new MachineRepository(client);
-            MachineRoles = new MachineRoleRepository(client);
-            MachinePolicies = new MachinePolicyRepository(client);
+            Configuration = new ConfigurationRepository(client);
+            DashboardConfigurations = new DashboardConfigurationRepository(client);
+            Dashboards = new DashboardRepository(client);
+            Defects = new DefectsRepository(client);
+            DeploymentProcesses = new DeploymentProcessRepository(client);
+            Deployments = new DeploymentRepository(client);
             Environments = new EnvironmentRepository(client);
             Events = new EventRepository(client);
             FeaturesConfiguration = new FeaturesConfigurationRepository(client);
+            Feeds = new FeedRepository(client);
+            Interruptions = new InterruptionRepository(client);
+            LibraryVariableSets = new LibraryVariableSetRepository(client);
+            Lifecycles = new LifecyclesRepository(client);
+            MachinePolicies = new MachinePolicyRepository(client);
+            MachineRoles = new MachineRoleRepository(client);
+            Machines = new MachineRepository(client);
+            Migrations = new MigrationRepository(client);
+            OctopusServerNodes = new OctopusServerNodeRepository(client);
             ProjectGroups = new ProjectGroupRepository(client);
             Projects = new ProjectRepository(client);
+            ProjectTriggers = new ProjectTriggerRepository(client);
             Proxies = new ProxyRepository(client);
+            Releases = new ReleaseRepository(client);
+            RetentionPolicies = new RetentionPolicyRepository(client);
+            Schedulers = new SchedulerRepository(client);
+            ServerStatus = new ServerStatusRepository(client);
+            Subscriptions = new SubscriptionRepository(client);
+            TagSets = new TagSetRepository(client);
             Tasks = new TaskRepository(client);
+            Teams = new TeamsRepository(client);
+            Tenants = new TenantRepository(client);
+            UserRoles = new UserRolesRepository(client);
             Users = new UserRepository(client);
             VariableSets = new VariableSetRepository(client);
-            LibraryVariableSets = new LibraryVariableSetRepository(client);
-            DeploymentProcesses = new DeploymentProcessRepository(client);
-            Releases = new ReleaseRepository(client);
-            Deployments = new DeploymentRepository(client);
-            Certificates = new CertificateRepository(client);
-            CertificateConfiguration = new CertificateConfigurationRepository(client);
-            Dashboards = new DashboardRepository(client);
-            DashboardConfigurations = new DashboardConfigurationRepository(client);
-            Artifacts = new ArtifactRepository(client);
-            Interruptions = new InterruptionRepository(client);
-            ServerStatus = new ServerStatusRepository(client);
-            UserRoles = new UserRolesRepository(client);
-            Teams = new TeamsRepository(client);
-            RetentionPolicies = new RetentionPolicyRepository(client);
-            Accounts = new AccountRepository(client);
-            Defects = new DefectsRepository(client);
-            Lifecycles = new LifecyclesRepository(client);
-            OctopusServerNodes = new OctopusServerNodeRepository(client);
-            Channels = new ChannelRepository(client);
-            ProjectTriggers = new ProjectTriggerRepository(client);
-            Schedulers = new SchedulerRepository(client);
-            Subscriptions = new SubscriptionRepository(client);
-            Tenants = new TenantRepository(client);
-            TagSets = new TagSetRepository(client);
-            BuiltInPackageRepository = new BuiltInPackageRepositoryRepository(client);
-            Configuration = new ConfigurationRepository(client);
         }
 
         public IOctopusAsyncClient Client { get; }
 
-        public IActionTemplateRepository ActionTemplates { get; }
-
-        public ICommunityActionTemplateRepository CommunityActionTemplates { get; }
-
-        public IConfigurationRepository Configuration { get; }
-
-        public IDashboardRepository Dashboards { get; }
-
-        public IDashboardConfigurationRepository DashboardConfigurations { get; }
-
-        public IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
-
-        public IFeedRepository Feeds { get; }
-
         public IAccountRepository Accounts { get; }
-
-        public IBackupRepository Backups { get; }
-
-        public IMachineRepository Machines { get; }
-
-        public IMachineRoleRepository MachineRoles { get; }
-
-        public IMachinePolicyRepository MachinePolicies { get; }
-
-        public ILifecyclesRepository Lifecycles { get; }
-
-        public IReleaseRepository Releases { get; }
-
-        public IDefectsRepository Defects { get; }
-
-        public IDeploymentRepository Deployments { get; }
-
-        public IEnvironmentRepository Environments { get; }
-
-        public IEventRepository Events { get; }
-
-        public IFeaturesConfigurationRepository FeaturesConfiguration { get; }
-
-        public IInterruptionRepository Interruptions { get; }
-
-        public IProjectGroupRepository ProjectGroups { get; }
-
-        public IProjectRepository Projects { get; }
-
-        public IProxyRepository Proxies { get; }
-
-        public ISubscriptionRepository Subscriptions { get; }
-
-        public ITaskRepository Tasks { get; }
-
-        public IUserRepository Users { get; }
-
-        public IUserRolesRepository UserRoles { get; }
-
-        public ITeamsRepository Teams { get; }
-
-        public IVariableSetRepository VariableSets { get; }
-
-        public ILibraryVariableSetRepository LibraryVariableSets { get; }
-
-        public IDeploymentProcessRepository DeploymentProcesses { get; }
-
-        public ICertificateRepository Certificates { get; }
-
-        public ICertificateConfigurationRepository CertificateConfiguration { get; }
-
+        public IActionTemplateRepository ActionTemplates { get; }
         public IArtifactRepository Artifacts { get; }
-
-        public IServerStatusRepository ServerStatus { get; }
-
-        public IRetentionPolicyRepository RetentionPolicies { get; }
-
-        public IOctopusServerNodeRepository OctopusServerNodes { get; }
-
+        public IBackupRepository Backups { get; }
+        public IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
+        public ICertificateConfigurationRepository CertificateConfiguration { get; }
+        public ICertificateRepository Certificates { get; }
         public IChannelRepository Channels { get; }
-
+        public ICommunityActionTemplateRepository CommunityActionTemplates { get; }
+        public IConfigurationRepository Configuration { get; }
+        public IDashboardConfigurationRepository DashboardConfigurations { get; }
+        public IDashboardRepository Dashboards { get; }
+        public IDefectsRepository Defects { get; }
+        public IDeploymentProcessRepository DeploymentProcesses { get; }
+        public IDeploymentRepository Deployments { get; }
+        public IEnvironmentRepository Environments { get; }
+        public IEventRepository Events { get; }
+        public IFeaturesConfigurationRepository FeaturesConfiguration { get; }
+        public IFeedRepository Feeds { get; }
+        public IInterruptionRepository Interruptions { get; }
+        public ILibraryVariableSetRepository LibraryVariableSets { get; }
+        public ILifecyclesRepository Lifecycles { get; }
+        public IMachinePolicyRepository MachinePolicies { get; }
+        public IMachineRepository Machines { get; }
+        public IMachineRoleRepository MachineRoles { get; }
+        public IMigrationRepository Migrations { get; }
+        public IOctopusServerNodeRepository OctopusServerNodes { get; }
+        public IProjectGroupRepository ProjectGroups { get; }
+        public IProjectRepository Projects { get; }
         public IProjectTriggerRepository ProjectTriggers { get; }
-
+        public IProxyRepository Proxies { get; }
+        public IReleaseRepository Releases { get; }
+        public IRetentionPolicyRepository RetentionPolicies { get; }
         public ISchedulerRepository Schedulers { get; }
-
+        public IServerStatusRepository ServerStatus { get; }
+        public ISubscriptionRepository Subscriptions { get; }
         public ITagSetRepository TagSets { get; }
-
+        public ITaskRepository Tasks { get; }
+        public ITeamsRepository Teams { get; }
         public ITenantRepository Tenants { get; }
+        public IUserRepository Users { get; }
+        public IUserRolesRepository UserRoles { get; }
+        public IVariableSetRepository VariableSets { get; }
     }
 }

--- a/source/Octopus.Client/OctopusRepository.cs
+++ b/source/Octopus.Client/OctopusRepository.cs
@@ -23,135 +23,97 @@ namespace Octopus.Client
         public OctopusRepository(IOctopusClient client)
         {
             this.Client = client;
-            Feeds = new FeedRepository(client);
+
+            Accounts = new AccountRepository(client);
+            ActionTemplates = new ActionTemplateRepository(client);
+            Artifacts = new ArtifactRepository(client);
             Backups = new BackupRepository(client);
-            Machines = new MachineRepository(client);
-            MachineRoles = new MachineRoleRepository(client);
-            MachinePolicies = new MachinePolicyRepository(client);
-            Subscriptions = new SubscriptionRepository(client);
+            BuiltInPackageRepository = new BuiltInPackageRepositoryRepository(client);
+            CertificateConfiguration = new CertificateConfigurationRepository(client);
+            Certificates = new CertificateRepository(client);
+            Channels = new ChannelRepository(client);
+            CommunityActionTemplates = new CommunityActionTemplateRepository(client);
+            Configuration = new ConfigurationRepository(client);
+            DashboardConfigurations = new DashboardConfigurationRepository(client);
+            Dashboards = new DashboardRepository(client);
+            Defects = new DefectsRepository(client);
+            DeploymentProcesses = new DeploymentProcessRepository(client);
+            Deployments = new DeploymentRepository(client);
             Environments = new EnvironmentRepository(client);
             Events = new EventRepository(client);
             FeaturesConfiguration = new FeaturesConfigurationRepository(client);
+            Feeds = new FeedRepository(client);
+            Interruptions = new InterruptionRepository(client);
+            LibraryVariableSets = new LibraryVariableSetRepository(client);
+            Lifecycles = new LifecyclesRepository(client);
+            MachinePolicies = new MachinePolicyRepository(client);
+            MachineRoles = new MachineRoleRepository(client);
+            Machines = new MachineRepository(client);
+            Migrations = new MigrationRepository(client);
+            OctopusServerNodes = new OctopusServerNodeRepository(client);
             ProjectGroups = new ProjectGroupRepository(client);
             Projects = new ProjectRepository(client);
+            ProjectTriggers = new ProjectTriggerRepository(client);
             Proxies = new ProxyRepository(client);
+            Releases = new ReleaseRepository(client);
+            RetentionPolicies = new RetentionPolicyRepository(client);
+            Schedulers = new SchedulerRepository(client);
+            ServerStatus = new ServerStatusRepository(client);
+            Subscriptions = new SubscriptionRepository(client);
+            TagSets = new TagSetRepository(client);
             Tasks = new TaskRepository(client);
+            Teams = new TeamsRepository(client);
+            Tenants = new TenantRepository(client);
+            UserRoles = new UserRolesRepository(client);
             Users = new UserRepository(client);
             VariableSets = new VariableSetRepository(client);
-            LibraryVariableSets = new LibraryVariableSetRepository(client);
-            DeploymentProcesses = new DeploymentProcessRepository(client);
-            Releases = new ReleaseRepository(client);
-            Deployments = new DeploymentRepository(client);
-            Certificates = new CertificateRepository(client);
-            CertificateConfiguration = new CertificateConfigurationRepository(client);
-            Dashboards = new DashboardRepository(client);
-            DashboardConfigurations = new DashboardConfigurationRepository(client);
-            Artifacts = new ArtifactRepository(client);
-            Interruptions = new InterruptionRepository(client);
-            ServerStatus = new ServerStatusRepository(client);
-            UserRoles = new UserRolesRepository(client);
-            Teams = new TeamsRepository(client);
-            RetentionPolicies = new RetentionPolicyRepository(client);
-            Accounts = new AccountRepository(client);
-            Defects = new DefectsRepository(client);
-            Lifecycles = new LifecyclesRepository(client);
-            OctopusServerNodes = new OctopusServerNodeRepository(client);
-            Channels = new ChannelRepository(client);
-            ProjectTriggers = new ProjectTriggerRepository(client);
-            Schedulers = new SchedulerRepository(client);
-            Tenants = new TenantRepository(client);
-            TagSets = new TagSetRepository(client);
-            BuiltInPackageRepository = new BuiltInPackageRepositoryRepository(client);
-            ActionTemplates = new ActionTemplateRepository(client);
-            CommunityActionTemplates = new CommunityActionTemplateRepository(client);
-            Configuration = new ConfigurationRepository(client);
         }
 
         public IOctopusClient Client { get; }
 
-        public IDashboardRepository Dashboards { get; }
-
-        public IDashboardConfigurationRepository DashboardConfigurations { get; }
-
-        public IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
-
-        public IFeedRepository Feeds { get; }
-
         public IAccountRepository Accounts { get; }
-
         public IActionTemplateRepository ActionTemplates { get; }
-
-        public ICommunityActionTemplateRepository CommunityActionTemplates { get; }
-
-        public IBackupRepository Backups { get; }
-
-        public IMachineRepository Machines { get; }
-
-        public IMachineRoleRepository MachineRoles { get; }
-
-        public IMachinePolicyRepository MachinePolicies { get; }
-
-        public ISubscriptionRepository Subscriptions { get; }
-
-        public ILifecyclesRepository Lifecycles { get; }
-
-        public IReleaseRepository Releases { get; }
-
-        public IDefectsRepository Defects { get; }
-
-        public IDeploymentRepository Deployments { get; }
-
-        public IEnvironmentRepository Environments { get; }
-
-        public IEventRepository Events { get; }
-
-        public IFeaturesConfigurationRepository FeaturesConfiguration { get; }
-
-        public IInterruptionRepository Interruptions { get; }
-
-        public IProjectGroupRepository ProjectGroups { get; }
-
-        public IProjectRepository Projects { get; }
-
-        public IProxyRepository Proxies { get; }
-
-        public ITaskRepository Tasks { get; }
-
-        public IUserRepository Users { get; }
-
-        public IUserRolesRepository UserRoles { get; }
-
-        public ITeamsRepository Teams { get; }
-
-        public IVariableSetRepository VariableSets { get; }
-
-        public ILibraryVariableSetRepository LibraryVariableSets { get; }
-
-        public IDeploymentProcessRepository DeploymentProcesses { get; }
-
-        public ICertificateRepository Certificates { get; }
-
-        public ICertificateConfigurationRepository CertificateConfiguration { get; }
-
         public IArtifactRepository Artifacts { get; }
-
-        public IServerStatusRepository ServerStatus { get; }
-
-        public IRetentionPolicyRepository RetentionPolicies { get; }
-
-        public IOctopusServerNodeRepository OctopusServerNodes { get; }
-
+        public IBackupRepository Backups { get; }
+        public IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
+        public ICertificateConfigurationRepository CertificateConfiguration { get; }
+        public ICertificateRepository Certificates { get; }
         public IChannelRepository Channels { get; }
-
-        public IProjectTriggerRepository ProjectTriggers { get; }
-
-        public ISchedulerRepository Schedulers { get; }
-
-        public ITagSetRepository TagSets { get; }
-
-        public ITenantRepository Tenants { get; }
-
+        public ICommunityActionTemplateRepository CommunityActionTemplates { get; }
         public IConfigurationRepository Configuration { get; }
+        public IDashboardConfigurationRepository DashboardConfigurations { get; }
+        public IDashboardRepository Dashboards { get; }
+        public IDefectsRepository Defects { get; }
+        public IDeploymentProcessRepository DeploymentProcesses { get; }
+        public IDeploymentRepository Deployments { get; }
+        public IEnvironmentRepository Environments { get; }
+        public IEventRepository Events { get; }
+        public IFeaturesConfigurationRepository FeaturesConfiguration { get; }
+        public IFeedRepository Feeds { get; }
+        public IInterruptionRepository Interruptions { get; }
+        public ILibraryVariableSetRepository LibraryVariableSets { get; }
+        public ILifecyclesRepository Lifecycles { get; }
+        public IMachinePolicyRepository MachinePolicies { get; }
+        public IMachineRepository Machines { get; }
+        public IMachineRoleRepository MachineRoles { get; }
+        public IMigrationRepository Migrations { get; }
+        public IOctopusServerNodeRepository OctopusServerNodes { get; }
+        public IProjectGroupRepository ProjectGroups { get; }
+        public IProjectRepository Projects { get; }
+        public IProjectTriggerRepository ProjectTriggers { get; }
+        public IProxyRepository Proxies { get; }
+        public IReleaseRepository Releases { get; }
+        public IRetentionPolicyRepository RetentionPolicies { get; }
+        public ISchedulerRepository Schedulers { get; }
+        public IServerStatusRepository ServerStatus { get; }
+        public ISubscriptionRepository Subscriptions { get; }
+        public ITagSetRepository TagSets { get; }
+        public ITaskRepository Tasks { get; }
+        public ITeamsRepository Teams { get; }
+        public ITenantRepository Tenants { get; }
+        public IUserRepository Users { get; }
+        public IUserRolesRepository UserRoles { get; }
+        public IVariableSetRepository VariableSets { get; }
     }
 }
 #endif

--- a/source/Octopus.Client/Repositories/Async/MigrationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MigrationRepository.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using Octopus.Client.Model.Migrations;
+
+namespace Octopus.Client.Repositories.Async
+{
+    public interface IMigrationRepository
+    {
+        Task<SpacePartialExportResource> SpacePartialExport(SpacePartialExportResource resource);
+        Task<SpaceImportResource> SpaceImport(SpaceImportResource resource);
+    }
+
+    class MigrationRepository : IMigrationRepository
+    {
+        readonly IOctopusAsyncClient client;
+
+        public MigrationRepository(IOctopusAsyncClient client)
+        {
+            this.client = client;
+        }
+
+        public async Task<SpacePartialExportResource> SpacePartialExport(SpacePartialExportResource resource)
+        {
+            return await client.Post<SpacePartialExportResource, SpacePartialExportResource>(client.RootDocument.Link("MigrationsSpacePartialExport"), resource).ConfigureAwait(false);
+        }
+
+        public async Task<SpaceImportResource> SpaceImport(SpaceImportResource resource)
+        {
+            return await client.Post<SpaceImportResource, SpaceImportResource>(client.RootDocument.Link("MigrationsSpaceImport"), resource).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/Octopus.Client/Repositories/MigrationRepository.cs
+++ b/source/Octopus.Client/Repositories/MigrationRepository.cs
@@ -1,0 +1,30 @@
+﻿using Octopus.Client.Model.Migrations;
+
+namespace Octopus.Client.Repositories
+{
+    public interface IMigrationRepository
+    {
+        SpacePartialExportResource SpacePartialExport(SpacePartialExportResource resource);
+        SpaceImportResource SpaceImport(SpaceImportResource resource);
+    }
+
+    class MigrationRepository : IMigrationRepository
+    {
+        readonly IOctopusClient client;
+
+        public MigrationRepository(IOctopusClient client)
+        {
+            this.client = client;
+        }
+
+        public SpacePartialExportResource SpacePartialExport(SpacePartialExportResource resource)
+        {
+            return client.Post<SpacePartialExportResource, SpacePartialExportResource>(client.RootDocument.Link("MigrationsSpacePartialExport"), resource);
+        }
+
+        public SpaceImportResource SpaceImport(SpaceImportResource resource)
+        {
+            return client.Post< SpaceImportResource, SpaceImportResource>(client.RootDocument.Link("MigrationsSpaceImport"), resource);
+        }
+    }
+}


### PR DESCRIPTION
We want to start exposing the migration API for hosted, so it's time to start exposing this in OctopusClients.

I also sorted the properties in the main repositories, as this has been bugging my OCD :)