### PR TITLE
Remove default value for `overwriteMode` parameter

### DIFF
--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -15,7 +15,7 @@ namespace Octopus.Client.Repositories.Async
     {
         Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, bool replaceExisting = false);
         Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, bool replaceExisting, bool useDeltaCompression);
-        Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode = OverwriteMode.FailIfExists);
+        Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode);
         Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode, bool useDeltaCompression);
 
         Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(string packageId, int skip = 0, int take = 30);

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -34,7 +34,7 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode = OverwriteMode.FailIfExists)
+        public async Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode)
         {
             return await PushPackage(fileName, contents, overwriteMode, useDeltaCompression: true);
         }

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -14,7 +14,7 @@ namespace Octopus.Client.Repositories
     {
         PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, bool replaceExisting = false);
         PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, bool replaceExisting, bool useDeltaCompression);
-        PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode = OverwriteMode.FailIfExists);
+        PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode);
         PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode, bool useDeltaCompression);
         ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(string packageId, int skip = 0, int take = 30);
         ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(int skip = 0, int take = 30);

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -32,7 +32,7 @@ namespace Octopus.Client.Repositories
             this.repository = repository;
         }
 
-        public PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode = OverwriteMode.FailIfExists)
+        public PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode)
         {
             return PushPackage(fileName, contents, overwriteMode, useDeltaCompression: true);
         }


### PR DESCRIPTION
Two `PushPackage` methods similar signatures and default parameters results in an ambiguous invocation when the parameter is not specified.

```
Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, bool replaceExisting = false);
Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode = OverwriteMode.FailIfExists);
```

Calling `PushPackage(fileName, contents)` is ambiguous.