### PR TITLE
Dont output empty brackets if no email address

### DIFF
--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -203,7 +203,10 @@ namespace Octopus.Cli.Commands
             var user = await Repository.Users.GetCurrent().ConfigureAwait(false);
             if (user != null)
             {
-                commandOutputProvider.Debug("Authenticated as: {Name:l} <{EmailAddress:l}> {IsService:l}", user.DisplayName, user.EmailAddress, user.IsService ? "(a service account)" : "");
+                if (string.IsNullOrEmpty(user.EmailAddress))
+                    commandOutputProvider.Debug("Authenticated as: {Name:l} {IsService:l}", user.DisplayName, user.IsService ? "(a service account)" : "");
+                else
+                    commandOutputProvider.Debug("Authenticated as: {Name:l} <{EmailAddress:l}> {IsService:l}", user.DisplayName, user.EmailAddress, user.IsService ? "(a service account)" : "");
             }
 
             await ValidateParameters().ConfigureAwait(false);

--- a/source/Octopus.Client/AutomationEnvironments/AutomationEnvironmentProvider.cs
+++ b/source/Octopus.Client/AutomationEnvironments/AutomationEnvironmentProvider.cs
@@ -67,7 +67,7 @@ namespace Octopus.Client.AutomationEnvironments
                 envString = $"{environment}/{environmentVariableReader.GetVariableValue(KnownEnvironmentVariables[environment].First()).Split(' ').First()}";
             }
 
-            Logger.InfoFormat("Detected automation environment: {environment}", envString);
+            Logger.InfoFormat("Detected automation environment: {environment:l}", envString);
 
             return envString;
         }


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/5292

I considered multiple ways of handling this while trying to stay true to serilogs structured logging principals... All of them were way more code and added more complexity.

As its unlikely we'll be shipping `octo.exe` output direct to seq or other structured logging endpoint, it's not a priority to support searching by message template (especially as we'd more likely just search for `authenticated as`).