### PR TITLE
Add TenantedDeploymentParticipation param to RegisterMachineOperation

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3769,6 +3769,7 @@ Octopus.Client.Operations
     String ProxyName { get; set; }
     String[] Roles { get; set; }
     Uri SubscriptionId { get; set; }
+    Octopus.Client.Model.TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
     String[] Tenants { get; set; }
     String[] TenantTags { get; set; }
     String TentacleHostname { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3826,6 +3826,7 @@ Octopus.Client.Operations
     String ProxyName { get; set; }
     String[] Roles { get; set; }
     Uri SubscriptionId { get; set; }
+    Octopus.Client.Model.TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
     String[] Tenants { get; set; }
     String[] TenantTags { get; set; }
     String TentacleHostname { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4179,6 +4179,7 @@ Octopus.Client.Operations
     String ProxyName { get; set; }
     String[] Roles { get; set; }
     Uri SubscriptionId { get; set; }
+    Octopus.Client.Model.TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
     String[] Tenants { get; set; }
     String[] TenantTags { get; set; }
     String TentacleHostname { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4235,6 +4235,7 @@ Octopus.Client.Operations
     String ProxyName { get; set; }
     String[] Roles { get; set; }
     Uri SubscriptionId { get; set; }
+    Octopus.Client.Model.TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
     String[] Tenants { get; set; }
     String[] TenantTags { get; set; }
     String TentacleHostname { get; set; }

--- a/source/Octopus.Client/Operations/IRegisterMachineOperation.cs
+++ b/source/Octopus.Client/Operations/IRegisterMachineOperation.cs
@@ -75,6 +75,12 @@ namespace Octopus.Client.Operations
 
         Uri SubscriptionId { get; set; }
 
+        /// <summary>
+        /// How the machine should participate in Tenanted Deployments.
+        /// Allowed values are Untenanted, TenantedOrUntenanted or Tenanted
+        /// </summary>
+        TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
+
 #if SYNC_CLIENT
         /// <summary>
         /// Executes the operation against the specified Octopus Deploy server.

--- a/source/Octopus.Client/Operations/RegisterMachineOperation.cs
+++ b/source/Octopus.Client/Operations/RegisterMachineOperation.cs
@@ -98,6 +98,12 @@ namespace Octopus.Client.Operations
 
         public Uri SubscriptionId { get; set; }
 
+        /// <summary>
+        /// How the machine should participate in Tenanted Deployments.
+        /// Allowed values are Untenanted, TenantedOrUntenanted or Tenanted
+        /// </summary>
+        public TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
+
 #if SYNC_CLIENT
         /// <summary>
         /// Executes the operation against the specified Octopus Deploy server.
@@ -374,6 +380,8 @@ namespace Octopus.Client.Operations
             machine.TenantTags = new ReferenceCollection(TenantTags);
             machine.Roles = new ReferenceCollection(Roles);
             machine.Name = MachineName;
+            machine.TenantedDeploymentParticipation = TenantedDeploymentParticipation;
+
             if (machinePolicy != null)
                 machine.MachinePolicyId = machinePolicy.Id;
 


### PR DESCRIPTION
So that you can specify how a Tentacle behaves with tenanted deployments at registration time (ie, during the `register-with` call).

Relates to: https://github.com/OctopusDeploy/Issues/issues/3782