### PR TITLE
Spaces tweak repository scope

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -59,6 +59,7 @@ Octopus.Client
   }
   interface IOctopusCommonAsyncRepository
   {
+    Octopus.Client.Repositories.Async.ICommunityActionTemplateRepository CommunityActionTemplates { get; }
     Octopus.Client.Repositories.Async.IEventRepository Events { get; }
     Octopus.Client.Repositories.Async.IScopedUserRoleRepository ScopedUserRoles { get; }
     Octopus.Client.Repositories.Async.ITaskRepository Tasks { get; }
@@ -72,7 +73,6 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.Async.IArtifactRepository Artifacts { get; }
     Octopus.Client.Repositories.Async.IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
-    Octopus.Client.Repositories.Async.ICertificateConfigurationRepository CertificateConfiguration { get; }
     Octopus.Client.Repositories.Async.ICertificateRepository Certificates { get; }
     Octopus.Client.Repositories.Async.IChannelRepository Channels { get; }
     Octopus.Client.Repositories.Async.IDashboardConfigurationRepository DashboardConfigurations { get; }
@@ -107,7 +107,7 @@ Octopus.Client
     Octopus.Client.IOctopusCommonAsyncRepository
   {
     Octopus.Client.Repositories.Async.IBackupRepository Backups { get; }
-    Octopus.Client.Repositories.Async.ICommunityActionTemplateRepository CommunityActionTemplates { get; }
+    Octopus.Client.Repositories.Async.ICertificateConfigurationRepository CertificateConfiguration { get; }
     Octopus.Client.Repositories.Async.IConfigurationRepository Configuration { get; }
     Octopus.Client.Repositories.Async.IFeaturesConfigurationRepository FeaturesConfiguration { get; }
     Octopus.Client.Repositories.Async.IMigrationRepository Migrations { get; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -95,6 +95,7 @@ Octopus.Client
   }
   interface IOctopusCommonAsyncRepository
   {
+    Octopus.Client.Repositories.Async.ICommunityActionTemplateRepository CommunityActionTemplates { get; }
     Octopus.Client.Repositories.Async.IEventRepository Events { get; }
     Octopus.Client.Repositories.Async.IScopedUserRoleRepository ScopedUserRoles { get; }
     Octopus.Client.Repositories.Async.ITaskRepository Tasks { get; }
@@ -126,7 +127,6 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.Async.IArtifactRepository Artifacts { get; }
     Octopus.Client.Repositories.Async.IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
-    Octopus.Client.Repositories.Async.ICertificateConfigurationRepository CertificateConfiguration { get; }
     Octopus.Client.Repositories.Async.ICertificateRepository Certificates { get; }
     Octopus.Client.Repositories.Async.IChannelRepository Channels { get; }
     Octopus.Client.Repositories.Async.IDashboardConfigurationRepository DashboardConfigurations { get; }
@@ -199,7 +199,7 @@ Octopus.Client
     Octopus.Client.IOctopusCommonAsyncRepository
   {
     Octopus.Client.Repositories.Async.IBackupRepository Backups { get; }
-    Octopus.Client.Repositories.Async.ICommunityActionTemplateRepository CommunityActionTemplates { get; }
+    Octopus.Client.Repositories.Async.ICertificateConfigurationRepository CertificateConfiguration { get; }
     Octopus.Client.Repositories.Async.IConfigurationRepository Configuration { get; }
     Octopus.Client.Repositories.Async.IFeaturesConfigurationRepository FeaturesConfiguration { get; }
     Octopus.Client.Repositories.Async.IMigrationRepository Migrations { get; }

--- a/source/Octopus.Client/IOctopusCommonAsyncRepository.cs
+++ b/source/Octopus.Client/IOctopusCommonAsyncRepository.cs
@@ -9,5 +9,6 @@ namespace Octopus.Client
         ITeamsRepository Teams { get; }
         IScopedUserRoleRepository ScopedUserRoles { get; }
         IUserPermissionsRepository UserPermissions { get; }
+        ICommunityActionTemplateRepository CommunityActionTemplates { get; }
     }
 }

--- a/source/Octopus.Client/IOctopusSpaceAsyncRepository.cs
+++ b/source/Octopus.Client/IOctopusSpaceAsyncRepository.cs
@@ -10,7 +10,6 @@ namespace Octopus.Client
         IActionTemplateRepository ActionTemplates { get; }
         IArtifactRepository Artifacts { get; }
         IBuiltInPackageRepositoryRepository BuiltInPackageRepository { get; }
-        ICertificateConfigurationRepository CertificateConfiguration { get; }
         ICertificateRepository Certificates { get; }
         IChannelRepository Channels { get; }
         IDashboardConfigurationRepository DashboardConfigurations { get; }

--- a/source/Octopus.Client/IOctopusSystemAsyncRepository.cs
+++ b/source/Octopus.Client/IOctopusSystemAsyncRepository.cs
@@ -8,6 +8,7 @@ namespace Octopus.Client
     {
         ISchedulerRepository Schedulers { get; }
         IBackupRepository Backups { get; }
+        ICertificateConfigurationRepository CertificateConfiguration { get; }
         ICommunityActionTemplateRepository CommunityActionTemplates { get; }
         IConfigurationRepository Configuration { get; }
         IFeaturesConfigurationRepository FeaturesConfiguration { get; }

--- a/source/Octopus.Client/IOctopusSystemAsyncRepository.cs
+++ b/source/Octopus.Client/IOctopusSystemAsyncRepository.cs
@@ -9,7 +9,6 @@ namespace Octopus.Client
         ISchedulerRepository Schedulers { get; }
         IBackupRepository Backups { get; }
         ICertificateConfigurationRepository CertificateConfiguration { get; }
-        ICommunityActionTemplateRepository CommunityActionTemplates { get; }
         IConfigurationRepository Configuration { get; }
         IFeaturesConfigurationRepository FeaturesConfiguration { get; }
         IMigrationRepository Migrations { get; }


### PR DESCRIPTION
- Need to be able to get the global octopus server certificates without stepping into a space scope
- You can't currently actually install community action templates into a non-default space, because the community action template repository is only exposed on the system repository.