### PR TITLE
Overwrite mode

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3270,6 +3270,12 @@ Octopus.Client.Model
     Octopus.Client.Model.LeadershipRank Rank { get; set; }
     Int32 RunningTaskCount { get; set; }
   }
+  OverwriteMode
+  {
+      FailIfExists = 0
+      OverwriteExisting = 1
+      IgnoreIfExists = 2
+  }
   PackageAcquisitionLocation
   {
       Server = 0
@@ -5884,6 +5890,8 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean, Boolean)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
   }
   interface ICanExtendSpaceContext`1
   {
@@ -6124,6 +6132,7 @@ Octopus.Client.Repositories
   interface IPackageMetadataRepository
   {
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Get(String)
+    Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata)
   }
   interface IPaginate`1
@@ -6420,6 +6429,7 @@ Octopus.Client.Repositories
     .ctor(Octopus.Client.IOctopusRepository)
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Get(String)
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata)
+    Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
   }
   class PerformanceConfigurationRepository
     Octopus.Client.Repositories.IPerformanceConfigurationRepository
@@ -6490,6 +6500,8 @@ Octopus.Client.Repositories.Async
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
   }
   interface ICanExtendSpaceContext`1
   {
@@ -6729,6 +6741,7 @@ Octopus.Client.Repositories.Async
   interface IPackageMetadataRepository
   {
     Task<OctopusPackageMetadataMappedResource> Get(String)
+    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
     Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Boolean)
   }
   interface IPaginate`1
@@ -7026,6 +7039,7 @@ Octopus.Client.Repositories.Async
     .ctor(Octopus.Client.IOctopusAsyncRepository)
     Task<OctopusPackageMetadataMappedResource> Get(String)
     Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Boolean)
+    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
   }
   class SpaceScopedOperationOutsideOfCurrentSpaceContextException
     ISerializable

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3288,6 +3288,12 @@ Octopus.Client.Model
     Octopus.Client.Model.LeadershipRank Rank { get; set; }
     Int32 RunningTaskCount { get; set; }
   }
+  OverwriteMode
+  {
+      FailIfExists = 0
+      OverwriteExisting = 1
+      IgnoreIfExists = 2
+  }
   PackageAcquisitionLocation
   {
       Server = 0
@@ -5908,6 +5914,8 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean, Boolean)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
   }
   interface ICanExtendSpaceContext`1
   {
@@ -6148,6 +6156,7 @@ Octopus.Client.Repositories
   interface IPackageMetadataRepository
   {
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Get(String)
+    Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata)
   }
   interface IPaginate`1
@@ -6444,6 +6453,7 @@ Octopus.Client.Repositories
     .ctor(Octopus.Client.IOctopusRepository)
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Get(String)
     Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata)
+    Octopus.Client.Model.PackageMetadata.OctopusPackageMetadataMappedResource Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
   }
   class PerformanceConfigurationRepository
     Octopus.Client.Repositories.IPerformanceConfigurationRepository
@@ -6514,6 +6524,8 @@ Octopus.Client.Repositories.Async
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
   }
   interface ICanExtendSpaceContext`1
   {
@@ -6753,6 +6765,7 @@ Octopus.Client.Repositories.Async
   interface IPackageMetadataRepository
   {
     Task<OctopusPackageMetadataMappedResource> Get(String)
+    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
     Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Boolean)
   }
   interface IPaginate`1
@@ -7050,6 +7063,7 @@ Octopus.Client.Repositories.Async
     .ctor(Octopus.Client.IOctopusAsyncRepository)
     Task<OctopusPackageMetadataMappedResource> Get(String)
     Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Boolean)
+    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
   }
   class SpaceScopedOperationOutsideOfCurrentSpaceContextException
     ISerializable

--- a/source/Octopus.Client/Model/OverwriteMode.cs
+++ b/source/Octopus.Client/Model/OverwriteMode.cs
@@ -1,0 +1,9 @@
+namespace Octopus.Client.Model
+{
+    public enum OverwriteMode
+    {
+        FailIfExists,
+        OverwriteExisting,
+        IgnoreIfExists
+    }
+}

--- a/source/Octopus.Client/Model/OverwriteMode.cs
+++ b/source/Octopus.Client/Model/OverwriteMode.cs
@@ -6,4 +6,9 @@ namespace Octopus.Client.Model
         OverwriteExisting,
         IgnoreIfExists
     }
+
+    internal static class OverwriteModeLink
+    {
+        public static string Link = "overwriteMode";
+    }
 }

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -133,7 +133,7 @@ namespace Octopus.Client.Repositories.Async
                     object pathParameters;
                     
                     // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
-                    if (link.Contains("overwritemode"))
+                    if (link.Contains(OverwriteModeLink.Link))
                     {
                         pathParameters = new {replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion};
                     }

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -74,10 +74,10 @@ namespace Octopus.Client.Repositories.Async
             var link = await repository.Link("PackageUpload").ConfigureAwait(false);
             object pathParameters;
 
-            // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
+            // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
             if (link.Contains(OverwriteModeLink.Link))
             {
-                pathParameters = new { overwritemode = overwriteMode };
+                pathParameters = new { overwriteMode = overwriteMode };
             }
             else
             {
@@ -132,14 +132,14 @@ namespace Octopus.Client.Repositories.Async
                     var link = await repository.Link("PackageDeltaUpload").ConfigureAwait(false);
                     object pathParameters;
                     
-                    // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
+                    // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
                     if (link.Contains(OverwriteModeLink.Link))
                     {
-                        pathParameters = new {overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion};
+                        pathParameters = new { overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion };
                     }
                     else
                     {
-                        pathParameters = new {replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion};
+                        pathParameters = new { replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion };
                     }
 
                     var result = await repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -139,7 +139,7 @@ namespace Octopus.Client.Repositories.Async
                     }
                     else
                     {
-                        pathParameters = new {overwritemode = overwriteMode, packageId, signatureResult.BaseVersion};
+                        pathParameters = new {overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion};
                     }
 
                     var result = await repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -135,11 +135,11 @@ namespace Octopus.Client.Repositories.Async
                     // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
                     if (link.Contains(OverwriteModeLink.Link))
                     {
-                        pathParameters = new {replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion};
+                        pathParameters = new {overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion};
                     }
                     else
                     {
-                        pathParameters = new {overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion};
+                        pathParameters = new {replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion};
                     }
 
                     var result = await repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
@@ -42,7 +42,7 @@ namespace Octopus.Client.Repositories.Async
             var link = await repository.Link("PackageMetadata");
 
             // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
-            if (link.Contains("overwritemode"))
+            if (link.Contains(OverwriteModeLink.Link))
             {
                 return await repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { overwrite = overwriteMode });
             }

--- a/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
@@ -44,7 +44,7 @@ namespace Octopus.Client.Repositories.Async
             // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
             if (link.Contains(OverwriteModeLink.Link))
             {
-                return await repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { overwrite = overwriteMode });
+                return await repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { overwriteMode = overwriteMode });
             }
             else
             {

--- a/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
@@ -41,7 +41,7 @@ namespace Octopus.Client.Repositories.Async
 
             var link = await repository.Link("PackageMetadata");
 
-            // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
+            // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
             if (link.Contains(OverwriteModeLink.Link))
             {
                 return await repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { overwriteMode = overwriteMode });

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -134,11 +134,11 @@ namespace Octopus.Client.Repositories
                     // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
                     if (link.Contains(OverwriteModeLink.Link))
                     {
-                        pathParameters = new {replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion};
+                        pathParameters = new {overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion};
                     }
                     else
                     {
-                        pathParameters = new {overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion};
+                        pathParameters = new {replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion};
                     }
 
                     var result = repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -73,10 +73,10 @@ namespace Octopus.Client.Repositories
             var link = repository.Link("PackageUpload");
             object pathParameters;
 
-            // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
+            // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
             if (link.Contains(OverwriteModeLink.Link))
             {
-                pathParameters = new { overwritemode = overwriteMode };
+                pathParameters = new { overwriteMode = overwriteMode };
             }
             else
             {
@@ -131,14 +131,14 @@ namespace Octopus.Client.Repositories
                     var link = repository.Link("PackageDeltaUpload");
                     object pathParameters;
                     
-                    // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
+                    // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
                     if (link.Contains(OverwriteModeLink.Link))
                     {
-                        pathParameters = new {overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion};
+                        pathParameters = new { overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion };
                     }
                     else
                     {
-                        pathParameters = new {replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion};
+                        pathParameters = new { replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion };
                     }
 
                     var result = repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -138,7 +138,7 @@ namespace Octopus.Client.Repositories
                     }
                     else
                     {
-                        pathParameters = new {overwritemode = overwriteMode, packageId, signatureResult.BaseVersion};
+                        pathParameters = new {overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion};
                     }
 
                     var result = repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -132,7 +132,7 @@ namespace Octopus.Client.Repositories
                     object pathParameters;
                     
                     // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
-                    if (link.Contains("overwritemode"))
+                    if (link.Contains(OverwriteModeLink.Link))
                     {
                         pathParameters = new {replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion};
                     }

--- a/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
@@ -40,7 +40,7 @@ namespace Octopus.Client.Repositories
 
             var link = repository.Link("PackageMetadata");
             
-            // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
+            // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
             if (link.Contains(OverwriteModeLink.Link))
             {
                 return repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { overwriteMode = overwriteMode });

--- a/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
@@ -41,7 +41,7 @@ namespace Octopus.Client.Repositories
             var link = repository.Link("PackageMetadata");
             
             // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
-            if (link.Contains("overwritemode"))
+            if (link.Contains(OverwriteModeLink.Link))
             {
                 return repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { overwrite = overwriteMode });
             }

--- a/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
@@ -43,7 +43,7 @@ namespace Octopus.Client.Repositories
             // if the link doesn't contain overwritemode then we're connected to an older server, which uses the `replace` parameter  
             if (link.Contains(OverwriteModeLink.Link))
             {
-                return repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { overwrite = overwriteMode });
+                return repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { overwriteMode = overwriteMode });
             }
             else
             {


### PR DESCRIPTION
Adding OverwriteMode, to replace the `replace` boolean in the push APIs. Adds the ability for the caller to IgnoreExisting.

Relates to OctopusDeploy/Octopus-TeamCity#18