### PR TITLE
Bug clihelp

### DIFF
--- a/source/Octopus.Cli/CliProgram.cs
+++ b/source/Octopus.Cli/CliProgram.cs
@@ -152,7 +152,7 @@ namespace Octopus.Cli
                 Log.Error(ex.Message);
                 if (LogExtensions.IsKnownEnvironment())
                 {
-                    Log.Error("This error is most likely ocurring while executing Octo.exe as part of an automated build process. The following doc is recommended to get some tips on how to troubleshoot this: https://g.octopushq.com/OctoexeTroubleshooting");
+                    Log.Error("This error is most likely occurring while executing Octo.exe as part of an automated build process. The following doc is recommended to get some tips on how to troubleshoot this: https://g.octopushq.com/OctoexeTroubleshooting");
                 }
                 return -1;
             }
@@ -173,7 +173,7 @@ namespace Octopus.Cli
             if (octo != null)
             {
                 Log.Information("{HttpErrorMessage:l}", octo.Message);
-                Log.Error("Error from Octopus server (HTTP {StatusCode} {StatusDescription})", octo.HttpStatusCode, (HttpStatusCode) octo.HttpStatusCode);
+                Log.Error("Error from Octopus Server (HTTP {StatusCode} {StatusDescription})", octo.HttpStatusCode, (HttpStatusCode) octo.HttpStatusCode);
                 return -7;
             }
 

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands
     public abstract class ApiCommand : CommandBase, ICommand
     {
         /// <summary>
-        /// The environment variable that can hold the Octopus server
+        /// The environment variable that can hold the Octopus Server
         /// </summary>
         public const string ServerUrlEnvVar = "OCTOPUS_CLI_SERVER";
         /// <summary>
@@ -55,14 +55,14 @@ namespace Octopus.Cli.Commands
             this.FileSystem = fileSystem;
 
             var options = Options.For("Common options");
-            options.Add("server=", $"[Optional] The base URL for your Octopus server - e.g., http://your-octopus/. This URL can also be set in the {ServerUrlEnvVar} environment variable.", v => serverBaseUrl = v);
+            options.Add("server=", $"[Optional] The base URL for your Octopus Server - e.g., http://your-octopus/. This URL can also be set in the {ServerUrlEnvVar} environment variable.", v => serverBaseUrl = v);
             options.Add("apiKey=", $"[Optional] Your API key. Get this from the user profile page. Your must provide an apiKey or username and password. If the guest account is enabled, a key of API-GUEST can be used. This key can also be set in the {ApiKeyEnvVar} environment variable.", v => apiKey = v);
             options.Add("user=", $"[Optional] Username to use when authenticating with the server. Your must provide an apiKey or username and password. This Username can also be set in the {UsernameEnvVar} environment variable.", v => username = v);
             options.Add("pass=", $"[Optional] Password to use when authenticating with the server. This Password can also be set in the {PasswordEnvVar} environment variable.", v => password = v);
             
             options.Add("configFile=", "[Optional] Text file of default values, with one 'key = value' per line.", v => ReadAdditionalInputsFromConfigurationFile(v));
             options.Add("debug", "[Optional] Enable debug logging", v => enableDebugging = true);
-            options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
+            options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus Server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
             options.Add("enableServiceMessages", "[Optional] Enable TeamCity or Team Foundation Build service messages when logging.", v => commandOutputProvider.EnableServiceMessages());
             options.Add("timeout=", $"[Optional] Timeout in seconds for network operations. Default is {ApiConstants.DefaultClientRequestTimeout/1000}.", v => clientOptions.Timeout = TimeSpan.FromSeconds(int.Parse(v)));
             options.Add("proxy=", $"[Optional] The URI of the proxy to use, eg http://example.com:8080.", v => clientOptions.Proxy = v);
@@ -146,7 +146,7 @@ namespace Octopus.Cli.Commands
                 Repository.Client.SendingOctopusRequest += request => commandOutputProvider.Debug("{Method:l} {Uri:l}", request.Method, request.Uri);
             }
 
-            commandOutputProvider.Debug("Handshaking with Octopus server: {Url:l}", ServerBaseUrl);
+            commandOutputProvider.Debug("Handshaking with Octopus Server: {Url:l}", ServerBaseUrl);
 
             var root = Repository.Client.RootDocument;
 

--- a/source/Octopus.Cli/Commands/Channel/CreateChannelCommand.cs
+++ b/source/Octopus.Cli/Commands/Channel/CreateChannelCommand.cs
@@ -39,7 +39,7 @@ namespace Octopus.Cli.Commands.Channel
 
         public async Task Request()
         {
-            if (!Repository.SupportsChannels()) throw new CommandException("Your Octopus server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus server to start using channels.");
+            if (!Repository.SupportsChannels()) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server to start using channels.");
             if (string.IsNullOrWhiteSpace(projectName)) throw new CommandException("Please specify a project using the parameter: --project=ProjectXYZ");
             if (string.IsNullOrWhiteSpace(channelName)) throw new CommandException("Please specify a channel name using the parameter: --channel=ChannelXYZ");
 

--- a/source/Octopus.Cli/Commands/CommandBase.cs
+++ b/source/Octopus.Cli/Commands/CommandBase.cs
@@ -87,7 +87,6 @@ namespace Octopus.Cli.Commands
         {
             commandOutputProvider.PrintCommandHelpHeader(executable, commandName, writer);
             commandOutputProvider.PrintCommandOptions(Options, writer);
-            commandOutputProvider.PrintCommandHelpFooter(executable, commandName, writer);
         }
 
         private void PrintJsonHelpOutput(string commandName)

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands.Deployment
         {
             var options = Options.For("Deployment");
             options.Add("project=", "Name of the project", v => ProjectName = v);
-            options.Add("deployto=", "Environment to deploy to, e.g., Production", v => DeployToEnvironmentNames.Add(v));
+            options.Add("deployto=", "Environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Channel to use when getting the release to deploy", v => ChannelName = v);
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -37,7 +37,7 @@ namespace Octopus.Cli.Commands.Deployment
         {
             if (DeployToEnvironmentNames.Count == 0) throw new CommandException("Please specify an environment using the parameter: --deployto=XYZ");
             if (string.IsNullOrWhiteSpace(VersionNumber)) throw new CommandException("Please specify a release version using the parameter: --version=1.0.0.0 or --version=latest for the latest release");
-            if (!string.IsNullOrWhiteSpace(ChannelName) && !Repository.SupportsChannels()) throw new CommandException("Your Octopus server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus server, or remove the --channel argument.");
+            if (!string.IsNullOrWhiteSpace(ChannelName) && !Repository.SupportsChannels()) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel argument.");
 
             base.ValidateParameters();
         }

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -80,7 +80,7 @@ namespace Octopus.Cli.Commands.Deployment
             if (Tenants.Contains("*") && (Tenants.Count > 1 || TenantTags.Count > 0)) throw new CommandException("When deploying to all tenants using --tenant=* wildcard no other tenant filters can be provided");
 
             if (IsTenantedDeployment && !Repository.SupportsTenants())
-                throw new CommandException("Your Octopus server does not support tenants, which was introduced in Octopus 3.4. Please upgrade your Octopus server, enable the multi-tenancy feature or remove the --tenant and --tenanttag arguments.");
+                throw new CommandException("Your Octopus Server does not support tenants, which was introduced in Octopus 3.4. Please upgrade your Octopus Server, enable the multi-tenancy feature or remove the --tenant and --tenanttag arguments.");
 
             base.ValidateParameters();
         }
@@ -236,7 +236,7 @@ namespace Octopus.Cli.Commands.Deployment
 
                     if (missing.Any())
                         throw new ArgumentException(
-                            $"Could not find the {"tenant" + (missing.Length == 1 ? "" : "s")} {string.Join(", ", missing)} on the Octopus server.");
+                            $"Could not find the {"tenant" + (missing.Length == 1 ? "" : "s")} {string.Join(", ", missing)} on the Octopus Server.");
 
                     deployableTenants.AddRange(tenantsByName);
                     deployableTenants.AddRange(tenantsById);

--- a/source/Octopus.Cli/Commands/Package/PushCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushCommand.cs
@@ -12,7 +12,7 @@ using Serilog;
 
 namespace Octopus.Cli.Commands.Package
 {
-    [Command("push", Description = "Pushes a package (.nupkg, .zip, .tar.gz, etc.) package to the built-in NuGet repository in an Octopus server.")]
+    [Command("push", Description = "Pushes a package (.nupkg, .zip, .tar.gz, etc.) package to the built-in NuGet repository in an Octopus Server.")]
     public class PushCommand : ApiCommand, ISupportFormattedOutput
     {
         private List<string> pushedPackages;

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -60,7 +60,7 @@ namespace Octopus.Cli.Commands.Releases
         protected override void ValidateParameters()
         {
             if (!string.IsNullOrWhiteSpace(ChannelName) && !Repository.SupportsChannels())
-                throw new CommandException("Your Octopus server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus server, or remove the --channel argument.");
+                throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel argument.");
 
             base.ValidateParameters();
         }

--- a/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
@@ -39,7 +39,7 @@ namespace Octopus.Cli.Commands.Releases
 
         public async Task Request()
         {
-            if (ChannelNames.Any() && !Repository.SupportsChannels()) throw new CommandException("Your Octopus server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus server, or remove the --channel arguments.");
+            if (ChannelNames.Any() && !Repository.SupportsChannels()) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel arguments.");
             if (string.IsNullOrWhiteSpace(ProjectName)) throw new CommandException("Please specify a project name using the parameter: --project=XYZ");
             if (string.IsNullOrWhiteSpace(MinVersion)) throw new CommandException("Please specify a minimum version number using the parameter: --minversion=X.Y.Z");
             if (string.IsNullOrWhiteSpace(MaxVersion)) throw new CommandException("Please specify a maximum version number using the parameter: --maxversion=X.Y.Z");

--- a/source/Octopus.Cli/Commands/VersionCommand.cs
+++ b/source/Octopus.Cli/Commands/VersionCommand.cs
@@ -14,9 +14,14 @@ namespace Octopus.Cli.Commands
 
         public Task Execute(string[] commandLineArgs)
         {
-            return Task.Run(() => 
+            return Task.Run(() =>
             {
-                Console.WriteLine($"{typeof(CliProgram).GetInformationalVersion()}");
+                Options.Parse(commandLineArgs);
+
+                if (printHelp)
+                    GetHelp(Console.Out, commandLineArgs);
+                else
+                    Console.WriteLine($"{typeof(CliProgram).GetInformationalVersion()}");
             });
         }
 

--- a/source/Octopus.Cli/Repositories/OctopusRepositoryCommonQueries.cs
+++ b/source/Octopus.Cli/Repositories/OctopusRepositoryCommonQueries.cs
@@ -100,7 +100,7 @@ namespace Octopus.Cli.Repositories
             if (!repository.SupportsTenants())
             {
                 throw new CommandException(
-                    "Your Octopus server does not support tenants, which was introduced in Octopus 3.4. Please upgrade your Octopus server, enable the multi-tenancy feature or remove the --tenant and --tenanttag arguments.");
+                    "Your Octopus Server does not support tenants, which was introduced in Octopus 3.4. Please upgrade your Octopus Server, enable the multi-tenancy feature or remove the --tenant and --tenanttag arguments.");
             }
 
             var tenantsByName = FindTenantsByName(tenantNames).ConfigureAwait(false);
@@ -140,7 +140,7 @@ namespace Octopus.Cli.Repositories
 
             if (missing.Any())
             {
-                throw new ArgumentException($"Could not find the {"tenant" + (missing.Length == 1 ? "" : "s")} {string.Join(", ", missing)} on the Octopus server.");
+                throw new ArgumentException($"Could not find the {"tenant" + (missing.Length == 1 ? "" : "s")} {string.Join(", ", missing)} on the Octopus Server.");
             }
 
             var allTenants = Enumerable.Empty<TenantResource>();

--- a/source/Octopus.Cli/Util/CommandOutputProvider.cs
+++ b/source/Octopus.Cli/Util/CommandOutputProvider.cs
@@ -47,19 +47,6 @@ namespace Octopus.Cli.Util
             }
         }
 
-        public void PrintCommandHelpFooter(string executable, string commandName, TextWriter textWriter)
-        {
-            if (PrintMessages)
-            {
-                textWriter.WriteLine();
-                textWriter.Write("Or use ");
-                Console.ForegroundColor = ConsoleColor.White;
-                textWriter.Write(executable + " help <command>");
-                Console.ResetColor();
-                textWriter.WriteLine(" for more details.");
-            }
-        }
-
         public void PrintCommandOptions(Options options, TextWriter writer)
         {
             if (PrintMessages)

--- a/source/Octopus.Cli/Util/ICommandOutputProvider.cs
+++ b/source/Octopus.Cli/Util/ICommandOutputProvider.cs
@@ -16,8 +16,6 @@ namespace Octopus.Cli.Util
 
         void PrintCommandOptions(Options options, TextWriter textWriter);
 
-        void PrintCommandHelpFooter(string executable, string commandName, TextWriter textWriter);
-
         void Debug(string template, string propertyValue);
 
         void Debug(string template, params object[] propertyValues);

--- a/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
@@ -53,7 +53,7 @@ namespace Octopus.Client.Tests.Operations
         {
             operation.EnvironmentNames = new[] {"Atlantis"};
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.ShouldThrow<ArgumentException>().WithMessage("Could not find the environment named Atlantis on the Octopus server. Ensure the environment exists and you have permission to access it.");
+            exec.ShouldThrow<ArgumentException>().WithMessage("Could not find the environment named Atlantis on the Octopus Server. Ensure the environment exists and you have permission to access it.");
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace Octopus.Client.Tests.Operations
 
             operation.EnvironmentNames = new[] {"Production", "Atlantis", "Hyperborea"};
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.ShouldThrow<ArgumentException>().WithMessage("Could not find the environments named: Atlantis, Hyperborea on the Octopus server. Ensure the environments exist and you have permission to access them.");
+            exec.ShouldThrow<ArgumentException>().WithMessage("Could not find the environments named: Atlantis, Hyperborea on the Octopus Server. Ensure the environments exist and you have permission to access them.");
         }
 
         [Test]

--- a/source/Octopus.Client/IOctopusAsyncClient.cs
+++ b/source/Octopus.Client/IOctopusAsyncClient.cs
@@ -14,7 +14,7 @@ namespace Octopus.Client
     public interface IOctopusAsyncClient : IDisposable
     {
         /// <summary>
-        /// Gets a document that identifies the Octopus server (from /api) and provides links to the resources available on the
+        /// Gets a document that identifies the Octopus Server (from /api) and provides links to the resources available on the
         /// server. Instead of hardcoding paths,
         /// clients should use these link properties to traverse the resources on the server. This document is lazily loaded so
         /// that it is only requested once for
@@ -38,7 +38,7 @@ namespace Octopus.Client
         event Action<OctopusRequest> SendingOctopusRequest;
 
         /// <summary>
-        /// Occurs when a response is received from the Octopus server.
+        /// Occurs when a response is received from the Octopus Server.
         /// </summary>
         event Action<OctopusResponse> ReceivedOctopusResponse;
 
@@ -289,7 +289,7 @@ namespace Octopus.Client
         /// <summary>
         /// Deletes the resource at the given URI from the server using a the DELETE verb. Deletes in Octopus happen
         /// asynchronously via a background task
-        /// that is executed by the Octopus server. The payload returned by delete will be the task that was created on the
+        /// that is executed by the Octopus Server. The payload returned by delete will be the task that was created on the
         /// server.
         /// </summary>
         /// <exception cref="OctopusSecurityException">

--- a/source/Octopus.Client/IOctopusClient.cs
+++ b/source/Octopus.Client/IOctopusClient.cs
@@ -13,7 +13,7 @@ namespace Octopus.Client
     public interface IOctopusClient : IDisposable
     {
         /// <summary>
-        /// Gets a document that identifies the Octopus server (from /api) and provides links to the resources available on the
+        /// Gets a document that identifies the Octopus Server (from /api) and provides links to the resources available on the
         /// server. Instead of hardcoding paths,
         /// clients should use these link properties to traverse the resources on the server. This document is lazily loaded so
         /// that it is only requested once for
@@ -42,7 +42,7 @@ namespace Octopus.Client
         event Action<OctopusRequest> SendingOctopusRequest;
 
         /// <summary>
-        /// Occurs when a response is received from the Octopus server.
+        /// Occurs when a response is received from the Octopus Server.
         /// </summary>
         event Action<OctopusResponse> ReceivedOctopusResponse;
 
@@ -273,7 +273,7 @@ namespace Octopus.Client
         /// <summary>
         /// Deletes the resource at the given URI from the server using a the DELETE verb. Deletes in Octopus happen
         /// asynchronously via a background task
-        /// that is executed by the Octopus server. The payload returned by delete will be the task that was created on the
+        /// that is executed by the Octopus Server. The payload returned by delete will be the task that was created on the
         /// server.
         /// </summary>
         /// <exception cref="OctopusSecurityException">

--- a/source/Octopus.Client/Model/InterruptionResource.cs
+++ b/source/Octopus.Client/Model/InterruptionResource.cs
@@ -5,7 +5,7 @@ using Octopus.Client.Model.Forms;
 namespace Octopus.Client.Model
 {
     /// <summary>
-    /// An interruption is a request by a process running in the Octopus server for
+    /// An interruption is a request by a process running in the Octopus Server for
     /// user action or input.
     /// </summary>
     public class InterruptionResource : Resource

--- a/source/Octopus.Client/Model/TaskResource.cs
+++ b/source/Octopus.Client/Model/TaskResource.cs
@@ -86,7 +86,7 @@ namespace Octopus.Client.Model
         public DateTimeOffset? StartTime { get; set; }
 
         /// <summary>
-        /// Gets or sets the time that the Octopus server last updated the status of this task. For a running task this should
+        /// Gets or sets the time that the Octopus Server last updated the status of this task. For a running task this should
         /// happen
         /// at least every couple of minutes.
         /// </summary>
@@ -100,7 +100,7 @@ namespace Octopus.Client.Model
         public DateTimeOffset? CompletedTime { get; set; }
 
         /// <summary>
-        /// Gets the ID of the Octopus server that created and will control this task.
+        /// Gets the ID of the Octopus Server that created and will control this task.
         /// </summary>
         [JsonProperty(Order = 15)]
         public string ServerNode { get; set; }

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -143,7 +143,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         }
 
         /// <summary>
-        /// Gets a document that identifies the Octopus server (from /api) and provides links to the resources available on the
+        /// Gets a document that identifies the Octopus Server (from /api) and provides links to the resources available on the
         /// server. Instead of hardcoding paths,
         /// clients should use these link properties to traverse the resources on the server. This document is lazily loaded so
         /// that it is only requested once for
@@ -182,7 +182,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         public event Action<OctopusRequest> SendingOctopusRequest;
 
         /// <summary>
-        /// Occurs when a response is received from the Octopus server.
+        /// Occurs when a response is received from the Octopus Server.
         /// </summary>
         public event Action<OctopusResponse> ReceivedOctopusResponse;
 

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -41,7 +41,7 @@ namespace Octopus.Client
         }
 
         /// <summary>
-        /// Gets a document that identifies the Octopus server (from /api) and provides links to the resources available on the
+        /// Gets a document that identifies the Octopus Server (from /api) and provides links to the resources available on the
         /// server. Instead of hardcoding paths,
         /// clients should use these link properties to traverse the resources on the server. This document is lazily loaded so
         /// that it is only requested once for
@@ -100,7 +100,7 @@ namespace Octopus.Client
         public event Action<OctopusRequest> SendingOctopusRequest;
 
         /// <summary>
-        /// Occurs when a response is received from the Octopus server.
+        /// Occurs when a response is received from the Octopus Server.
         /// </summary>
         public event Action<OctopusResponse> ReceivedOctopusResponse;
 

--- a/source/Octopus.Client/OctopusRequest.cs
+++ b/source/Octopus.Client/OctopusRequest.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Octopus.Client
 {
     /// <summary>
-    /// Describes a request made to the Octopus server by the client.
+    /// Describes a request made to the Octopus Server by the client.
     /// </summary>
     public class OctopusRequest
     {

--- a/source/Octopus.Client/OctopusResponse.cs
+++ b/source/Octopus.Client/OctopusResponse.cs
@@ -4,7 +4,7 @@ using System.Net;
 namespace Octopus.Client
 {
     /// <summary>
-    /// Describes a response from the Octopus server.
+    /// Describes a response from the Octopus Server.
     /// </summary>
     /// <typeparam name="TResponseResource">The resource type associated with the response.</typeparam>
     public class OctopusResponse<TResponseResource> : OctopusResponse
@@ -20,7 +20,7 @@ namespace Octopus.Client
     }
 
     /// <summary>
-    /// Describes a response from the Octopus server.
+    /// Describes a response from the Octopus Server.
     /// </summary>
     public class OctopusResponse
     {

--- a/source/Octopus.Client/OctopusServerEndpoint.cs
+++ b/source/Octopus.Client/OctopusServerEndpoint.cs
@@ -35,7 +35,7 @@ namespace Octopus.Client
         /// will assume Octopus runs under a virtual directory.
         /// </param>
         /// <param name="apiKey">
-        /// The API key to use when connecting to the Octopus server. For more information on API keys, please
+        /// The API key to use when connecting to the Octopus Server. For more information on API keys, please
         /// see the API documentation on authentication
         /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
         /// </param>
@@ -53,7 +53,7 @@ namespace Octopus.Client
         /// will assume Octopus runs under a virtual directory.
         /// </param>
         /// <param name="apiKey">
-        /// The API key to use when connecting to the Octopus server. For more information on API keys, please
+        /// The API key to use when connecting to the Octopus Server. For more information on API keys, please
         /// see the API documentation on authentication
         /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
         /// </param>
@@ -64,11 +64,11 @@ namespace Octopus.Client
         public OctopusServerEndpoint(string octopusServerAddress, string apiKey, ICredentials credentials)
         {
             if (string.IsNullOrWhiteSpace(octopusServerAddress))
-                throw new ArgumentException("An Octopus server URI was not specified.");
+                throw new ArgumentException("An Octopus Server URI was not specified.");
 
             Uri uri;
             if (!Uri.TryCreate(octopusServerAddress, UriKind.Absolute, out uri) || !uri.Scheme.StartsWith("http"))
-                throw new ArgumentException("The Octopus server URI given was invalid. The URI should start with http:// or https:// and be a valid URI.");
+                throw new ArgumentException("The Octopus Server URI given was invalid. The URI should start with http:// or https:// and be a valid URI.");
 
             octopusServer = new DefaultLinkResolver(new Uri(octopusServerAddress));
             this.apiKey = apiKey;
@@ -80,7 +80,7 @@ namespace Octopus.Client
         /// </summary>
         /// <param name="octopusServer">The resolver that should be used to turn relative links into full URIs.</param>
         /// <param name="apiKey">
-        /// The API key to use when connecting to the Octopus server. For more information on API keys, please
+        /// The API key to use when connecting to the Octopus Server. For more information on API keys, please
         /// see the API documentation on authentication
         /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
         /// </param>
@@ -110,7 +110,7 @@ namespace Octopus.Client
         public bool IsUsingSecureConnection => octopusServer.IsUsingSecureConnection;
         
         /// <summary>
-        /// Gets the API key to use when connecting to the Octopus server. For more information on API keys, please see the API
+        /// Gets the API key to use when connecting to the Octopus Server. For more information on API keys, please see the API
         /// documentation on authentication
         /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
         /// </summary>

--- a/source/Octopus.Client/Operations/IRegisterMachineOperationBase.cs
+++ b/source/Octopus.Client/Operations/IRegisterMachineOperationBase.cs
@@ -48,7 +48,7 @@ namespace Octopus.Client.Operations
 
         /// <summary>
         /// The communication style to use with the Tentacle. Allowed values are: TentacleActive, in which case the
-        /// Tentacle will connect to the Octopus server for instructions; or, TentaclePassive, in which case the
+        /// Tentacle will connect to the Octopus Server for instructions; or, TentaclePassive, in which case the
         /// Tentacle will listen for commands from the server (default).
         /// </summary>
         CommunicationStyle CommunicationStyle { get; set; }

--- a/source/Octopus.Client/Operations/RegisterMachineOperationBase.cs
+++ b/source/Octopus.Client/Operations/RegisterMachineOperationBase.cs
@@ -65,7 +65,7 @@ namespace Octopus.Client.Operations
 
         /// <summary>
         /// The communication style to use with the Tentacle. Allowed values are: TentacleActive, in which case the
-        /// Tentacle will connect to the Octopus server for instructions; or, TentaclePassive, in which case the
+        /// Tentacle will connect to the Octopus Server for instructions; or, TentaclePassive, in which case the
         /// Tentacle will listen for commands from the server (default).
         /// </summary>
         public CommunicationStyle CommunicationStyle { get; set; }
@@ -221,8 +221,8 @@ namespace Octopus.Client.Operations
         protected static string CouldNotFindMessage(string modelType, params string[] missing)
         {
             return missing.Length == 1
-                ? $"Could not find the {modelType} named {missing.Single()} on the Octopus server. Ensure the {modelType} exists and you have permission to access it."
-                : $"Could not find the {modelType}s named: {string.Join(", ", missing)} on the Octopus server. Ensure the {modelType}s exist and you have permission to access them.";
+                ? $"Could not find the {modelType} named {missing.Single()} on the Octopus Server. Ensure the {modelType} exists and you have permission to access it."
+                : $"Could not find the {modelType}s named: {string.Join(", ", missing)} on the Octopus Server. Ensure the {modelType}s exist and you have permission to access them.";
         }
     }
 }


### PR DESCRIPTION
Fixes a few small issues with command line help for octo.exe:

* Command specific (eg `octo.exe list-releases --help`) help shows `Or use octo help <command> for more details.`. The only problem is there that that shows the same help.
* `octo.exe version --help` doesn't show help 
* Some of the help text uses the incorrect casing for `Octopus Server`
* The `deploy-release` command's `--deployto` argument is missing missing `; specify this argument multiple times to deploy to multiple environments` which was added in the help docs.

Fixes https://github.com/OctopusDeploy/Issues/issues/5034