### PR TITLE
Exposed server health status directly

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6122,7 +6122,7 @@ Octopus.Client.Repositories
   }
   interface IServerStatusRepository
   {
-    Octopus.Client.Model.ServerStatusHealthResource GetServerHealth(Octopus.Client.Model.ServerStatusResource)
+    Octopus.Client.Model.ServerStatusHealthResource GetServerHealth()
     Octopus.Client.Model.ServerStatusResource GetServerStatus()
     Octopus.Client.Model.SystemInfoResource GetSystemInfo(Octopus.Client.Model.ServerStatusResource)
   }
@@ -6720,7 +6720,7 @@ Octopus.Client.Repositories.Async
   }
   interface IServerStatusRepository
   {
-    Task<ServerStatusHealthResource> GetServerHealth(Octopus.Client.Model.ServerStatusResource)
+    Task<ServerStatusHealthResource> GetServerHealth()
     Task<ServerStatusResource> GetServerStatus()
     Task<SystemInfoResource> GetSystemInfo(Octopus.Client.Model.ServerStatusResource)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6144,7 +6144,7 @@ Octopus.Client.Repositories
   }
   interface IServerStatusRepository
   {
-    Octopus.Client.Model.ServerStatusHealthResource GetServerHealth(Octopus.Client.Model.ServerStatusResource)
+    Octopus.Client.Model.ServerStatusHealthResource GetServerHealth()
     Octopus.Client.Model.ServerStatusResource GetServerStatus()
     Octopus.Client.Model.SystemInfoResource GetSystemInfo(Octopus.Client.Model.ServerStatusResource)
   }
@@ -6742,7 +6742,7 @@ Octopus.Client.Repositories.Async
   }
   interface IServerStatusRepository
   {
-    Task<ServerStatusHealthResource> GetServerHealth(Octopus.Client.Model.ServerStatusResource)
+    Task<ServerStatusHealthResource> GetServerHealth()
     Task<ServerStatusResource> GetServerStatus()
     Task<SystemInfoResource> GetSystemInfo(Octopus.Client.Model.ServerStatusResource)
   }

--- a/source/Octopus.Client/Repositories/Async/ServerStatusRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ServerStatusRepository.cs
@@ -8,7 +8,7 @@ namespace Octopus.Client.Repositories.Async
     {
         Task<ServerStatusResource> GetServerStatus();
         Task<SystemInfoResource> GetSystemInfo(ServerStatusResource status);
-        Task<ServerStatusHealthResource> GetServerHealth(ServerStatusResource status);
+        Task<ServerStatusHealthResource> GetServerHealth();
     }
 
     class ServerStatusRepository : BasicRepository<ServerStatusResource>, IServerStatusRepository
@@ -29,10 +29,9 @@ namespace Octopus.Client.Repositories.Async
             return Client.Get<SystemInfoResource>(status.Link("SystemInfo"));
         }
 
-        public Task<ServerStatusHealthResource> GetServerHealth(ServerStatusResource status)
+        public async Task<ServerStatusHealthResource> GetServerHealth()
         {
-            if (status == null) throw new ArgumentNullException("status");
-            return Client.Get<ServerStatusHealthResource>(status.Link("Health"));
+            return await Client.Get<ServerStatusHealthResource>(await Repository.Link("ServerHealthStatus").ConfigureAwait(false)).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/ServerStatusRepository.cs
+++ b/source/Octopus.Client/Repositories/ServerStatusRepository.cs
@@ -7,7 +7,7 @@ namespace Octopus.Client.Repositories
     {
         ServerStatusResource GetServerStatus();
         SystemInfoResource GetSystemInfo(ServerStatusResource status);
-        ServerStatusHealthResource GetServerHealth(ServerStatusResource status);
+        ServerStatusHealthResource GetServerHealth();
     }
 
     class ServerStatusRepository : BasicRepository<ServerStatusResource>, IServerStatusRepository
@@ -22,10 +22,9 @@ namespace Octopus.Client.Repositories
             return Client.Get<ServerStatusResource>(Repository.Link("ServerStatus"));
         }
 
-        public ServerStatusHealthResource GetServerHealth(ServerStatusResource status)
+        public ServerStatusHealthResource GetServerHealth()
         {
-            if (status == null) throw new ArgumentNullException("status");
-            return Client.Get<ServerStatusHealthResource>(status.Link("Health"));
+            return Client.Get<ServerStatusHealthResource>(Repository.Link("ServerHealthStatus"));
         }
 
         public SystemInfoResource GetSystemInfo(ServerStatusResource status)


### PR DESCRIPTION
Details: https://github.com/OctopusDeploy/OctopusDeploy/pull/3710
Technically speaking this is a breaking change but this C# API was introduced by me only a few weeks ago and I don't expect people to use it.