### PR TITLE
Spaces api update

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -25,7 +25,6 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task Delete(String, Object)
-    Task<IOctopusAsyncClient> ForGlobalContext()
     Task<IOctopusAsyncClient> ForSpaceContext(String)
     Task<TResource> Get(String, Object)
     Task<Stream> GetContent(String, Object)
@@ -114,7 +113,6 @@ Octopus.Client
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task Delete(String, Object)
     void Dispose()
-    Task<IOctopusAsyncClient> ForGlobalContext()
     Task<IOctopusAsyncClient> ForSpaceContext(String)
     Task<TResource> Get(String, Object)
     Task<Stream> GetContent(String, Object)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -32,7 +32,6 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task Delete(String, Object)
-    Task<IOctopusAsyncClient> ForGlobalContext()
     Task<IOctopusAsyncClient> ForSpaceContext(String)
     Task<TResource> Get(String, Object)
     Task<Stream> GetContent(String, Object)
@@ -111,7 +110,6 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
-    Octopus.Client.IOctopusClient ForGlobalContext()
     Octopus.Client.IOctopusClient ForSpaceContext(String)
     Octopus.Client.TResource Get(String, Object)
     Stream GetContent(String, Object)
@@ -201,7 +199,6 @@ Octopus.Client
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task Delete(String, Object)
     void Dispose()
-    Task<IOctopusAsyncClient> ForGlobalContext()
     Task<IOctopusAsyncClient> ForSpaceContext(String)
     Task<TResource> Get(String, Object)
     Task<Stream> GetContent(String, Object)
@@ -289,7 +286,6 @@ Octopus.Client
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
     void Dispose()
-    Octopus.Client.IOctopusClient ForGlobalContext()
     Octopus.Client.IOctopusClient ForSpaceContext(String)
     Octopus.Client.TResource Get(String, Object)
     Stream GetContent(String, Object)

--- a/source/Octopus.Client/IOctopusAsyncClient.cs
+++ b/source/Octopus.Client/IOctopusAsyncClient.cs
@@ -346,11 +346,5 @@ namespace Octopus.Client
         /// <param name="spaceId">The ID of the space.</param>
         /// <returns>An instance of IOctopusClient</returns>
         Task<IOctopusAsyncClient> ForSpaceContext(string spaceId);
-
-        /// <summary>
-        /// Requests an IOctopusAsyncClient which will operate within the global context.
-        /// </summary>
-        /// <returns>An instance of IOctopusClient</returns>
-        Task<IOctopusAsyncClient> ForGlobalContext();
     }
 }

--- a/source/Octopus.Client/IOctopusClient.cs
+++ b/source/Octopus.Client/IOctopusClient.cs
@@ -330,12 +330,6 @@ namespace Octopus.Client
         /// <param name="spaceId">The ID of the space.</param>
         /// <returns>An instance of IOctopusClient</returns>
         IOctopusClient ForSpaceContext(string spaceId);
-
-        /// <summary>
-        /// Requests an IOctopusClient which will operate within the global context.
-        /// </summary>
-        /// <returns>An instance of IOctopusClient</returns>
-        IOctopusClient ForGlobalContext();
     }
 }
 #endif

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -181,11 +181,6 @@ Certificate thumbprint:   {certificate.Thumbprint}";
             return await Create(this.serverEndpoint, newOptions);
         }
 
-        public async Task<IOctopusAsyncClient> ForGlobalContext()
-        {
-            return await ForSpaceContext("global");
-        }
-
         /// <summary>
         /// Occurs when a request is about to be sent.
         /// </summary>

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -94,11 +94,6 @@ namespace Octopus.Client
             return new OctopusClient(this.serverEndpoint, spaceId);
         }
 
-        public IOctopusClient ForGlobalContext()
-        {
-            return new OctopusClient(this.serverEndpoint, "global");
-        }
-
         /// <summary>
         /// Occurs when a request is about to be sent.
         /// </summary>


### PR DESCRIPTION
## Remove ForGlobalContext

As we no longer have the route of `api/global/MixScopedThing`, post/put request should be based on the `SpaceId` inside the resource, `ForGlobalContext` is no longer needed. We can update this one and start changing codes in Octopus server project