### PR TITLE
Support deserializing package publish date using multiple formats

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3344,7 +3344,7 @@ Octopus.Client.Model
     String NuGetPackageId { get; set; }
     String PackageId { get; set; }
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource PackageMetadata { get; set; }
-    String Published { get; set; }
+    Nullable<DateTimeOffset> Published { get; set; }
     String ReleaseNotes { get; set; }
     String Summary { get; set; }
     String Title { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3362,7 +3362,7 @@ Octopus.Client.Model
     String NuGetPackageId { get; set; }
     String PackageId { get; set; }
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource PackageMetadata { get; set; }
-    String Published { get; set; }
+    Nullable<DateTimeOffset> Published { get; set; }
     String ReleaseNotes { get; set; }
     String Summary { get; set; }
     String Title { get; set; }

--- a/source/Octopus.Client.Tests/Serialization/MultiIsoDateTimeFormatConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/MultiIsoDateTimeFormatConverterFixture.cs
@@ -1,0 +1,49 @@
+using System;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Octopus.Client.Serialization;
+
+namespace Octopus.Client.Tests.Serialization
+{
+    [TestFixture]
+    public class MultiIsoDateTimeFormatConverterFixture
+    {
+        readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings()
+        {
+            Converters = { 
+                new MultiIsoDateTimeFormatConverter("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffK", "dddd, dd MMMM yyyy h:mm tt zzz" ),
+            },
+        };
+
+        static readonly DateTimeOffset selectedDate = new DateTimeOffset(2018, 11, 09, 21, 09, 00,  TimeSpan.FromHours(1));
+        static readonly DummyDateClass testDateObj = new DummyDateClass() { Event = selectedDate };
+        
+        
+        [Test]
+        public void DateSerializesUsingDefaultFormat()
+        {
+            var raw = JsonConvert.SerializeObject(testDateObj, serializerSettings);
+            StringAssert.Contains("2018-11-09T21:09:00.000+01:00", raw);
+        }
+        
+        [Test]
+        public void DeserializesBothFormats()
+        {
+            var deserialized1 = JsonConvert.DeserializeObject<DummyDateClass>("{\"Event\":\"2018-11-09T21:09:00.000+01:00\"}", serializerSettings);
+            var deserialized2 = JsonConvert.DeserializeObject<DummyDateClass>("{\"Event\":\"Friday, 09 November 2018 9:09 PM +01:00\"}", serializerSettings);
+
+            Assert.AreEqual(deserialized1.Event.Value.ToLocalTime(), deserialized2.Event.Value.ToLocalTime());
+        }
+
+        [Test]
+        public void DeserializesNull()
+        {
+            var deserialized = JsonConvert.DeserializeObject<DummyDateClass>("{\"Event\":null}", serializerSettings);
+            Assert.IsFalse(deserialized.Event.HasValue);
+        }
+        
+        class DummyDateClass{
+            public DateTimeOffset? Event {get;set;}
+        }
+    }
+}

--- a/source/Octopus.Client/Model/PackageResource.cs
+++ b/source/Octopus.Client/Model/PackageResource.cs
@@ -26,7 +26,7 @@ namespace Octopus.Client.Model
         
         public string Version { get; set; }
         public string Description { get; set; }
-        public string Published { get; set; }
+        public DateTimeOffset? Published { get; set; }
         public string ReleaseNotes { get; set; }
         public string FileExtension { get; set; }
 

--- a/source/Octopus.Client/Serialization/JsonSerialization.cs
+++ b/source/Octopus.Client/Serialization/JsonSerialization.cs
@@ -21,7 +21,8 @@ namespace Octopus.Client.Serialization
                 Converters = new JsonConverterCollection
                 {
                     new StringEnumConverter(),
-                    new IsoDateTimeConverter {DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffK"},
+                    new MultiIsoDateTimeFormatConverter("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffK", 
+                        "dddd, dd MMMM yyyy h:mm tt zzz" ),
                     new ControlConverter(),
                     new EndpointConverter(),
                     new AccountConverter(),

--- a/source/Octopus.Client/Serialization/MultiIsoDateTimeFormatConverter.cs
+++ b/source/Octopus.Client/Serialization/MultiIsoDateTimeFormatConverter.cs
@@ -6,6 +6,12 @@ using Newtonsoft.Json.Converters;
 
 namespace Octopus.Client.Serialization
 {
+    /// <summary>
+    /// Multiple dates are required to be parseable to allow the new client
+    /// (which now models the package publish date property as a DateTimeOffset instead of a string)
+    /// to be both forwards and backwards compatible with the new format being returned
+    /// https://github.com/OctopusDeploy/Issues/issues/5535 
+    /// </summary>
     public class MultiIsoDateTimeFormatConverter : JsonConverter
     {
         public MultiIsoDateTimeFormatConverter(string defaultFormat, params string[] additionalReadFormats)

--- a/source/Octopus.Client/Serialization/MultiIsoDateTimeFormatConverter.cs
+++ b/source/Octopus.Client/Serialization/MultiIsoDateTimeFormatConverter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Octopus.Client.Serialization
+{
+    public class MultiIsoDateTimeFormatConverter : JsonConverter
+    {
+        public MultiIsoDateTimeFormatConverter(string defaultFormat, params string[] additionalReadFormats)
+        {
+            converters = new List<JsonConverter>();
+            converters.Add(new IsoDateTimeConverter(){ DateTimeFormat = defaultFormat });
+            converters.AddRange(additionalReadFormats.Select(format => new IsoDateTimeConverter() {DateTimeFormat = format}));
+        }
+        private readonly List<JsonConverter> converters;
+            
+        private JsonConverter DefaultConverter => converters[0];
+            
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            DefaultConverter.WriteJson(writer, value, serializer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            // Try all converters catching any errors, then let any errors from the last converter bubble up
+            for (var i = 0; i < converters.Count - 1; i++)
+            {
+                try
+                {
+                    return converters[i].ReadJson(reader, objectType, existingValue, serializer);
+                }
+                catch
+                {
+                    // Try next converter
+                }
+            }
+
+            return  converters[ converters.Count-1].ReadJson(reader, objectType, existingValue, serializer);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return DefaultConverter.CanConvert(objectType);
+        }
+    }
+}


### PR DESCRIPTION
This change ensures that the `PackageResource` model matches what the Octopus server is now returning for the `PublishDate` which is a nullable DateTimeOffset.  Related server change https://github.com/OctopusDeploy/OctopusDeploy/pull/3937

For older clients reading the server, there is no real breaking change since they are just reading string. For new clients reading old servers,  the multi-deserialization logic provided in this PR will convert both new server or old server responses to a DateTimeOffset property.
