### PR TITLE
octo.cmd for portable fails if executed from another directory

### DIFF
--- a/BuildAssets/Octo.cmd
+++ b/BuildAssets/Octo.cmd
@@ -1,1 +1,1 @@
-dotnet Octo.dll %*
+dotnet "%~dp0/Octo.dll" %*


### PR DESCRIPTION
This fixes a problem when trying to use the batch file from another folder. It will complain about not being able to find Octo.dll otherwise.