### PR TITLE
Add repository to retrieve all tenant variables

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -84,6 +84,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.Async.ITeamsRepository Teams { get; }
     Octopus.Client.Repositories.Async.ITenantRepository Tenants { get; }
+    Octopus.Client.Repositories.Async.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.Async.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.Async.IUserRepository Users { get; }
     Octopus.Client.Repositories.Async.IVariableSetRepository VariableSets { get; }
@@ -168,6 +169,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.Async.ITeamsRepository Teams { get; }
     Octopus.Client.Repositories.Async.ITenantRepository Tenants { get; }
+    Octopus.Client.Repositories.Async.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.Async.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.Async.IUserRepository Users { get; }
     Octopus.Client.Repositories.Async.IVariableSetRepository VariableSets { get; }
@@ -4306,6 +4308,11 @@ Octopus.Client.Repositories.Async
     Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource)
     Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
+  }
+  interface ITenantVariablesRepository
+    Octopus.Client.Repositories.Async.IGetAll<TenantVariableResource>
+  {
+    Task<List<TenantVariableResource>> GetAll(Octopus.Client.Model.ProjectResource)
   }
   interface IUserRepository
     Octopus.Client.Repositories.Async.IPaginate<UserResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -91,6 +91,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.Async.ITeamsRepository Teams { get; }
     Octopus.Client.Repositories.Async.ITenantRepository Tenants { get; }
+    Octopus.Client.Repositories.Async.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.Async.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.Async.IUserRepository Users { get; }
     Octopus.Client.Repositories.Async.IVariableSetRepository VariableSets { get; }
@@ -248,6 +249,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.Async.ITeamsRepository Teams { get; }
     Octopus.Client.Repositories.Async.ITenantRepository Tenants { get; }
+    Octopus.Client.Repositories.Async.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.Async.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.Async.IUserRepository Users { get; }
     Octopus.Client.Repositories.Async.IVariableSetRepository VariableSets { get; }
@@ -5183,6 +5185,11 @@ Octopus.Client.Repositories.Async
     Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource)
     Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
+  }
+  interface ITenantVariablesRepository
+    Octopus.Client.Repositories.Async.IGetAll<TenantVariableResource>
+  {
+    Task<List<TenantVariableResource>> GetAll(Octopus.Client.Model.ProjectResource)
   }
   interface IUserRepository
     Octopus.Client.Repositories.Async.IPaginate<UserResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -169,6 +169,7 @@ Octopus.Client
     Octopus.Client.Repositories.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.ITeamsRepository Teams { get; }
     Octopus.Client.Repositories.ITenantRepository Tenants { get; }
+    Octopus.Client.Repositories.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.IUserRepository Users { get; }
     Octopus.Client.Repositories.IVariableSetRepository VariableSets { get; }
@@ -347,6 +348,7 @@ Octopus.Client
     Octopus.Client.Repositories.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.ITeamsRepository Teams { get; }
     Octopus.Client.Repositories.ITenantRepository Tenants { get; }
+    Octopus.Client.Repositories.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.IUserRepository Users { get; }
     Octopus.Client.Repositories.IVariableSetRepository VariableSets { get; }
@@ -4724,6 +4726,11 @@ Octopus.Client.Repositories
     Octopus.Client.Model.TenantVariableResource GetVariables(Octopus.Client.Model.TenantResource)
     Octopus.Client.Model.TenantVariableResource ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     void SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
+  }
+  interface ITenantVariablesRepository
+    Octopus.Client.Repositories.IGetAll<TenantVariableResource>
+  {
+    List<TenantVariableResource> GetAll(Octopus.Client.Model.ProjectResource)
   }
   interface IUserRepository
     Octopus.Client.Repositories.IPaginate<UserResource>

--- a/source/Octopus.Client/IOctopusAsyncRepository.cs
+++ b/source/Octopus.Client/IOctopusAsyncRepository.cs
@@ -55,6 +55,7 @@ namespace Octopus.Client
         ITaskRepository Tasks { get; }
         ITeamsRepository Teams { get; }
         ITenantRepository Tenants { get; }
+        ITenantVariablesRepository TenantVariables { get; }
         IUserRepository Users { get; }
         IUserRolesRepository UserRoles { get; }
         IVariableSetRepository VariableSets { get; }

--- a/source/Octopus.Client/IOctopusRepository.cs
+++ b/source/Octopus.Client/IOctopusRepository.cs
@@ -56,6 +56,7 @@ namespace Octopus.Client
         ITaskRepository Tasks { get; }
         ITeamsRepository Teams { get; }
         ITenantRepository Tenants { get; }
+        ITenantVariablesRepository TenantVariables { get; }
         IUserRepository Users { get; }
         IUserRolesRepository UserRoles { get; }
         IVariableSetRepository VariableSets { get; }

--- a/source/Octopus.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Client/OctopusAsyncRepository.cs
@@ -70,6 +70,7 @@ namespace Octopus.Client
             Tasks = new TaskRepository(client);
             Teams = new TeamsRepository(client);
             Tenants = new TenantRepository(client);
+            TenantVariables = new TenantVariablesRepository(client);
             UserRoles = new UserRolesRepository(client);
             Users = new UserRepository(client);
             VariableSets = new VariableSetRepository(client);
@@ -117,6 +118,7 @@ namespace Octopus.Client
         public ITaskRepository Tasks { get; }
         public ITeamsRepository Teams { get; }
         public ITenantRepository Tenants { get; }
+        public ITenantVariablesRepository TenantVariables { get; }
         public IUserRepository Users { get; }
         public IUserRolesRepository UserRoles { get; }
         public IVariableSetRepository VariableSets { get; }

--- a/source/Octopus.Client/OctopusRepository.cs
+++ b/source/Octopus.Client/OctopusRepository.cs
@@ -64,6 +64,7 @@ namespace Octopus.Client
             Tasks = new TaskRepository(client);
             Teams = new TeamsRepository(client);
             Tenants = new TenantRepository(client);
+            TenantVariables = new TenantVariablesRepository(client);
             UserRoles = new UserRolesRepository(client);
             Users = new UserRepository(client);
             VariableSets = new VariableSetRepository(client);
@@ -111,6 +112,7 @@ namespace Octopus.Client
         public ITaskRepository Tasks { get; }
         public ITeamsRepository Teams { get; }
         public ITenantRepository Tenants { get; }
+        public ITenantVariablesRepository TenantVariables { get; }
         public IUserRepository Users { get; }
         public IUserRolesRepository UserRoles { get; }
         public IVariableSetRepository VariableSets { get; }

--- a/source/Octopus.Client/Repositories/Async/TenantVariablesRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/TenantVariablesRepository.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Repositories.Async
+{
+    public interface ITenantVariablesRepository : IGetAll<TenantVariableResource>
+    {
+        Task<List<TenantVariableResource>> GetAll(ProjectResource projectResource);
+    }
+
+    class TenantVariablesRepository : BasicRepository<TenantVariableResource>, ITenantVariablesRepository
+    {
+        public Task<List<TenantVariableResource>> GetAll(ProjectResource projectResource)
+        {
+            return Client.Get<List<TenantVariableResource>>(Client.RootDocument.Link("TenantVariables"), new
+            {
+                projectId = projectResource?.Id
+            });
+        }
+
+        public TenantVariablesRepository(IOctopusAsyncClient client) 
+            : base(client, "TenantVariables")
+        {
+        }
+    }
+}

--- a/source/Octopus.Client/Repositories/TenantVariablesRepository.cs
+++ b/source/Octopus.Client/Repositories/TenantVariablesRepository.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Repositories
+{
+    public interface ITenantVariablesRepository : IGetAll<TenantVariableResource>
+    {
+        List<TenantVariableResource> GetAll(ProjectResource projectResource);
+    }
+
+    class TenantVariablesRepository : BasicRepository<TenantVariableResource>, ITenantVariablesRepository
+    {
+        public List<TenantVariableResource> GetAll(ProjectResource projectResource)
+        {
+            return Client.Get<List<TenantVariableResource>>(Client.RootDocument.Link("TenantVariables"), new
+            {
+                projectId = projectResource?.Id
+            });
+        }
+
+        public TenantVariablesRepository(IOctopusClient client) 
+            : base(client, "TenantVariables")
+        {
+        }
+    }
+}


### PR DESCRIPTION
New repository to retrieve all tenant variables via the `/api/tenantvariables/all{?projectId}` endpoint.

Needed for the Hosted Portal project