### PR TITLE
Bug/removed tenant

### DIFF
--- a/source/Octo.Tests/Commands/ListLatestDeploymentsCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ListLatestDeploymentsCommandFixture.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Cli.Commands.Deployment;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+
+namespace Octo.Tests.Commands
+{
+    [TestFixture]
+    public class ListLatestDeploymentsCommandFixture : ApiCommandFixtureBase
+    {
+        ListLatestDeploymentsCommand listLatestDeploymentsCommands;
+
+        [SetUp]
+        public void SetUp()
+        {
+            listLatestDeploymentsCommands = new ListLatestDeploymentsCommand(RepositoryFactory, FileSystem, ClientFactory, CommandOutputProvider);
+
+            var dashboardResources = new DashboardResource
+            {
+                Items = new List<DashboardItemResource>
+                {
+                    new DashboardItemResource
+                    {
+                        EnvironmentId = "environmentid1",
+                        ProjectId = "projectaid",
+                        TenantId = "tenantid1"                        
+                    },
+                    new DashboardItemResource
+                    {
+                        EnvironmentId = "environmentid1",
+                        ProjectId = "projectaid",
+                        TenantId = "tenantid2"                        
+                    }
+                },
+                Tenants = new List<DashboardTenantResource>
+                {
+                    new DashboardTenantResource
+                    {
+                        Id = "tenantid1",
+                        Name = "tenant1"
+                    }
+                }
+            };
+
+            Repository.Projects.FindByNames(Arg.Any<IEnumerable<string>>())
+                .Returns(Task.FromResult(
+                    new List<ProjectResource>
+                    {
+                        new ProjectResource {Name = "ProjectA", Id = "projectaid"}
+                    }));
+
+            Repository.Environments.FindAll()
+                .Returns(Task.FromResult(
+                    new List<EnvironmentResource>
+                    {
+                        new EnvironmentResource {Name = "EnvA", Id = "environmentid1"}
+                    }));
+
+            Repository.Releases.Get(Arg.Any<string>()).ReturnsForAnyArgs(new ReleaseResource { Version = "0.0.1" });
+
+            Repository.Dashboards.GetDynamicDashboard(Arg.Any<string[]>(), Arg.Any<string[]>()).ReturnsForAnyArgs(dashboardResources);
+        }
+
+        [Test]
+        public async Task ShouldNotFailWhenTenantIsRemoved()
+        {
+            CommandLineArgs.Add("--project=ProjectA");
+
+            await listLatestDeploymentsCommands.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
+
+            LogLines.Should().Contain(" - Tenant: tenant1");
+            LogLines.Should().Contain(" - Tenant: <Removed>");
+        }
+
+        [Test]
+        public async Task JsonOutput_ShouldNotFailOnRemovedTenant()
+        {
+            CommandLineArgs.Add("--project=ProjectA");
+            CommandLineArgs.Add("--outputFormat=json");
+
+            await listLatestDeploymentsCommands.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
+
+            var logoutput = LogOutput.ToString();
+            JsonConvert.DeserializeObject(logoutput);
+            logoutput.Should().Contain("tenant1");
+            logoutput.Should().Contain("<Removed>");
+        }
+    }
+}

--- a/source/Octopus.Cli/Commands/Deployment/ListLatestDeploymentsCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/ListLatestDeploymentsCommand.cs
@@ -81,7 +81,7 @@ namespace Octopus.Cli.Commands.Deployment
             commandOutputProvider.Information(" - Environment: {Environment:l}", nameOfDeploymentEnvironment);
             if (!string.IsNullOrEmpty(dashboardItem.TenantId))
             {
-                var nameOfDeploymentTenant = tenantsById[dashboardItem.TenantId];
+                var nameOfDeploymentTenant = GetNameOfDeploymentTenant(tenantsById, dashboardItem.TenantId);
                 commandOutputProvider.Information(" - Tenant: {Tenant:l}", nameOfDeploymentTenant);
             }
 
@@ -172,7 +172,7 @@ namespace Octopus.Cli.Commands.Deployment
                     Environment = new { Id = x.dashboardItem.EnvironmentId, Name = environmentsById[x.dashboardItem.EnvironmentId] },
                     Tenant = string.IsNullOrWhiteSpace(x.dashboardItem.TenantId)
                         ? null
-                        : new { Id = x.dashboardItem.TenantId, Name = tenantsById[x.dashboardItem.TenantId] },
+                        : new { Id = x.dashboardItem.TenantId, Name = GetNameOfDeploymentTenant(tenantsById, x.dashboardItem.TenantId) },
                     Channel = x.channel == null ? null : new { x.channel.Id, x.channel.Name },
                     Date = x.dashboardItem.QueueTime,
                     x.dashboardItem.Duration,
@@ -182,6 +182,14 @@ namespace Octopus.Cli.Commands.Deployment
                     PackageVersion = GetPackageVersionsAsString(x.release.SelectedPackages),
                     ReleaseNotes = GetReleaseNotes(x.release)
                 }));
+        }
+        
+        private static string GetNameOfDeploymentTenant(IDictionary<string,string> tenantsById, string tenantId)
+        {
+            if (string.IsNullOrWhiteSpace(tenantId))
+                return null;
+
+            return tenantsById.ContainsKey(tenantId) ? tenantsById[tenantId] : "<Removed>";
         }
     }
 }


### PR DESCRIPTION
When listing the latest deployments with octo.exe it failed in the situation where we have a deployment that is pointing to a tenant that was removed. The latest deployment command is fixed to deal with this scenario.

Tests were added for our fix.

The command used was:
```
.\octo.exe list-latestdeployments --server=<serveruri> --apikey=<apikey> --project=<some project> --environment=Test --outputformat=json
```

The exception that occurred was:
```
System.Collections.Generic.KeyNotFoundException: The given key was not present i
n the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Octopus.Cli.Commands.Deployment.ListLatestDeploymentsCommand.<PrintJsonOut
put>b__15_1(<>f__AnonymousType16`3 x)
   at System.Linq.Enumerable.<>c__DisplayClass7_0`3.<CombineSelectors>b__0(TSour
ce x)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeList(J
sonWriter writer, IEnumerable values, JsonArrayContract contract, JsonProperty m
ember, JsonContainerContract collectionContract, JsonProperty containerProperty)

   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeValue(
JsonWriter writer, Object value, JsonContract valueContract, JsonProperty member
, JsonContainerContract containerContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.Serialize(JsonW
riter jsonWriter, Object value, Type objectType)
   at Newtonsoft.Json.JsonSerializer.SerializeInternal(JsonWriter jsonWriter, Ob
ject value, Type objectType)
   at Newtonsoft.Json.JsonConvert.SerializeObjectInternal(Object value, Type typ
e, JsonSerializer jsonSerializer)
   at Octopus.Cli.Util.CommandOutputProvider.Json(Object o)
   at Octopus.Cli.Commands.Deployment.ListLatestDeploymentsCommand.PrintJsonOutp
ut()
   at Octopus.Cli.Commands.ApiCommand.Respond()
   at Octopus.Cli.Commands.ApiCommand.<Execute>d__38.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNot
ification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   at Octopus.Cli.Commands.ApiCommand.<Execute>d__36.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNot
ification(Task task)
   at Octopus.Cli.CliProgram.Run(String[] args)
```