### PR TITLE
Fix a small bug with the OctopusRepository.HasLink method where it wo…

### DIFF
--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -210,7 +210,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
 
         public bool HasLink(string name)
         {
-            return SpaceRootDocument?.HasLink(name) ?? RootDocument.HasLink(name);
+            return SpaceRootDocument != null && SpaceRootDocument.HasLink(name) || RootDocument.HasLink(name);
         }
         
         public string Link(string name)

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -110,7 +110,7 @@ namespace Octopus.Client
 
         public bool HasLink(string name)
         {
-            return SpaceRootDocument?.HasLink(name) ?? RootDocument.HasLink(name);
+            return SpaceRootDocument != null && SpaceRootDocument.HasLink(name) || RootDocument.HasLink(name);
         }
 
         public string Link(string name)


### PR DESCRIPTION
…uld return false if the SpaceRootDocument did not contain the link, even if the RootDocument did.