### PR TITLE
Suppress logging when using json output

### DIFF
--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -137,6 +137,7 @@ namespace Octopus.Cli.Commands
 #endif
             
             commandOutputProvider.PrintMessages = OutputFormat == OutputFormat.Default || enableDebugging;
+            CliSerilogLogProvider.PrintMessages = commandOutputProvider.PrintMessages;
             commandOutputProvider.PrintHeader();
 
             var client = await clientFactory.CreateAsyncClient(endpoint, clientOptions).ConfigureAwait(false);

--- a/source/Octopus.Cli/Util/SerilogLogProvider.cs
+++ b/source/Octopus.Cli/Util/SerilogLogProvider.cs
@@ -15,6 +15,8 @@ namespace Octopus.Cli.Util
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
+        public static bool PrintMessages { get; set; }
+
         public Logger GetLogger(string name) 
             => new SerilogLogger(Logger.ForContext("SourceContext", name, destructureObjects: false)).Log;
 
@@ -35,6 +37,9 @@ namespace Octopus.Cli.Util
 
             public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
             {
+                if (!PrintMessages)
+                    return false;
+
                 var translatedLevel = TranslateLevel(logLevel);
                 if (messageFunc == null)
                 {


### PR DESCRIPTION
modified the SerilogLogProvider so it is aware of when message printing is being suppressed.

We may still want a more holistic longer term solution, but this addresses the immediate issues with the user agent logging interfering with the json output.

Fixes OctopusDeploy/Issues#5224