### PR TITLE
Revert "Add heartbeat policy to nodes"

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1913,11 +1913,6 @@ Octopus.Client.Model
       FullHealthCheck = 0
       ConnectionTest = 1
   }
-  HeartbeatDeletionPolicy
-  {
-      NeverDelete = 0
-      DeleteAfterOfflineTimeout = 1
-  }
   interface IAuditedResource
   {
     String LastModifiedBy { get; set; }
@@ -2317,18 +2312,6 @@ Octopus.Client.Model
     .ctor()
     Octopus.Client.Model.FeedType FeedType { get; }
   }
-  class OctopusServerNodeHeartbeatPolicy
-  {
-    static System.TimeSpan DefaultOfflineTimeout
-    .ctor()
-    Octopus.Client.Model.HeartbeatDeletionPolicy DeletionPolicy { get; set; }
-    TimeSpan OfflineTimeout { get; set; }
-    HeartbeatDeletionPolicy
-    {
-        NeverDelete = 0
-        DeleteAfterOfflineTimeout = 1
-    }
-  }
   class OctopusServerNodeResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -2336,7 +2319,6 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    Octopus.Client.Model.OctopusServerNodeHeartbeatPolicy HeartbeatPolicy { get; set; }
     Boolean IsInMaintenanceMode { get; set; }
     Boolean IsOffline { get; set; }
     String LastSeen { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2408,11 +2408,6 @@ Octopus.Client.Model
       FullHealthCheck = 0
       ConnectionTest = 1
   }
-  HeartbeatDeletionPolicy
-  {
-      NeverDelete = 0
-      DeleteAfterOfflineTimeout = 1
-  }
   interface IAuditedResource
   {
     String LastModifiedBy { get; set; }
@@ -2815,18 +2810,6 @@ Octopus.Client.Model
     .ctor()
     Octopus.Client.Model.FeedType FeedType { get; }
   }
-  class OctopusServerNodeHeartbeatPolicy
-  {
-    static System.TimeSpan DefaultOfflineTimeout
-    .ctor()
-    Octopus.Client.Model.HeartbeatDeletionPolicy DeletionPolicy { get; set; }
-    TimeSpan OfflineTimeout { get; set; }
-    HeartbeatDeletionPolicy
-    {
-        NeverDelete = 0
-        DeleteAfterOfflineTimeout = 1
-    }
-  }
   class OctopusServerNodeResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -2834,7 +2817,6 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    Octopus.Client.Model.OctopusServerNodeHeartbeatPolicy HeartbeatPolicy { get; set; }
     Boolean IsInMaintenanceMode { get; set; }
     Boolean IsOffline { get; set; }
     String LastSeen { get; set; }

--- a/source/Octopus.Client/Model/OctopusServerNodeResource.cs
+++ b/source/Octopus.Client/Model/OctopusServerNodeResource.cs
@@ -4,20 +4,6 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model
 {
-    public class OctopusServerNodeHeartbeatPolicy
-    {
-        public static TimeSpan DefaultOfflineTimeout = TimeSpan.FromMinutes(30);
-
-        public enum HeartbeatDeletionPolicy
-        {
-            NeverDelete,
-            DeleteAfterOfflineTimeout
-        }
-
-        public HeartbeatDeletionPolicy DeletionPolicy { get; set; } = HeartbeatDeletionPolicy.NeverDelete;
-        public TimeSpan OfflineTimeout { get; set; } = DefaultOfflineTimeout;
-    }
-
     public class OctopusServerNodeResource : Resource, INamedResource
     {
         public string Name { get; set; }
@@ -28,7 +14,5 @@ namespace Octopus.Client.Model
         public int MaxConcurrentTasks { get; set; }
         [Writeable]
         public bool IsInMaintenanceMode { get; set; }
-        [Writeable]
-        public OctopusServerNodeHeartbeatPolicy HeartbeatPolicy { get; set; }
     }
 }


### PR DESCRIPTION
Transient nodes are not going to be a thing anymore.

This reverts commit 4d61eb4505ea1ceb8410d88ec7996a6152517a01.