### PR TITLE
Added support for specifying the proxy on the Discover call

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1569,6 +1569,14 @@ Octopus.Client.Model
       TentacleActive = 1
       Ssh = 2
   }
+  class DiscoverMachineOptions
+  {
+    .ctor(String)
+    String Host { get; }
+    Int32 Port { get; set; }
+    Octopus.Client.Model.ProxyResource Proxy { get; set; }
+    Nullable<DiscoverableEndpointType> Type { get; set; }
+  }
   class DockerFeedResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -4246,6 +4254,7 @@ Octopus.Client.Repositories.Async
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
     Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions)
     Task<List<MachineResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1973,6 +1973,14 @@ Octopus.Client.Model
       TentacleActive = 1
       Ssh = 2
   }
+  class DiscoverMachineOptions
+  {
+    .ctor(String)
+    String Host { get; }
+    Int32 Port { get; set; }
+    Octopus.Client.Model.ProxyResource Proxy { get; set; }
+    Nullable<DiscoverableEndpointType> Type { get; set; }
+  }
   class DockerFeedResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -4665,6 +4673,7 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
     Octopus.Client.Model.MachineResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Octopus.Client.Model.MachineResource Discover(Octopus.Client.Model.DiscoverMachineOptions)
     List<MachineResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.MachineResource)
     IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource)
@@ -5130,6 +5139,7 @@ Octopus.Client.Repositories.Async
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
     Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions)
     Task<List<MachineResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource)

--- a/source/Octopus.Client/Model/DiscoverMachineOptions.cs
+++ b/source/Octopus.Client/Model/DiscoverMachineOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace Octopus.Client.Model
+{
+    public class DiscoverMachineOptions
+    {
+        public DiscoverMachineOptions(string host)
+        {
+            Host = host;
+        }
+        
+        public string Host { get; }
+        public int Port { get; set; } = 10933;
+        public DiscoverableEndpointType? Type { get; set; }
+        public ProxyResource Proxy { get; set; }
+    }
+}

--- a/source/Octopus.Client/Repositories/Async/MachineRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MachineRepository.cs
@@ -10,6 +10,7 @@ namespace Octopus.Client.Repositories.Async
     public interface IMachineRepository : IFindByName<MachineResource>, IGet<MachineResource>, ICreate<MachineResource>, IModify<MachineResource>, IDelete<MachineResource>
     {
         Task<MachineResource> Discover(string host, int port = 10933, DiscoverableEndpointType? discoverableEndpointType = null);
+        Task<MachineResource> Discover(DiscoverMachineOptions options);
         Task<MachineConnectionStatus> GetConnectionStatus(MachineResource machine);
         Task<List<MachineResource>> FindByThumbprint(string thumbprint);
         Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine);
@@ -51,9 +52,20 @@ namespace Octopus.Client.Repositories.Async
         }
 
         public Task<MachineResource> Discover(string host, int port = 10933, DiscoverableEndpointType? type = null)
-        {
-            return Client.Get<MachineResource>(Client.RootDocument.Link("DiscoverMachine"), new { host, port, type });
-        }
+            => Discover(new DiscoverMachineOptions(host)
+            {
+                Port = port,
+                Type = type
+            });
+
+        public Task<MachineResource> Discover(DiscoverMachineOptions options)
+            => Client.Get<MachineResource>(Client.RootDocument.Link("DiscoverMachine"), new
+            {
+                host = options.Host,
+                port = options.Port,
+                type = options.Type,
+                proxyId = options.Proxy?.Id
+            });
 
         public Task<MachineConnectionStatus> GetConnectionStatus(MachineResource machine)
         {

--- a/source/Octopus.Client/Repositories/MachineRepository.cs
+++ b/source/Octopus.Client/Repositories/MachineRepository.cs
@@ -9,6 +9,7 @@ namespace Octopus.Client.Repositories
     public interface IMachineRepository : IFindByName<MachineResource>, IGet<MachineResource>, ICreate<MachineResource>, IModify<MachineResource>, IDelete<MachineResource>
     {
         MachineResource Discover(string host, int port = 10933, DiscoverableEndpointType? discoverableEndpointType = null);
+        MachineResource Discover(DiscoverMachineOptions options);
         MachineConnectionStatus GetConnectionStatus(MachineResource machine);
         List<MachineResource> FindByThumbprint(string thumbprint);
         IReadOnlyList<TaskResource> GetTasks(MachineResource machine);
@@ -51,9 +52,20 @@ namespace Octopus.Client.Repositories
         }
 
         public MachineResource Discover(string host, int port = 10933, DiscoverableEndpointType? type = null)
-        {
-            return Client.Get<MachineResource>(Client.RootDocument.Link("DiscoverMachine"), new { host, port, type });
-        }
+            => Discover(new DiscoverMachineOptions(host)
+            {
+                Port = port,
+                Type = type
+            });
+
+        public MachineResource Discover(DiscoverMachineOptions options)
+            => Client.Get<MachineResource>(Client.RootDocument.Link("DiscoverMachine"), new
+            {
+                host = options.Host,
+                port = options.Port,
+                type = options.Type,
+                proxyId = options.Proxy?.Id
+            });
 
         public MachineConnectionStatus GetConnectionStatus(MachineResource machine)
         {

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.24.0" />
+    <package id="Cake" version="0.24.2" />
 </packages>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.24.2" />
+    <package id="Cake" version="0.24.0" />
 </packages>


### PR DESCRIPTION
 Extra method added to avoid breaking API change, the Options object should ensure new parameters are easier to add. Fixes https://github.com/OctopusDeploy/OctopusClients/issues/244