### PR TITLE
Enh splitnodetable

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -4,13 +4,14 @@
 #tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
 #tool "nuget:?package=ILRepack&version=2.0.13"
 #addin "nuget:?package=SharpCompress&version=0.12.4"
-#addin "nuget:?package=Cake.Incubator&version=3.0.0"
+#addin "nuget:?package=Cake.Incubator&version=4.0.0"
 
 using SharpCompress;
 using SharpCompress.Common;
 using SharpCompress.Writer;
 using System.Xml;
 using Cake.Incubator;
+using Cake.Incubator.LoggingExtensions;
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS

--- a/build.cake
+++ b/build.cake
@@ -4,7 +4,7 @@
 #tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
 #tool "nuget:?package=ILRepack&version=2.0.13"
 #addin "nuget:?package=SharpCompress&version=0.12.4"
-#addin "nuget:?package=Cake.Incubator"
+#addin "nuget:?package=Cake.Incubator&version=3.0.0"
 
 using SharpCompress;
 using SharpCompress.Common;

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2708,6 +2708,11 @@ Octopus.Client.Model
     Octopus.Client.Model.TContainer AddOrUpdateVariableTemplate(String, String, IDictionary<String, String>, String, String)
     Octopus.Client.Model.TContainer Clear()
   }
+  LeadershipRank
+  {
+      Follower = 0
+      Leader = 1
+  }
   class Library
   {
     .ctor(String)
@@ -3115,7 +3120,7 @@ Octopus.Client.Model
     Nullable<DateTimeOffset> LastSeen { get; set; }
     Int32 MaxConcurrentTasks { get; set; }
     String Name { get; set; }
-    String Rank { get; set; }
+    Octopus.Client.Model.LeadershipRank Rank { get; set; }
     Int32 RunningTaskCount { get; set; }
   }
   PackageAcquisitionLocation

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3078,6 +3078,12 @@ Octopus.Client.Model
     .ctor()
     Octopus.Client.Model.FeedType FeedType { get; }
   }
+  class OctopusServerClusterSummaryResource
+  {
+    .ctor()
+    Octopus.Client.Extensibility.LinkCollection Links { get; set; }
+    Octopus.Client.Model.OctopusServerNodeSummaryResource[] Nodes { get; set; }
+  }
   class OctopusServerNodeDetailsResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -3094,11 +3100,23 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean IsInMaintenanceMode { get; set; }
+    Int32 MaxConcurrentTasks { get; set; }
+    String Name { get; set; }
+  }
+  class OctopusServerNodeSummaryResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Boolean IsInMaintenanceMode { get; set; }
+    Boolean IsLeader { get; set; }
     Boolean IsOffline { get; set; }
-    String LastSeen { get; set; }
+    Nullable<DateTimeOffset> LastSeen { get; set; }
     Int32 MaxConcurrentTasks { get; set; }
     String Name { get; set; }
     String Rank { get; set; }
+    Int32 RunningTaskCount { get; set; }
   }
   PackageAcquisitionLocation
   {
@@ -5770,6 +5788,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<OctopusServerNodeResource>
   {
     Octopus.Client.Model.OctopusServerNodeDetailsResource Details(Octopus.Client.Model.OctopusServerNodeResource)
+    Octopus.Client.Model.OctopusServerClusterSummaryResource Summary()
   }
   interface IPaginate`1
   {
@@ -6341,6 +6360,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<OctopusServerNodeResource>
   {
     Task<OctopusServerNodeDetailsResource> Details(Octopus.Client.Model.OctopusServerNodeResource)
+    Task<OctopusServerClusterSummaryResource> Summary()
   }
   interface IPaginate`1
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2721,6 +2721,11 @@ Octopus.Client.Model
     Octopus.Client.Model.TContainer AddOrUpdateVariableTemplate(String, String, IDictionary<String, String>, String, String)
     Octopus.Client.Model.TContainer Clear()
   }
+  LeadershipRank
+  {
+      Follower = 0
+      Leader = 1
+  }
   class Library
   {
     .ctor(String)
@@ -3131,7 +3136,7 @@ Octopus.Client.Model
     Nullable<DateTimeOffset> LastSeen { get; set; }
     Int32 MaxConcurrentTasks { get; set; }
     String Name { get; set; }
-    String Rank { get; set; }
+    Octopus.Client.Model.LeadershipRank Rank { get; set; }
     Int32 RunningTaskCount { get; set; }
   }
   PackageAcquisitionLocation

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3094,6 +3094,12 @@ Octopus.Client.Model
     .ctor()
     Octopus.Client.Model.FeedType FeedType { get; }
   }
+  class OctopusServerClusterSummaryResource
+  {
+    .ctor()
+    Octopus.Client.Extensibility.LinkCollection Links { get; set; }
+    Octopus.Client.Model.OctopusServerNodeSummaryResource[] Nodes { get; set; }
+  }
   class OctopusServerNodeDetailsResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -3110,11 +3116,23 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean IsInMaintenanceMode { get; set; }
+    Int32 MaxConcurrentTasks { get; set; }
+    String Name { get; set; }
+  }
+  class OctopusServerNodeSummaryResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Boolean IsInMaintenanceMode { get; set; }
+    Boolean IsLeader { get; set; }
     Boolean IsOffline { get; set; }
-    String LastSeen { get; set; }
+    Nullable<DateTimeOffset> LastSeen { get; set; }
     Int32 MaxConcurrentTasks { get; set; }
     String Name { get; set; }
     String Rank { get; set; }
+    Int32 RunningTaskCount { get; set; }
   }
   PackageAcquisitionLocation
   {
@@ -5792,6 +5810,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<OctopusServerNodeResource>
   {
     Octopus.Client.Model.OctopusServerNodeDetailsResource Details(Octopus.Client.Model.OctopusServerNodeResource)
+    Octopus.Client.Model.OctopusServerClusterSummaryResource Summary()
   }
   interface IPaginate`1
   {
@@ -6363,6 +6382,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<OctopusServerNodeResource>
   {
     Task<OctopusServerNodeDetailsResource> Details(Octopus.Client.Model.OctopusServerNodeResource)
+    Task<OctopusServerClusterSummaryResource> Summary()
   }
   interface IPaginate`1
   {

--- a/source/Octopus.Client/Model/LeadershipRank.cs
+++ b/source/Octopus.Client/Model/LeadershipRank.cs
@@ -1,0 +1,8 @@
+﻿namespace Octopus.Client.Model
+{
+    public enum LeadershipRank
+    {
+        Follower,
+        Leader
+    }
+}

--- a/source/Octopus.Client/Model/OctopusServerClusterSummaryResource.cs
+++ b/source/Octopus.Client/Model/OctopusServerClusterSummaryResource.cs
@@ -1,0 +1,10 @@
+﻿using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
+{
+    public class OctopusServerClusterSummaryResource
+    {
+        public OctopusServerNodeSummaryResource[] Nodes { get; set; }
+        public LinkCollection Links { get; set; }
+    }
+}

--- a/source/Octopus.Client/Model/OctopusServerNodeResource.cs
+++ b/source/Octopus.Client/Model/OctopusServerNodeResource.cs
@@ -7,9 +7,6 @@ namespace Octopus.Client.Model
     public class OctopusServerNodeResource : Resource, INamedResource
     {
         public string Name { get; set; }
-        public string LastSeen { get; set; }
-        public string Rank { get; set; }
-        public bool IsOffline { get; set; }
         [Writeable]
         public int MaxConcurrentTasks { get; set; }
         [Writeable]

--- a/source/Octopus.Client/Model/OctopusServerNodeSummaryResource.cs
+++ b/source/Octopus.Client/Model/OctopusServerNodeSummaryResource.cs
@@ -9,7 +9,7 @@ namespace Octopus.Client.Model
         public int MaxConcurrentTasks { get; set; }
         public bool IsInMaintenanceMode { get; set; }
         public DateTimeOffset? LastSeen { get; set; }
-        public string Rank { get; set; }
+        public LeadershipRank Rank { get; set; }
         public bool IsLeader { get; set; }
         public bool IsOffline { get; set; }
         public int RunningTaskCount { get;set; }

--- a/source/Octopus.Client/Model/OctopusServerNodeSummaryResource.cs
+++ b/source/Octopus.Client/Model/OctopusServerNodeSummaryResource.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
+{
+    public class OctopusServerNodeSummaryResource : Resource
+    {
+        public string Name { get; set; }
+        public int MaxConcurrentTasks { get; set; }
+        public bool IsInMaintenanceMode { get; set; }
+        public DateTimeOffset? LastSeen { get; set; }
+        public string Rank { get; set; }
+        public bool IsLeader { get; set; }
+        public bool IsOffline { get; set; }
+        public int RunningTaskCount { get;set; }
+    }
+}

--- a/source/Octopus.Client/Repositories/Async/OctopusServerNodeRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/OctopusServerNodeRepository.cs
@@ -8,6 +8,7 @@ namespace Octopus.Client.Repositories.Async
     public interface IOctopusServerNodeRepository : IModify<OctopusServerNodeResource>, IDelete<OctopusServerNodeResource>, IGet<OctopusServerNodeResource>, IFindByName<OctopusServerNodeResource>
     {
         Task<OctopusServerNodeDetailsResource> Details(OctopusServerNodeResource node);
+        Task<OctopusServerClusterSummaryResource> Summary();
     }
 
     class OctopusServerNodeRepository : BasicRepository<OctopusServerNodeResource>, IOctopusServerNodeRepository
@@ -23,6 +24,11 @@ namespace Octopus.Client.Repositories.Async
         public async Task<OctopusServerNodeDetailsResource> Details(OctopusServerNodeResource node)
         {
             return await repository.Client.Get<OctopusServerNodeDetailsResource>(node.Link("Details"));
+        }
+
+        public async Task<OctopusServerClusterSummaryResource> Summary()
+        {
+            return await repository.Client.Get<OctopusServerClusterSummaryResource>(await repository.Link("OctopusServerClusterSummary").ConfigureAwait(false)).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/OctopusServerNodeRepository.cs
+++ b/source/Octopus.Client/Repositories/OctopusServerNodeRepository.cs
@@ -7,6 +7,7 @@ namespace Octopus.Client.Repositories
     public interface IOctopusServerNodeRepository : IModify<OctopusServerNodeResource>, IDelete<OctopusServerNodeResource>, IGet<OctopusServerNodeResource>, IFindByName<OctopusServerNodeResource>
     {
         OctopusServerNodeDetailsResource Details(OctopusServerNodeResource node);
+        OctopusServerClusterSummaryResource Summary();
     }
     
     class OctopusServerNodeRepository : BasicRepository<OctopusServerNodeResource>, IOctopusServerNodeRepository
@@ -22,6 +23,11 @@ namespace Octopus.Client.Repositories
         public OctopusServerNodeDetailsResource Details(OctopusServerNodeResource node)
         {
             return repository.Client.Get<OctopusServerNodeDetailsResource>(node.Link("Details"));
+        }
+
+        public OctopusServerClusterSummaryResource Summary()
+        {
+            return repository.Client.Get<OctopusServerClusterSummaryResource>(repository.Link("OctopusServerClusterSummary"));
         }
     }
 }

--- a/source/OctopusClients.sln
+++ b/source/OctopusClients.sln
@@ -4,7 +4,14 @@ VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{193F466A-BECE-4809-A369-7CC061C31C82}"
 	ProjectSection(SolutionItems) = preProject
+		..\build.cake = ..\build.cake
+		..\build.cmd = ..\build.cmd
+		..\build.ps1 = ..\build.ps1
+		..\build.sh = ..\build.sh
+		..\gitversion.yml = ..\gitversion.yml
+		..\global.json = ..\global.json
 		NuGet.Config = NuGet.Config
+		..\readme.md = ..\readme.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octo", "Octo\Octo.csproj", "{D1BFD88F-FB8E-49EC-968F-F4D9A8A52519}"


### PR DESCRIPTION
Client updates for https://github.com/OctopusDeploy/OctopusDeploy/pull/3391

**note: these are breaking changes**, but we (@michaelnoonan  and I) came to the conclusion that this would be low risk (as its unlikely that people are using the client for this) and that changing the `LastSeen` to a `DateTimeOffset` is worth the break.