### PR TITLE
`client.Repository` should mostly work in a backwards compatible way.…

### DIFF
--- a/source/Octopus.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Client/OctopusAsyncRepository.cs
@@ -244,9 +244,14 @@ namespace Octopus.Client
 
             async Task<SpaceResource> TryGetDefaultSpace()
             {
+                var rootDocument = await loadRootResource.Value.ConfigureAwait(false);
+                var spacesIsSupported = rootDocument.HasLink("Spaces");
+                if (!spacesIsSupported)
+                {
+                    return null;
+                }
                 try
                 {
-                    var rootDocument = await loadRootResource.Value.ConfigureAwait(false);
                     var currentUser = await Client.Get<UserResource>(rootDocument.Links["CurrentUser"]).ConfigureAwait(false);
                     var userSpaces = await Client.Get<SpaceResource[]>(currentUser.Links["Spaces"]).ConfigureAwait(false);
                     return userSpaces.SingleOrDefault(s => s.IsDefault);

--- a/source/Octopus.Client/OctopusRepository.cs
+++ b/source/Octopus.Client/OctopusRepository.cs
@@ -231,9 +231,13 @@ namespace Octopus.Client
 
             SpaceResource TryGetDefaultSpace()
             {
+                var rootResource = loadRootResource.Value;
+                var spacesIsSupported = rootResource.HasLink("Spaces");
+                if (!spacesIsSupported)
+                    return null;
                 try
                 {
-                    var currentUser = Client.Get<UserResource>(loadRootResource.Value.Links["CurrentUser"]);
+                    var currentUser = Client.Get<UserResource>(rootResource.Links["CurrentUser"]);
                     var userSpaces = Client.Get<SpaceResource[]>(currentUser.Links["Spaces"]);
                     return userSpaces.SingleOrDefault(s => s.IsDefault);
                 }


### PR DESCRIPTION
Calling `client.Repository` should work when targeting old versions of Octopus Server. This means it should not call new endpoints (like "Spaces") if it doesn't need to.