### PR TITLE
Add netcore 2.0 portable rids for linux and mac

### DIFF
--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS</DefineConstants>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;linuxmint.17-x64;centos.7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;linuxmint.17-x64;centos.7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">


### PR DESCRIPTION
Added portable RID for [linux](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#linux-rids) and [mac](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#macos-rids)