### PR TITLE
improved info for user who cannot see a space due to no permissions f…

### DIFF
--- a/source/Octo.Tests/Commands/ApiCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixture.cs
@@ -124,10 +124,10 @@ namespace Octo.Tests.Commands
             client.ForSystem().Returns(Repository);
 
             apiCommand = new DummyApiCommand(RepositoryFactory, FileSystem, ClientFactory, CommandOutputProvider);
-            var argsWithSpaceName = CommandLineArgs.Concat(new[] { "--space=notExisted" });
+            var argsWithSpaceName = CommandLineArgs.Concat(new[] { "--space=nonExistent" });
 
             Func<Task> action = async () => await apiCommand.Execute(argsWithSpaceName.ToArray()).ConfigureAwait(false);
-            action.ShouldThrow<CommandException>().WithMessage("Cannot find the space with name notExisted");
+            action.ShouldThrow<CommandException>().WithMessage("Cannot find the space with name 'nonExistent'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
         }
     }
 }

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -154,7 +154,7 @@ namespace Octopus.Cli.Commands
                 var space = await client.ForSystem().Spaces.FindByName(spaceName).ConfigureAwait(false);
                 if (space == null)
                 {
-                    throw new CommandException($"Cannot find the space with name {spaceName}");
+                    throw new CommandException($"Cannot find the space with name '{spaceName}'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
                 }
 
                 Repository = repositoryFactory.CreateRepository(client, RepositoryScope.ForSpace(space));


### PR DESCRIPTION
Fixes: https://github.com/OctopusDeploy/Issues/issues/5320

## Details
 If you do not have *ANY* permissions on the Space, that means it is invisible to you. This is a feature, so all we can do is let you know to check the name and check your permissions.
 
 It already lets you know about permissions if you're lacking them
 
> This action requires permission to push new packages to the built-in package repository. None of your teams have this permission.
> You do not have permission to perform this action. Please contact your Octopus administrator. Missing permission: BuiltInFeedPush

![image](https://user-images.githubusercontent.com/119096/53082629-5c611480-3551-11e9-9613-8aa01cde1c60.png)
