### PR TITLE
[WIP] Ensure resource space scope matches the repository scope

### DIFF
--- a/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
@@ -33,35 +33,24 @@ namespace Octopus.Client.Tests.Repositories.Async
         }
         
         [Test]
-        public void Create_ResourceWithImpliedSpace_DefaultRepoScopeSetsTheSpace()
+        public void Create_ResourceWithNoSpaceId_RepoSetsTheSpace()
         {
             var resource = CreateProjectResourceForSpace(null);
-            Assert.DoesNotThrow(() => subject.Create(resource));
-
-            resource.SpaceId.Should()
-                .Be(defaultSpace.Id, $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
+            Assert.DoesNotThrow(() => subject.Create(resource).Wait());
+            resource.SpaceId
+                .Should().Be(defaultSpace.Id, $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
         }
         
         [Test]
-        public void Create_ResourceWithImpliedSpace_RepoScopeSetsTheSpace()
-        {
-            SetupRepositoryToUseADifferentSpace();
-            var resource = CreateProjectResourceForSpace(null);
-            Assert.DoesNotThrow(() => subject.Create(resource));
-
-            resource.SpaceId.Should()
-                .Be("Spaces-2", $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
-        }
-
-        [Test]
-        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldOverwrite()
+        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
         {
             var resource = CreateProjectResourceForSpace("Spaces-2");
-            Assert.DoesNotThrow(() => subject.Create(resource).Wait());
+            Action activityUnderTest= () => subject.Create(resource).Wait();
 
-            resource.SpaceId.Should().Be(defaultSpace.Id, because: "https://github.com/OctopusDeploy/OctopusDeploy/blob/ff86277e425b2f2f7e5093a01cc7bc948bfbfca3/source/Octopus.IntegrationTests/Octopus.Server/Spaces/MixedScopeTest.cs#L127");
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
         }
-
 
         [Test]
         public void Create_ResourceInExplicitSpace_MatchingSpaceRepoIsOk()

--- a/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
@@ -54,14 +54,12 @@ namespace Octopus.Client.Tests.Repositories.Async
         }
 
         [Test]
-        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
+        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldOverwrite()
         {
             var resource = CreateProjectResourceForSpace("Spaces-2");
-            Action activityUnderTest = () => subject.Create(resource).Wait();
-            
-            activityUnderTest
-                .ShouldThrow<ArgumentException>()
-                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
+            Assert.DoesNotThrow(() => subject.Create(resource).Wait());
+
+            resource.SpaceId.Should().Be(defaultSpace.Id, because: "https://github.com/OctopusDeploy/OctopusDeploy/blob/ff86277e425b2f2f7e5093a01cc7bc948bfbfca3/source/Octopus.IntegrationTests/Octopus.Server/Spaces/MixedScopeTest.cs#L127");
         }
 
 

--- a/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Repositories.Async;
+
+namespace Octopus.Client.Tests.Repositories.Async
+{
+    [TestFixture]
+    public class BasicRepositoryFixture
+    {
+        private TestSpaceResourceAsyncRepository subject;
+        private IOctopusAsyncRepository mockRepo;
+        private SpaceResource defaultSpace;
+
+        [SetUp]
+        public void Setup()
+        {
+            mockRepo = Substitute.For<IOctopusAsyncRepository>();
+            
+            subject = new TestSpaceResourceAsyncRepository(mockRepo, "", async repo => await Task.FromResult(""));
+            
+            defaultSpace = new SpaceResource
+            {
+                Id = "Spaces-1",
+                Name = "Default Space",
+                IsDefault = true
+            };
+            mockRepo.Scope.Returns(RepositoryScope.ForSpace(defaultSpace));
+        }
+        
+        [Test]
+        public void Create_ResourceWithImpliedSpace_DefaultRepoScopeSetsTheSpace()
+        {
+            var resource = CreateProjectResourceForSpace(null);
+            Assert.DoesNotThrow(() => subject.Create(resource));
+
+            resource.SpaceId.Should()
+                .Be(defaultSpace.Id, $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
+        }
+        
+        [Test]
+        public void Create_ResourceWithImpliedSpace_RepoScopeSetsTheSpace()
+        {
+            SetupRepositoryToUseADifferentSpace();
+            var resource = CreateProjectResourceForSpace(null);
+            Assert.DoesNotThrow(() => subject.Create(resource));
+
+            resource.SpaceId.Should()
+                .Be("Spaces-2", $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
+        }
+
+        [Test]
+        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
+        {
+            var resource = CreateProjectResourceForSpace("Spaces-2");
+            Action activityUnderTest = () => subject.Create(resource).Wait();
+            
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
+        }
+
+
+        [Test]
+        public void Create_ResourceInExplicitSpace_MatchingSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(defaultSpace.Id);
+            Assert.DoesNotThrow(() => subject.Create(resource).Wait());
+            resource.SpaceId.Should()
+                .Be(defaultSpace.Id, $"the space resource {nameof(IHaveSpaceResource.SpaceId)} shouldn't have changed");
+        }
+        
+        [Test]
+        public void Update_ResourceInExplicitSpace_MatchingSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(defaultSpace.Id);
+            
+            Assert.DoesNotThrow(() => subject.Modify(resource).Wait());
+            resource.SpaceId.Should()
+                .Be(defaultSpace.Id, $"the space resource {nameof(IHaveSpaceResource.SpaceId)} shouldn't have changed");
+        }
+        
+        [Test]
+        public void Update_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
+        {
+            var resource = CreateProjectResourceForSpace("Spaces-2");
+            Action activityUnderTest = () => subject.Modify(resource).Wait();
+            
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
+        }
+
+        [Test]
+        public void Update_ResourceWithImpliedSpace_DefaultSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(null);
+            Assert.DoesNotThrow(() => subject.Modify(resource).Wait());
+            
+        }
+        
+        [Test]
+        public void Update_ResourceWithImpliedSpace_AnyOtherSpaceShouldThrow()
+        {
+            SetupRepositoryToUseADifferentSpace();
+            var resource = CreateProjectResourceForSpace(null);
+            Action activityUnderTest = () => subject.Modify(resource).Wait();
+            
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-2, or use a repository that is scoped to the default space.");
+        }
+
+        [Test]
+        public void Delete_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
+        {
+            var resource = CreateProjectResourceForSpace("Spaces-2");
+            Action activityUnderTest = () => subject.Delete(resource).Wait();
+            
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
+        }
+        
+        [Test]
+        public void Delete_ResourceInExplicitSpace_MatchingSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(defaultSpace.Id);
+            Assert.DoesNotThrow(() => subject.Delete(resource).Wait());
+        }
+        
+        [Test]
+        public void Delete_ResourceWithImpliedSpace_DefaultSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(null);
+            Assert.DoesNotThrow(() => subject.Delete(resource).Wait());
+
+        }
+        
+        [Test]
+        public void Delete_ResourceWithImpliedSpace_AnyOtherSpaceRepoShouldThrow()
+        {
+            SetupRepositoryToUseADifferentSpace();
+            var resource = CreateProjectResourceForSpace(null);
+            Action activityUnderTest = () => subject.Delete(resource).Wait();
+
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-2, or use a repository that is scoped to the default space.");
+        }
+
+        private void SetupRepositoryToUseADifferentSpace()
+        {
+            mockRepo.Scope.Returns(RepositoryScope.ForSpace(new SpaceResource {Id = "Spaces-2", IsDefault = false}));
+        }
+
+        private ProjectResource CreateProjectResourceForSpace(string spaceId)
+        {
+            return new ProjectResource
+            {
+                Name = "Foo", 
+                SpaceId = spaceId, 
+                Links = new LinkCollection { {"Self", ""} }
+            };
+        }
+
+        private class TestSpaceResourceAsyncRepository : BasicRepository<ProjectResource>
+        {
+            public TestSpaceResourceAsyncRepository(IOctopusAsyncRepository repository, string collectionLinkName, Func<IOctopusAsyncRepository, Task<string>> getCollectionLinkName = null) : base(repository, collectionLinkName, getCollectionLinkName)
+            {
+            }
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
@@ -1,0 +1,178 @@
+using System;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.Core;
+using NUnit.Framework;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Repositories;
+
+namespace Octopus.Client.Tests.Repositories
+{
+    [TestFixture]
+    public class BasicRepositoryFixture
+    {
+        private TestSpaceResourceRepository subject;
+        private IOctopusRepository mockRepo;
+        private SpaceResource defaultSpace;
+
+        [SetUp]
+        public void Setup()
+        {
+            mockRepo = Substitute.For<IOctopusRepository>();
+            
+            subject = new TestSpaceResourceRepository(mockRepo, "", repo => "");
+            
+            defaultSpace = new SpaceResource
+            {
+                Id = "Spaces-1",
+                Name = "Default Space",
+                IsDefault = true
+            };
+            mockRepo.Scope.Returns(RepositoryScope.ForSpace(defaultSpace));
+        }
+        
+        [Test]
+        public void Create_ResourceWithImpliedSpace_DefaultRepoScopeSetsTheSpace()
+        {
+            var resource = CreateProjectResourceForSpace(null);
+            Assert.DoesNotThrow(() => subject.Create(resource));
+
+            resource.SpaceId.Should()
+                .Be(defaultSpace.Id, $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
+        }
+        
+        [Test]
+        public void Create_ResourceWithImpliedSpace_RepoScopeSetsTheSpace()
+        {
+            SetupRepositoryToUseADifferentSpace();
+            var resource = CreateProjectResourceForSpace(null);
+            Assert.DoesNotThrow(() => subject.Create(resource));
+
+            resource.SpaceId.Should()
+                .Be("Spaces-2", $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
+        }
+
+        [Test]
+        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
+        {
+            var resource = CreateProjectResourceForSpace("Spaces-2");
+            Action activityUnderTest = () => subject.Create(resource);
+            
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
+        }
+
+
+        [Test]
+        public void Create_ResourceInExplicitSpace_MatchingSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(defaultSpace.Id);
+            Assert.DoesNotThrow(() => subject.Create(resource));
+            resource.SpaceId.Should()
+                .Be(defaultSpace.Id, $"the space resource {nameof(IHaveSpaceResource.SpaceId)} shouldn't have changed");
+        }
+        
+        [Test]
+        public void Update_ResourceInExplicitSpace_MatchingSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(defaultSpace.Id);
+            
+            Assert.DoesNotThrow(() => subject.Modify(resource));
+            resource.SpaceId.Should()
+                .Be(defaultSpace.Id, $"the space resource {nameof(IHaveSpaceResource.SpaceId)} shouldn't have changed");
+        }
+        
+        [Test]
+        public void Update_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
+        {
+            var resource = CreateProjectResourceForSpace("Spaces-2");
+            Action activityUnderTest = () => subject.Modify(resource);
+            
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
+        }
+
+        [Test]
+        public void Update_ResourceWithImpliedSpace_DefaultSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(null);
+            Assert.DoesNotThrow(() => subject.Modify(resource));
+            
+        }
+        
+        [Test]
+        public void Update_ResourceWithImpliedSpace_AnyOtherSpaceShouldThrow()
+        {
+            SetupRepositoryToUseADifferentSpace();
+            var resource = CreateProjectResourceForSpace(null);
+            Action activityUnderTest = () => subject.Modify(resource);
+            
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-2, or use a repository that is scoped to the default space.");
+        }
+
+        [Test]
+        public void Delete_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
+        {
+            var resource = CreateProjectResourceForSpace("Spaces-2");
+            Action activityUnderTest = () => subject.Delete(resource);
+            
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
+        }
+        
+        [Test]
+        public void Delete_ResourceInExplicitSpace_MatchingSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(defaultSpace.Id);
+            Assert.DoesNotThrow(() => subject.Delete(resource));
+        }
+        
+        [Test]
+        public void Delete_ResourceWithImpliedSpace_DefaultSpaceRepoIsOk()
+        {
+            var resource = CreateProjectResourceForSpace(null);
+            Assert.DoesNotThrow(() => subject.Delete(resource));
+
+        }
+        
+        [Test]
+        public void Delete_ResourceWithImpliedSpace_AnyOtherSpaceRepoShouldThrow()
+        {
+            SetupRepositoryToUseADifferentSpace();
+            var resource = CreateProjectResourceForSpace(null);
+            Action activityUnderTest = () => subject.Delete(resource);
+
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-2, or use a repository that is scoped to the default space.");
+        }
+
+        private void SetupRepositoryToUseADifferentSpace()
+        {
+            mockRepo.Scope.Returns(RepositoryScope.ForSpace(new SpaceResource {Id = "Spaces-2", IsDefault = false}));
+        }
+
+        private ProjectResource CreateProjectResourceForSpace(string spaceId)
+        {
+            return new ProjectResource
+            {
+                Name = "Foo", 
+                SpaceId = spaceId, 
+                Links = new LinkCollection { {"Self", ""} }
+            };
+        }
+
+        private class TestSpaceResourceRepository : BasicRepository<ProjectResource>
+        {
+            public TestSpaceResourceRepository(IOctopusRepository repository, string collectionLinkName, Func<IOctopusRepository, string> getCollectionLinkName = null) : base(repository, collectionLinkName, getCollectionLinkName)
+            {
+            }
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
@@ -32,33 +32,25 @@ namespace Octopus.Client.Tests.Repositories
         }
 
         [Test]
-        public void Create_ResourceWithNoSpaceId_DefaultRepoScopeSetsTheSpace()
-        {
-            var resource = CreateProjectResourceForSpace(null);
-            Assert.DoesNotThrow(() => subject.Create(resource));
-
-            resource.SpaceId.Should()
-                .Be(defaultSpace.Id, $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
-        }
-        
-        [Test]
         public void Create_ResourceWithNoSpaceId_RepoScopeSetsTheSpace()
         {
-            SetupRepositoryToUseADifferentSpace();
             var resource = CreateProjectResourceForSpace(null);
             Assert.DoesNotThrow(() => subject.Create(resource));
 
-            resource.SpaceId.Should()
-                .Be("Spaces-2", $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
+            resource.SpaceId
+                .Should().Be(defaultSpace.Id, $"the repository scope will be used to enrich the spaceResource's {nameof(IHaveSpaceResource.SpaceId)} property");
         }
+        
 
         [Test]
-        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldOverwrite()
+        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
         {
             var resource = CreateProjectResourceForSpace("Spaces-2");
-            Assert.DoesNotThrow(() => subject.Create(resource));
+            Action activityUnderTest= () => subject.Create(resource);
 
-            resource.SpaceId.Should().Be(defaultSpace.Id, because: "https://github.com/OctopusDeploy/OctopusDeploy/blob/ff86277e425b2f2f7e5093a01cc7bc948bfbfca3/source/Octopus.IntegrationTests/Octopus.Server/Spaces/MixedScopeTest.cs#L127");
+            activityUnderTest
+                .ShouldThrow<ArgumentException>()
+                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
         }
 
 

--- a/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
@@ -1,7 +1,6 @@
 using System;
 using FluentAssertions;
 using NSubstitute;
-using NSubstitute.Core;
 using NUnit.Framework;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Model;
@@ -31,9 +30,9 @@ namespace Octopus.Client.Tests.Repositories
             };
             mockRepo.Scope.Returns(RepositoryScope.ForSpace(defaultSpace));
         }
-        
+
         [Test]
-        public void Create_ResourceWithImpliedSpace_DefaultRepoScopeSetsTheSpace()
+        public void Create_ResourceWithNoSpaceId_DefaultRepoScopeSetsTheSpace()
         {
             var resource = CreateProjectResourceForSpace(null);
             Assert.DoesNotThrow(() => subject.Create(resource));
@@ -43,7 +42,7 @@ namespace Octopus.Client.Tests.Repositories
         }
         
         [Test]
-        public void Create_ResourceWithImpliedSpace_RepoScopeSetsTheSpace()
+        public void Create_ResourceWithNoSpaceId_RepoScopeSetsTheSpace()
         {
             SetupRepositoryToUseADifferentSpace();
             var resource = CreateProjectResourceForSpace(null);
@@ -96,7 +95,7 @@ namespace Octopus.Client.Tests.Repositories
         }
 
         [Test]
-        public void Update_ResourceWithImpliedSpace_DefaultSpaceRepoIsOk()
+        public void Update_ResourceWithNoSpaceId_DefaultSpaceRepoIsOk()
         {
             var resource = CreateProjectResourceForSpace(null);
             Assert.DoesNotThrow(() => subject.Modify(resource));
@@ -104,7 +103,7 @@ namespace Octopus.Client.Tests.Repositories
         }
         
         [Test]
-        public void Update_ResourceWithImpliedSpace_AnyOtherSpaceShouldThrow()
+        public void Update_ResourceWithNoSpaceId_AnyOtherSpaceShouldThrow()
         {
             SetupRepositoryToUseADifferentSpace();
             var resource = CreateProjectResourceForSpace(null);
@@ -134,7 +133,7 @@ namespace Octopus.Client.Tests.Repositories
         }
         
         [Test]
-        public void Delete_ResourceWithImpliedSpace_DefaultSpaceRepoIsOk()
+        public void Delete_ResourceWithNoSpaceId_DefaultSpaceRepoIsOk()
         {
             var resource = CreateProjectResourceForSpace(null);
             Assert.DoesNotThrow(() => subject.Delete(resource));
@@ -142,7 +141,7 @@ namespace Octopus.Client.Tests.Repositories
         }
         
         [Test]
-        public void Delete_ResourceWithImpliedSpace_AnyOtherSpaceRepoShouldThrow()
+        public void Delete_ResourceWithNoSpaceId_AnyOtherSpaceRepoShouldThrow()
         {
             SetupRepositoryToUseADifferentSpace();
             var resource = CreateProjectResourceForSpace(null);

--- a/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
@@ -53,14 +53,12 @@ namespace Octopus.Client.Tests.Repositories
         }
 
         [Test]
-        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldThrow()
+        public void Create_ResourceInExplicitSpace_NonMatchingSpaceRepoShouldOverwrite()
         {
             var resource = CreateProjectResourceForSpace("Spaces-2");
-            Action activityUnderTest = () => subject.Create(resource);
-            
-            activityUnderTest
-                .ShouldThrow<ArgumentException>()
-                .WithMessage("The resource has a different space specified than the one specified by the repository scope. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
+            Assert.DoesNotThrow(() => subject.Create(resource));
+
+            resource.SpaceId.Should().Be(defaultSpace.Id, because: "https://github.com/OctopusDeploy/OctopusDeploy/blob/ff86277e425b2f2f7e5093a01cc7bc948bfbfca3/source/Octopus.IntegrationTests/Octopus.Server/Spaces/MixedScopeTest.cs#L127");
         }
 
 

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -33,16 +33,13 @@ namespace Octopus.Client.Repositories.Async
         public IOctopusAsyncClient Client { get; }
         public IOctopusAsyncRepository Repository { get; }
 
-        private void AssertSpaceIdMatchesResource(TResource resource, bool isEmptySpaceIdAllowed = false)
+        private void AssertSpaceIdMatchesResource(TResource resource)
         {
             if (resource is IHaveSpaceResource spaceResource)
             {
                 Repository.Scope
                     .Apply(space =>
                         {
-                            if (isEmptySpaceIdAllowed && string.IsNullOrWhiteSpace(spaceResource.SpaceId))
-                                return (string) null;
-                            
                             var errorMessageTemplate = $"The resource has a different space specified than the one specified by the repository scope. Either change the {nameof(IHaveSpaceResource.SpaceId)} on the resource to {space.Id}, or use a repository that is scoped to";
             
                             if (string.IsNullOrWhiteSpace(spaceResource.SpaceId) && !space.IsDefault)
@@ -63,7 +60,6 @@ namespace Octopus.Client.Repositories.Async
         public virtual async Task<TResource> Create(TResource resource, object pathParameters = null)
         {
             var link = await ResolveLink().ConfigureAwait(false);
-            AssertSpaceIdMatchesResource(resource, true);
             EnrichSpaceId(resource);
             return await Client.Create(link, resource, pathParameters).ConfigureAwait(false);
         }

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -31,7 +31,7 @@ namespace Octopus.Client.Repositories
 
         public IOctopusClient Client => client;
 
-        private void AssertSpaceIdMatchesResource(TResource resource)
+        private void AssertSpaceIdMatchesResource(TResource resource, bool isEmptySpaceAllowed = false)
         {
             if (resource is IHaveSpaceResource spaceResource)
             {
@@ -39,7 +39,10 @@ namespace Octopus.Client.Repositories
                     .Apply(space =>
                         {
                             var errorMessageTemplate = $"The resource has a different space specified than the one specified by the repository scope. Either change the {nameof(IHaveSpaceResource.SpaceId)} on the resource to {space.Id}, or use a repository that is scoped to";
-            
+
+                            if (isEmptySpaceAllowed && string.IsNullOrWhiteSpace(spaceResource.SpaceId))
+                                return (string) null;
+                            
                             if (string.IsNullOrWhiteSpace(spaceResource.SpaceId) && !space.IsDefault)
                                 throw new ArgumentException(
                                     $"{errorMessageTemplate} the default space.");
@@ -58,7 +61,8 @@ namespace Octopus.Client.Repositories
         public virtual TResource Create(TResource resource, object pathParameters = null)
         {
             if (resource == null) throw new ArgumentNullException(nameof(resource));
-                
+            AssertSpaceIdMatchesResource(resource, isEmptySpaceAllowed: true);
+            
             var link = ResolveLink();
             EnrichSpaceId(resource);
             return client.Create(link, resource, pathParameters);

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -31,16 +31,13 @@ namespace Octopus.Client.Repositories
 
         public IOctopusClient Client => client;
 
-        private void AssertSpaceIdMatchesResource(TResource resource, bool isEmptySpaceIdAllowed = false)
+        private void AssertSpaceIdMatchesResource(TResource resource)
         {
             if (resource is IHaveSpaceResource spaceResource)
             {
                 Repository.Scope
                     .Apply(space =>
                         {
-                            if (isEmptySpaceIdAllowed && string.IsNullOrWhiteSpace(spaceResource.SpaceId))
-                                return (string) null;
-                            
                             var errorMessageTemplate = $"The resource has a different space specified than the one specified by the repository scope. Either change the {nameof(IHaveSpaceResource.SpaceId)} on the resource to {space.Id}, or use a repository that is scoped to";
             
                             if (string.IsNullOrWhiteSpace(spaceResource.SpaceId) && !space.IsDefault)
@@ -61,7 +58,6 @@ namespace Octopus.Client.Repositories
         public virtual TResource Create(TResource resource, object pathParameters = null)
         {
             if (resource == null) throw new ArgumentNullException(nameof(resource));
-            AssertSpaceIdMatchesResource(resource, true);
                 
             var link = ResolveLink();
             EnrichSpaceId(resource);

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -59,7 +59,6 @@ namespace Octopus.Client.Repositories
         {
             if (resource == null) throw new ArgumentNullException(nameof(resource));
             var link = ResolveLink();
-            AssertSpaceIdMatchesResource(resource);
             EnrichSpaceId(resource);
             return client.Create(link, resource, pathParameters);
         }

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -31,15 +31,18 @@ namespace Octopus.Client.Repositories
 
         public IOctopusClient Client => client;
 
-        private void AssertSpaceIdMatchesResource(TResource resource)
+        private void AssertSpaceIdMatchesResource(TResource resource, bool isEmptySpaceIdAllowed = false)
         {
             if (resource is IHaveSpaceResource spaceResource)
             {
                 Repository.Scope
                     .Apply(space =>
                         {
+                            if (isEmptySpaceIdAllowed && string.IsNullOrWhiteSpace(spaceResource.SpaceId))
+                                return (string) null;
+                            
                             var errorMessageTemplate = $"The resource has a different space specified than the one specified by the repository scope. Either change the {nameof(IHaveSpaceResource.SpaceId)} on the resource to {space.Id}, or use a repository that is scoped to";
-
+            
                             if (string.IsNullOrWhiteSpace(spaceResource.SpaceId) && !space.IsDefault)
                                 throw new ArgumentException(
                                     $"{errorMessageTemplate} the default space.");
@@ -58,6 +61,8 @@ namespace Octopus.Client.Repositories
         public virtual TResource Create(TResource resource, object pathParameters = null)
         {
             if (resource == null) throw new ArgumentNullException(nameof(resource));
+            AssertSpaceIdMatchesResource(resource, true);
+                
             var link = ResolveLink();
             EnrichSpaceId(resource);
             return client.Create(link, resource, pathParameters);


### PR DESCRIPTION
This PR attempts to ensure that the user has good advice if they try and modify a resource in a different scope to the repository they are working with.