### PR TITLE
One small change in Linux Shell script to better support spaces in Project Names

### DIFF
--- a/BuildAssets/Octo
+++ b/BuildAssets/Octo
@@ -8,4 +8,4 @@ done
 cd -P "$( dirname "$SOURCE" )"
 # LTTNG_UST_REGISTER_TIMEOUT=0 is there to work around a bug in docker that causes an assertion violation in dotnet on first launch
 # See https://github.com/dotnet/cli/issues/1582
-LTTNG_UST_REGISTER_TIMEOUT=0 dotnet Octo.dll $*
+LTTNG_UST_REGISTER_TIMEOUT=0 dotnet Octo.dll "$@"


### PR DESCRIPTION
As suggested by John Smith via a Support Ticket.

Changes the line 

`LTTNG_UST_REGISTER_TIMEOUT=0 dotnet Octo.dll $*`

to

`LTTNG_UST_REGISTER_TIMEOUT=0 dotnet Octo.dll "$@"`

Tested locally. Fails with original line, and works as expected with the change. Nice little tweak.
