### PR TITLE
Re-added legacy root document properties and marked them as obsolete.

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -22,6 +22,7 @@ Octopus.Client
     event Action<OctopusRequest> SendingOctopusRequest
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
+    Octopus.Client.Model.RootResource RootDocument { get; }
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task Delete(String, Object)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(String)
@@ -130,6 +131,7 @@ Octopus.Client
     event Action<OctopusRequest> SendingOctopusRequest
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
+    Octopus.Client.Model.RootResource RootDocument { get; }
     static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task Delete(String, Object)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -29,6 +29,7 @@ Octopus.Client
     event Action<OctopusRequest> SendingOctopusRequest
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
+    Octopus.Client.Model.RootResource RootDocument { get; }
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task Delete(String, Object)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(String)
@@ -67,6 +68,7 @@ Octopus.Client
     event Action<OctopusRequest> SendingOctopusRequest
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
+    Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
     Octopus.Client.IOctopusSpaceRepository ForSpace(String)
@@ -239,6 +241,7 @@ Octopus.Client
     event Action<OctopusRequest> SendingOctopusRequest
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
+    Octopus.Client.Model.RootResource RootDocument { get; }
     static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task Delete(String, Object)
@@ -338,6 +341,7 @@ Octopus.Client
     .ctor(Octopus.Client.OctopusServerEndpoint)
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
+    Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
     void Dispose()

--- a/source/Octopus.Client/IOctopusAsyncClient.cs
+++ b/source/Octopus.Client/IOctopusAsyncClient.cs
@@ -15,7 +15,26 @@ namespace Octopus.Client
     /// </summary>
     public interface IOctopusAsyncClient : IDisposable
     {
-
+        /// <summary>
+        /// Gets a document that identifies the Octopus Server (from /api) and provides links to the resources available on the
+        /// server. Instead of hardcoding paths,
+        /// clients should use these link properties to traverse the resources on the server. This document is lazily loaded so
+        /// that it is only requested once for
+        /// the current <see cref="IOctopusAsyncClient" />.
+        /// </summary>
+        /// <exception cref="OctopusSecurityException">
+        /// HTTP 401 or 403: Thrown when the current user's API key was not valid, their
+        /// account is disabled, or they don't have permission to perform the specified action.
+        /// </exception>
+        /// <exception cref="OctopusServerException">
+        /// If any other error is successfully returned from the server (e.g., a 500
+        /// server error).
+        /// </exception>
+        /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
+        /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
+        [Obsolete("This call is a blocking call. For a non-blocking call, access the root document through the IOctopusSystemAsyncRepository instead: client.Repository.LoadRootDocument()", false)]
+        RootResource RootDocument { get; }
+        
         /// <summary>
         /// Occurs when a request is about to be sent.
         /// </summary>

--- a/source/Octopus.Client/IOctopusAsyncClient.cs
+++ b/source/Octopus.Client/IOctopusAsyncClient.cs
@@ -32,6 +32,7 @@ namespace Octopus.Client
         /// </exception>
         /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This call is a blocking call. For a non-blocking call, access the root document through the IOctopusSystemAsyncRepository instead: client.Repository.LoadRootDocument()", false)]
         RootResource RootDocument { get; }
         

--- a/source/Octopus.Client/IOctopusClient.cs
+++ b/source/Octopus.Client/IOctopusClient.cs
@@ -30,6 +30,7 @@ namespace Octopus.Client
         /// </exception>
         /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Access the root document through the IOctopusSystemRepository instead: client.Repository.LoadRootDocument()", false)]
         RootResource RootDocument { get; }
         IOctopusRepository Repository { get; }

--- a/source/Octopus.Client/IOctopusClient.cs
+++ b/source/Octopus.Client/IOctopusClient.cs
@@ -14,6 +14,24 @@ namespace Octopus.Client
     /// </summary>
     public interface IOctopusClient : IDisposable
     {
+        // <summary>
+        /// Gets a document that identifies the Octopus Server (from /api) and provides links to the resources available on the
+        /// server. Instead of hardcoding paths,
+        /// clients should use these link properties to traverse the resources on the server. This document is lazily loaded so
+        /// that it is only requested once for
+        /// the current <see cref="IOctopusClient" />.
+        /// <exception cref="OctopusSecurityException">
+        /// HTTP 401 or 403: Thrown when the current user's API key was not valid, their
+        /// account is disabled, or they don't have permission to perform the specified action.
+        /// </exception>
+        /// <exception cref="OctopusServerException">
+        /// If any other error is successfully returned from the server (e.g., a 500
+        /// server error).
+        /// </exception>
+        /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
+        /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
+        [Obsolete("Access the root document through the IOctopusSystemRepository instead: client.Repository.LoadRootDocument()", false)]
+        RootResource RootDocument { get; }
         IOctopusRepository Repository { get; }
     
         /// <summary>

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -183,6 +183,8 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// </summary>
         public event Action<HttpResponseMessage> AfterReceivedHttpResponse;
 
+        public RootResource RootDocument => Repository.LoadRootDocument().GetAwaiter().GetResult();
+
         /// <summary>
         /// Occurs when a request is about to be sent.
         /// </summary>

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -41,6 +41,7 @@ namespace Octopus.Client
             Repository = new OctopusRepository(this);
         }
 
+        public RootResource RootDocument => Repository.LoadRootDocument();
         public IOctopusRepository Repository { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
Marking the old root document properties as obsolete to encourage people to avoid them.

Also prevent them from showing up in intellisense so new people won't even know about them.