### PR TITLE
test adjustment: accept both kinds of certificate rejection exception

### DIFF
--- a/source/Octopus.Client.Tests/Integration/OctopusClient/SslTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/SslTests.cs
@@ -30,8 +30,9 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
                 var e = ex.InnerException?.InnerException;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    e.GetType().Name.Should().Be("WinHttpException");
-                    e.Message.Should().Be("A security error occurred");
+                    e.GetType().Name.Should().BeOneOf("WinHttpException", "AuthenticationException");
+                    e.Message.Should().BeOneOf("A security error occurred",
+                        "The remote certificate is invalid according to the validation procedure.");
                 }
                 else
                 {


### PR DESCRIPTION
For whatever reason, my machines produce a slightly different exception than this test expectation.

A GitHub search doesn't show any code relying directly on the type or message, so I think allowing either is probably going to be okay.

This has been necessary on all 3 machines I have tried, including a clean install of Win10 Pro 1809 with minimal tools to run the tests (our traditional .NET Core SDK 2.1.300, .NET Framework SDK 4.5.2, Visual Studio command line tools, git).