### PR TITLE
Make the client work with ALL THE SERVERS

### DIFF
--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -97,6 +97,13 @@ namespace Octopus.Client
         {
             if (this.SpaceContext == null)
             {
+                // This check will allow Spaces aware Client to work with a pre-Spaces Server. 
+                if (!rootDocument.HasLink("Spaces"))
+                {
+                    SpaceContext = SpaceContext.SystemOnly();
+                    return null;
+                }
+
                 var defaultSpace = GetDefaultSpace(rootDocument);
                 SpaceContext = defaultSpace == null ? SpaceContext.SystemOnly() : SpaceContext.SpecificSpaceAndSystem(defaultSpace.Id);
             }


### PR DESCRIPTION
I would not call it a supported feature but it might give some of our biggest clients time to migrate all of their Octopus Servers to Spaces without having to use different version of the client with different versions of the server.