### PR TITLE
Make new project cloneId optional to make it backwards compatible again

### DIFF
--- a/source/Octopus.Client/Editors/Async/ProjectEditor.cs
+++ b/source/Octopus.Client/Editors/Async/ProjectEditor.cs
@@ -65,7 +65,7 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId)
+        public async Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null)
         {
             var existing = await repository.FindByName(name).ConfigureAwait(false);
 

--- a/source/Octopus.Client/Editors/ProjectEditor.cs
+++ b/source/Octopus.Client/Editors/ProjectEditor.cs
@@ -65,7 +65,7 @@ namespace Octopus.Client.Editors
             return this;
         }
 
-        public ProjectEditor CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId)
+        public ProjectEditor CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null)
         {
             var existing = repository.FindByName(name);
 

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -17,7 +17,7 @@ namespace Octopus.Client.Repositories.Async
         Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(ProjectResource project);
         Task SetLogo(ProjectResource project, string fileName, Stream contents);
         Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle);
-        Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId);
+        Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null);
     }
 
     class ProjectRepository : BasicRepository<ProjectResource>, IProjectRepository
@@ -67,7 +67,7 @@ namespace Octopus.Client.Repositories.Async
             return new ProjectEditor(this, new ChannelRepository(Client), new DeploymentProcessRepository(Client), new ProjectTriggerRepository(Client), new VariableSetRepository(Client)).CreateOrModify(name, projectGroup, lifecycle);
         }
 
-        public Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId)
+        public Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null)
         {
             return new ProjectEditor(this, new ChannelRepository(Client), new DeploymentProcessRepository(Client), new ProjectTriggerRepository(Client), new VariableSetRepository(Client)).CreateOrModify(name, projectGroup, lifecycle, description, cloneId);
         }

--- a/source/Octopus.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectRepository.cs
@@ -17,7 +17,7 @@ namespace Octopus.Client.Repositories
         IReadOnlyList<ProjectTriggerResource> GetAllTriggers(ProjectResource project);
         void SetLogo(ProjectResource project, string fileName, Stream contents);
         ProjectEditor CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle);
-        ProjectEditor CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId);
+        ProjectEditor CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null);
     }
     
     class ProjectRepository : BasicRepository<ProjectResource>, IProjectRepository
@@ -77,7 +77,7 @@ namespace Octopus.Client.Repositories
             return new ProjectEditor(this, new ChannelRepository(Client), new DeploymentProcessRepository(Client), new ProjectTriggerRepository(Client), new VariableSetRepository(Client)).CreateOrModify(name, projectGroup, lifecycle);
         }
 
-        public ProjectEditor CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId)
+        public ProjectEditor CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null)
         {
             return new ProjectEditor(this, new ChannelRepository(Client), new DeploymentProcessRepository(Client), new ProjectTriggerRepository(Client), new VariableSetRepository(Client)).CreateOrModify(name, projectGroup, lifecycle, description, cloneId);
         }


### PR DESCRIPTION
Relates to: https://github.com/OctopusDeploy/Issues/issues/4960
Source https://help.octopus.com/t/octopus-client-4-41-2-breaking-change/21440