### PR TITLE
Add support for "octopack" file

### DIFF
--- a/source/Octo.Tests/Integration/PackTests.cs
+++ b/source/Octo.Tests/Integration/PackTests.cs
@@ -84,6 +84,81 @@ namespace Octopus.Cli.Tests.Integration
             }
         }
 
+        [Test]
+        [TestCase("nupkg", null, Description = "Should calculate a default version from the date")]
+        [TestCase("zip", null, Description = "Should calculate a default version from the date")]
+        [TestCase("nupkg", "1.0.0.0", Description = "NuGet should retain four-part versions")]
+        [TestCase("nupkg", "2016.02.01.09", Description = "NuGet should retain four-part versions with leading zeros")]
+        [TestCase("zip", "1.0.0.0", Description = "Zip should retain four-part versions")]
+        [TestCase("zip", "2016.02.01.09", Description = "Zip should retain four-part versions with leading zeros")]
+        public void ExecutePackFile(string format, string version)
+        {
+            var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            try
+            {
+                var rootDirectory = Directory.CreateDirectory(tempFolder);
+                var inputDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory.FullName, "input"));
+                var packagedDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory.FullName, "packaged"));
+                var extractedDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory.FullName, "extracted"));
+                var octoPackFilePath = Path.Combine(rootDirectory.FullName, "TestPackage.octoPack");
+                File.WriteAllText(Path.Combine(inputDirectory.FullName, "Test.txt"), "Test");
+                File.WriteAllText(Path.Combine(inputDirectory.FullName, "Test[squarebrackets].txt"), "Test");
+
+                var octoPackFile = new List<string>
+                {
+                    "id TestPackage"
+                };
+
+                if (!string.IsNullOrWhiteSpace(version))
+                {
+                    octoPackFile.Add($"version {version}");
+                }
+
+                File.WriteAllLines(octoPackFilePath, octoPackFile);
+
+                var args = new List<string>
+                {
+                    "pack",
+                    $"--octoPackFile={octoPackFilePath}",
+                    $"--basePath={inputDirectory.FullName}",
+                    $"--outFolder={packagedDirectory.FullName}",
+                    $"--format={format}"
+                };
+
+                var now = DateTime.Now;
+                var result = new CliProgram().Run(args.ToArray());
+
+                result.Should().Be(0);
+
+                if (!string.IsNullOrWhiteSpace(version))
+                {
+                    var expectedOutputFilePath = Path.Combine(packagedDirectory.FullName, $"TestPackage.{version}.{format}");
+                    File.Exists(expectedOutputFilePath)
+                        .Should()
+                        .BeTrue("the package should have been given the right name.");
+                }
+                else
+                {
+                    var searchPattern = $"TestPackage.{now.Year}.{now.Month}.{now.Day}.*.{format}";
+                    var files = Directory.GetFiles(packagedDirectory.FullName, searchPattern, SearchOption.TopDirectoryOnly);
+                    files.Should().HaveCount(1, "There should be a package where the version is calculated from the date");
+                }
+
+                // TODO: It would be really nice to have a simple end-to-end test that proves we can pack/unpack files preserving filenames and timestamps etc...
+                //var calamariResult = SilentProcessRunner.ExecuteCommand(@"C:\dev\Calamari\source\Calamari\bin\Debug\netcoreapp1.0\win7-x64\Calamari.exe",
+                //    $"extract-package --package={expectedOutputFilePath} --target={extractedDirectory.FullName}", rootDirectory.FullName, Console.WriteLine, Console.WriteLine);
+                //calamariResult.Should().Be(0);
+
+                //var extractedFiles = Directory.GetFiles(extractedDirectory.FullName, "*", SearchOption.AllDirectories).Select(x => x.Replace(extractedDirectory.FullName, ""));
+                //var inputFiles = Directory.GetFiles(inputDirectory.FullName, "*", SearchOption.AllDirectories).Select(x => x.Replace(inputDirectory.FullName, ""));
+                //extractedFiles.ShouldAllBeEquivalentTo(inputFiles);
+            }
+            finally
+            {
+                Directory.Delete(tempFolder, true);
+            }
+        }
+
         [TestCase("nupkg", "2016.02.01.09", Description = "NuGet should retain modified date")]
         [TestCase("zip", "2016.02.01.09", Description = "Zip should retain modified date")]
         public void CheckModifiedDate(string format, string version)

--- a/source/Octo.Tests/Integration/PackTests.cs
+++ b/source/Octo.Tests/Integration/PackTests.cs
@@ -24,12 +24,12 @@ namespace Octopus.Cli.Tests.Integration
         [TestCase("nupkg", "2016.02.01.09", false, Description = "NuGet should retain four-part versions with leading zeros")]
         [TestCase("zip", "1.0.0.0", false, Description = "Zip should retain four-part versions")]
         [TestCase("zip", "2016.02.01.09", false, Description = "Zip should retain four-part versions with leading zeros")]
-        [TestCase("nupkg", null, true, Description = "Should calculate a default version from the date")]
-        [TestCase("zip", null, true, Description = "Should calculate a default version from the date")]
-        [TestCase("nupkg", "1.0.0.0", true, Description = "NuGet should retain four-part versions")]
-        [TestCase("nupkg", "2016.02.01.09", true, Description = "NuGet should retain four-part versions with leading zeros")]
-        [TestCase("zip", "1.0.0.0", true, Description = "Zip should retain four-part versions")]
-        [TestCase("zip", "2016.02.01.09", true, Description = "Zip should retain four-part versions with leading zeros")]
+        [TestCase("nupkg", null, true, Description = "Should calculate a default version from the date using octopack file")]
+        [TestCase("zip", null, true, Description = "Should calculate a default version from the date using octopack file")]
+        [TestCase("nupkg", "1.0.0.0", true, Description = "NuGet should retain four-part versions using octopack file")]
+        [TestCase("nupkg", "2016.02.01.09", true, Description = "NuGet should retain four-part versions with leading zeros using octopack file")]
+        [TestCase("zip", "1.0.0.0", true, Description = "Zip should retain four-part versions using octopack file")]
+        [TestCase("zip", "2016.02.01.09", true, Description = "Zip should retain four-part versions with leading zeros using octopack file")]
         public void Execute(string format, string version, bool asOctoPackFile)
         {
             var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/source/Octopus.Cli/Commands/Package/PackCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PackCommand.cs
@@ -48,7 +48,7 @@ namespace Octopus.Cli.Commands.Package
             nuget.Add("releaseNotesFile=", "[Optional] A file containing release notes for this version of the package", v => releaseNotesFile = v);
             
             var basic = Options.For("Basic options");
-            basic.Add("id=", "[Optional if --file used] The ID of the package; e.g. MyCompany.MyApp", v => id = v);
+            basic.Add("id=", "[Optional if --octoPackFile used] The ID of the package; e.g. MyCompany.MyApp", v => id = v);
             basic.Add("octoPackFile=", "[Optional] The path to a .octopack file", v => octoPackFile = v);
             basic.Add("format=", "[Optional] Package format. Options are: NuPkg, Zip. Defaults to NuPkg, though we recommend Zip going forward", fmt => packageBuilder = SelectFormat(fmt));
             basic.Add("version=", "[Optional] The version of the package; must be a valid SemVer; defaults to a timestamp-based version", v => version = string.IsNullOrWhiteSpace(v) ? null : new SemanticVersion(v));
@@ -93,6 +93,12 @@ namespace Octopus.Cli.Commands.Package
                     foreach (var octoPackFileLine in octoPackFileLines)
                     {
                         var arg = octoPackFileLine.Split(new[] { ' ' }, 2);
+
+                        if (arg.Length < 2 || string.IsNullOrWhiteSpace(arg[0]) || string.IsNullOrWhiteSpace(arg[1]))
+                        {
+                            throw new CommandException($"octoPackFile line {octoPackFileLine} in file {octoPackFile} is not valid");
+                        }
+
                         switch (arg[0].ToLower())
                         {
                             case "id" when string.IsNullOrWhiteSpace(id):


### PR DESCRIPTION
An octopack contains various command line arguments and means you can
store the structure of your octopus package in a repo rather than as a
set of command line arguments
The format of this is similar to a paket.template file

Update existing pack tests to include tests for octopack files