### PR TITLE
Remove IncludeEventsFromSpaces

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3293,7 +3293,6 @@ Octopus.Client.Model
   {
     .ctor()
     Octopus.Client.Model.EventNotificationSubscription EventNotificationSubscription { get; set; }
-    Boolean IncludeEventsFromSpaces { get; set; }
     Boolean IsDisabled { get; set; }
     String Name { get; set; }
     String SpaceId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3810,7 +3810,6 @@ Octopus.Client.Model
   {
     .ctor()
     Octopus.Client.Model.EventNotificationSubscription EventNotificationSubscription { get; set; }
-    Boolean IncludeEventsFromSpaces { get; set; }
     Boolean IsDisabled { get; set; }
     String Name { get; set; }
     String SpaceId { get; set; }

--- a/source/Octopus.Client/Model/SubscriptionResource.cs
+++ b/source/Octopus.Client/Model/SubscriptionResource.cs
@@ -23,8 +23,5 @@ namespace Octopus.Client.Model
         public EventNotificationSubscription EventNotificationSubscription { get; set; }
 
         public string SpaceId { get; set; }
-
-        [Writeable]
-        public bool IncludeEventsFromSpaces { get; set; }
     }
 }


### PR DESCRIPTION
Removes IncludeEventsFromSpaces - no longer considered necessary to support spaces.

Related to https://github.com/OctopusDeploy/OctopusDeploy/pull/2851