### PR TITLE
Embedded octodiff into the windows exe

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -166,7 +166,8 @@ Task("MergeOctoExe")
         ILRepack(
             $"{outputFolder}/Octo.exe",
             $"{inputFolder}/Octo.exe",
-            System.IO.Directory.EnumerateFiles(inputFolder, "*.dll").Select(f => (FilePath) f),
+            System.IO.Directory.EnumerateFiles(inputFolder, "*.dll").Select(f => (FilePath) f)
+				.Union(System.IO.Directory.EnumerateFiles(inputFolder, "octodiff.exe").Select(f => (FilePath) f)),
             new ILRepackSettings {
                 Internalize = true,
                 Parallel = true,

--- a/build.cake
+++ b/build.cake
@@ -166,8 +166,9 @@ Task("MergeOctoExe")
         ILRepack(
             $"{outputFolder}/Octo.exe",
             $"{inputFolder}/Octo.exe",
-            System.IO.Directory.EnumerateFiles(inputFolder, "*.dll").Select(f => (FilePath) f)
-				.Union(System.IO.Directory.EnumerateFiles(inputFolder, "octodiff.exe").Select(f => (FilePath) f)),
+            System.IO.Directory.EnumerateFiles(inputFolder, "*.dll")
+				.Union(System.IO.Directory.EnumerateFiles(inputFolder, "octodiff.exe")
+				.Select(f => (FilePath) f),
             new ILRepackSettings {
                 Internalize = true,
                 Parallel = true,

--- a/build.cake
+++ b/build.cake
@@ -167,7 +167,7 @@ Task("MergeOctoExe")
             $"{outputFolder}/Octo.exe",
             $"{inputFolder}/Octo.exe",
             System.IO.Directory.EnumerateFiles(inputFolder, "*.dll")
-				.Union(System.IO.Directory.EnumerateFiles(inputFolder, "octodiff.exe")
+				.Union(System.IO.Directory.EnumerateFiles(inputFolder, "octodiff.exe"))
 				.Select(f => (FilePath) f),
             new ILRepackSettings {
                 Internalize = true,


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/5175

Octodiff.exe needs to be repacked to enable delta transfers.