### PR TITLE
Report 'removed packages in use' when attempting to update deployment actions from templates

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -847,6 +847,21 @@ Octopus.Client.Model
       Success = 0
       ManualMergeRequired = 1
       DefaultParamterValueMissing = 2
+      RemovedPackageInUse = 3
+  }
+  ActionUpdatePackageUsedBy
+  {
+      ProjectVersionStrategy = 0
+      ProjectReleaseCreationStrategy = 1
+      ChannelRule = 2
+  }
+  class ActionUpdateRemovedPackageUsage
+  {
+    .ctor(String, Octopus.Client.Model.ActionUpdatePackageUsedBy, String, String)
+    String PackageReference { get; }
+    Octopus.Client.Model.ActionUpdatePackageUsedBy UsedBy { get; }
+    String UsedById { get; }
+    String UsedByName { get; }
   }
   class ActionUpdateResultResource
     Octopus.Client.Extensibility.IResource
@@ -857,6 +872,7 @@ Octopus.Client.Model
     IDictionary<String, String[]> ManualMergeRequiredReasonsByPropertyName { get; set; }
     String[] NamesOfNewParametersMissingDefaultValue { get; set; }
     Octopus.Client.Model.ActionUpdateOutcome Outcome { get; set; }
+    ICollection<ActionUpdateRemovedPackageUsage> RemovedPackageUsages { get; set; }
   }
   class ActivityElement
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1343,6 +1343,21 @@ Octopus.Client.Model
       Success = 0
       ManualMergeRequired = 1
       DefaultParamterValueMissing = 2
+      RemovedPackageInUse = 3
+  }
+  ActionUpdatePackageUsedBy
+  {
+      ProjectVersionStrategy = 0
+      ProjectReleaseCreationStrategy = 1
+      ChannelRule = 2
+  }
+  class ActionUpdateRemovedPackageUsage
+  {
+    .ctor(String, Octopus.Client.Model.ActionUpdatePackageUsedBy, String, String)
+    String PackageReference { get; }
+    Octopus.Client.Model.ActionUpdatePackageUsedBy UsedBy { get; }
+    String UsedById { get; }
+    String UsedByName { get; }
   }
   class ActionUpdateResultResource
     Octopus.Client.Extensibility.IResource
@@ -1353,6 +1368,7 @@ Octopus.Client.Model
     IDictionary<String, String[]> ManualMergeRequiredReasonsByPropertyName { get; set; }
     String[] NamesOfNewParametersMissingDefaultValue { get; set; }
     Octopus.Client.Model.ActionUpdateOutcome Outcome { get; set; }
+    ICollection<ActionUpdateRemovedPackageUsage> RemovedPackageUsages { get; set; }
   }
   class ActivityElement
   {

--- a/source/Octopus.Client/Model/ActionUpdateOutcome.cs
+++ b/source/Octopus.Client/Model/ActionUpdateOutcome.cs
@@ -6,6 +6,7 @@ namespace Octopus.Client.Model
     {
         Success = 0,
         ManualMergeRequired = 1,
-        DefaultParamterValueMissing = 2
+        DefaultParamterValueMissing = 2,
+        RemovedPackageInUse = 3
     }
 }

--- a/source/Octopus.Client/Model/ActionUpdatePackageUsedBy.cs
+++ b/source/Octopus.Client/Model/ActionUpdatePackageUsedBy.cs
@@ -1,0 +1,9 @@
+namespace Octopus.Client.Model
+{
+    public enum ActionUpdatePackageUsedBy
+    {
+        ProjectVersionStrategy,
+        ProjectReleaseCreationStrategy,
+        ChannelRule
+    }
+}

--- a/source/Octopus.Client/Model/ActionUpdateRemovedPackageUsage.cs
+++ b/source/Octopus.Client/Model/ActionUpdateRemovedPackageUsage.cs
@@ -1,0 +1,18 @@
+namespace Octopus.Client.Model
+{
+    public class ActionUpdateRemovedPackageUsage
+    {
+        public ActionUpdateRemovedPackageUsage(string packageReference, ActionUpdatePackageUsedBy usedBy, string usedById, string usedByName)
+        {
+            PackageReference = packageReference;
+            UsedBy = usedBy;
+            UsedById = usedById;
+            UsedByName = usedByName;
+        }
+
+        public string PackageReference { get; }
+        public ActionUpdatePackageUsedBy UsedBy { get; }
+        public string UsedById { get; }
+        public string UsedByName { get; }
+    }
+}

--- a/source/Octopus.Client/Model/ActionUpdateResultResource.cs
+++ b/source/Octopus.Client/Model/ActionUpdateResultResource.cs
@@ -15,6 +15,7 @@ namespace Octopus.Client.Model
         public ActionUpdateOutcome Outcome { get; set; }
         public IDictionary<string, string[]> ManualMergeRequiredReasonsByPropertyName { get; set; }
         public string[] NamesOfNewParametersMissingDefaultValue { get; set; }
+        public ICollection<ActionUpdateRemovedPackageUsage> RemovedPackageUsages { get; set; } = new List<ActionUpdateRemovedPackageUsage>();
         public LinkCollection Links { get; set; }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ActionTemplateRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ActionTemplateRepository.cs
@@ -33,6 +33,7 @@ namespace Octopus.Client.Repositories.Async
         {
             return Client.Post<ActionsUpdateResource, ActionUpdateResultResource[]>(actionTemplate.Links["ActionsUpdate"], update, new { actionTemplate.Id });
         }
+        
         public Task SetLogo(ActionTemplateResource resource, string fileName, Stream contents)
         {
             return Client.Post(resource.Link("Logo"), new FileUpload { Contents = contents, FileName = fileName }, false);


### PR DESCRIPTION
Added result when updating deployment actions from step templates to indicate a removed package was in use.
See https://github.com/OctopusDeploy/OctopusDeploy/pull/3113