### PR TITLE
Use operator when setting SensitiveValue

### DIFF
--- a/source/Octopus.Client/Model/PropertyValueResource.cs
+++ b/source/Octopus.Client/Model/PropertyValueResource.cs
@@ -19,7 +19,7 @@ namespace Octopus.Client.Model
             if (isSensitive)
             {
                 IsSensitive = true;
-                SensitiveValue = new SensitiveValue { NewValue = value };
+                SensitiveValue = value;
                 return;
             }
 


### PR DESCRIPTION
Using the operator correctly sets SensitiveValue.HasValue. Fixes #389