### PR TITLE
Resource changes to reflect machine policy model changes

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2653,6 +2653,11 @@ Octopus.Client.Model
   }
   HealthCheckType
   {
+      RunScript = 0
+      OnlyConnectivity = 1
+  }
+  HealthCheckType
+  {
       FullHealthCheck = 0
       ConnectionTest = 1
   }
@@ -2882,9 +2887,12 @@ Octopus.Client.Model
   {
     .ctor()
     .ctor(Octopus.Client.Model.MachineScriptPolicy, Octopus.Client.Model.MachineScriptPolicy)
+    Octopus.Client.Model.MachineScriptPolicy BashHealthCheckPolicy { get; set; }
     TimeSpan HealthCheckInterval { get; set; }
-    Octopus.Client.Model.MachineScriptPolicy SshEndpointHealthCheckPolicy { get; set; }
-    Octopus.Client.Model.MachineScriptPolicy TentacleEndpointHealthCheckPolicy { get; set; }
+    Octopus.Client.Model.HealthCheckType HealthCheckType { get; set; }
+    Octopus.Client.Model.MachineScriptPolicy PowerShellHealthCheckPolicy { get; set; }
+    Octopus.Client.Model.MachineScriptPolicy SshEndpointHealthCheckPolicy { get; }
+    Octopus.Client.Model.MachineScriptPolicy TentacleEndpointHealthCheckPolicy { get; }
   }
   MachineModelHealthStatus
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2666,6 +2666,11 @@ Octopus.Client.Model
   }
   HealthCheckType
   {
+      RunScript = 0
+      OnlyConnectivity = 1
+  }
+  HealthCheckType
+  {
       FullHealthCheck = 0
       ConnectionTest = 1
   }
@@ -2895,9 +2900,12 @@ Octopus.Client.Model
   {
     .ctor()
     .ctor(Octopus.Client.Model.MachineScriptPolicy, Octopus.Client.Model.MachineScriptPolicy)
+    Octopus.Client.Model.MachineScriptPolicy BashHealthCheckPolicy { get; set; }
     TimeSpan HealthCheckInterval { get; set; }
-    Octopus.Client.Model.MachineScriptPolicy SshEndpointHealthCheckPolicy { get; set; }
-    Octopus.Client.Model.MachineScriptPolicy TentacleEndpointHealthCheckPolicy { get; set; }
+    Octopus.Client.Model.HealthCheckType HealthCheckType { get; set; }
+    Octopus.Client.Model.MachineScriptPolicy PowerShellHealthCheckPolicy { get; set; }
+    Octopus.Client.Model.MachineScriptPolicy SshEndpointHealthCheckPolicy { get; }
+    Octopus.Client.Model.MachineScriptPolicy TentacleEndpointHealthCheckPolicy { get; }
   }
   MachineModelHealthStatus
   {

--- a/source/Octopus.Client/Model/MachineHealthCheckPolicy.cs
+++ b/source/Octopus.Client/Model/MachineHealthCheckPolicy.cs
@@ -5,22 +5,35 @@ namespace Octopus.Client.Model
 {
     public class MachineHealthCheckPolicy
     {
-        public MachineScriptPolicy TentacleEndpointHealthCheckPolicy { get; set; }
-        public MachineScriptPolicy SshEndpointHealthCheckPolicy { get; set; }
+        [Obsolete("Use " + nameof(PowerShellHealthCheckPolicy) + " instead.")]
+        public MachineScriptPolicy TentacleEndpointHealthCheckPolicy => PowerShellHealthCheckPolicy;
+        public MachineScriptPolicy PowerShellHealthCheckPolicy { get; set; }
+        [Obsolete("Use " + nameof(BashHealthCheckPolicy) + " instead.")]
+        public MachineScriptPolicy SshEndpointHealthCheckPolicy => BashHealthCheckPolicy;
+        public MachineScriptPolicy BashHealthCheckPolicy { get; set; }
         public TimeSpan HealthCheckInterval { get; set; }
+
+        public HealthCheckType HealthCheckType { get; set; }
 
         public MachineHealthCheckPolicy()
         {
-            TentacleEndpointHealthCheckPolicy = new MachineScriptPolicy();
-            SshEndpointHealthCheckPolicy = new MachineScriptPolicy();
+            PowerShellHealthCheckPolicy = new MachineScriptPolicy();
+            BashHealthCheckPolicy = new MachineScriptPolicy();
             HealthCheckInterval = TimeSpan.FromHours(1);
+            HealthCheckType = HealthCheckType.RunScript;
         }
 
         [JsonConstructor]
-        public MachineHealthCheckPolicy(MachineScriptPolicy tentacleEndpointHealthCheckPolicy, MachineScriptPolicy sshEndpointHealthCheckPolicy)
+        public MachineHealthCheckPolicy(MachineScriptPolicy powerShellHealthCheckPolicy, MachineScriptPolicy bashHealthCheckPolicy)
         {
-            TentacleEndpointHealthCheckPolicy = tentacleEndpointHealthCheckPolicy;
-            SshEndpointHealthCheckPolicy = sshEndpointHealthCheckPolicy;
+            PowerShellHealthCheckPolicy = powerShellHealthCheckPolicy;
+            BashHealthCheckPolicy = bashHealthCheckPolicy;
         }
+    }
+
+    public enum HealthCheckType
+    {
+        RunScript,
+        OnlyConnectivity
     }
 }

--- a/source/Octopus.Client/Model/MachineScriptPolicy.cs
+++ b/source/Octopus.Client/Model/MachineScriptPolicy.cs
@@ -1,10 +1,13 @@
 ﻿
+using System;
+
 namespace Octopus.Client.Model
 {
     public enum MachineScriptPolicyRunType : int
     {
         InheritFromDefault = 0,
         Inline,
+        [Obsolete("The connectivity setting is now configured per " + nameof(MachineHealthCheckPolicy) + " using the property " + nameof(MachineHealthCheckPolicy.HealthCheckType), true)]
         OnlyConnectivity
     }
 


### PR DESCRIPTION
I'm not sure about the naming of `HealthCheckType` as a `HealthCheckType` already exists.

Would `MachinePolicyHealthCheckType` work better?

Relates to https://github.com/OctopusDeploy/OctopusDeploy/pull/3724

This is a breaking change.