### PR TITLE
ILMerge in newtonsoft.json

### DIFF
--- a/source/Octopus.Client.Tests/AutomationEnvironment/AutomationEnvironmentProviderFixture.cs
+++ b/source/Octopus.Client.Tests/AutomationEnvironment/AutomationEnvironmentProviderFixture.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using Octopus.Client.AutomationEnvironments;
+using Octopus.Client.Model;
+
+namespace Octo.Tests.Commands
+{
+    class AutomationEnvironmentProviderFixture
+    {
+        [Test]
+        public void EnvironmentIsKnownIfBuildVariablesHaveValues()
+        {
+            foreach (var knownEnvironmentVariable in AutomationEnvironmentProvider.KnownEnvironmentVariables)
+            {
+                foreach (var variable in knownEnvironmentVariable.Value)
+                {
+                    AutomationEnvironmentProvider.environmentVariableReader = new ServerEnvironmentVariablesForTest(variable, "whatever value");
+                    var provider = new AutomationEnvironmentProvider();
+
+                    Assert.That(provider.DetermineAutomationEnvironment(), Is.Not.EqualTo(AutomationEnvironment.NoneOrUnknown));
+                }
+            }
+        }
+
+        [Test]
+        public void EnvironmentIsUnknownIfBuildVariablesDontHaveValues()
+        {
+            AutomationEnvironmentProvider.environmentVariableReader = new ServerEnvironmentVariablesForTest(string.Empty, string.Empty);
+            var provider = new AutomationEnvironmentProvider();
+
+            Assert.That(provider.DetermineAutomationEnvironment(), Is.EqualTo(AutomationEnvironment.NoneOrUnknown));
+        }
+
+        private class ServerEnvironmentVariablesForTest : IEnvironmentVariableReader
+        {
+            public ServerEnvironmentVariablesForTest(string environmentVariableName, string environmentVariableValue)
+            {
+                EnvironmentVariableName = environmentVariableName;
+                EnvironmentVariableValue = environmentVariableValue;
+            }
+
+            private string EnvironmentVariableName { get; set; }
+            private string EnvironmentVariableValue { get; set; }
+            public string GetVariableValue(string name)
+            {
+                return name == EnvironmentVariableName ?
+                    EnvironmentVariableValue :
+                    null;
+            }
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7179,7 +7179,7 @@ Octopus.Client.Serialization
   }
   abstract class Serializer
   {
-    static IDictionary<String, Object> DeserializeObject(String)
+    static Object Deserialize(String)
     static String Serialize(Object, Octopus.Client.Serialization.T)
     static String Serialize(Object)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -390,7 +390,6 @@ Octopus.Client
     .ctor()
     Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint)
-    static void SetRequestingTool(String)
   }
   class OctopusClientOptions
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -390,6 +390,7 @@ Octopus.Client
     .ctor()
     Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint)
+    static void SetRequestingTool(String)
   }
   class OctopusClientOptions
   {
@@ -7175,6 +7176,12 @@ Octopus.Client.Serialization
     Boolean CanConvert(Type)
     Object ReadJson(JsonReader, Type, Object, JsonSerializer)
     void WriteJson(JsonWriter, Object, JsonSerializer)
+  }
+  abstract class Serializer
+  {
+    static IDictionary<String, Object> DeserializeObject(String)
+    static String Serialize(Object, Octopus.Client.Serialization.T)
+    static String Serialize(Object)
   }
   class TriggerActionConverter
     Octopus.Client.Serialization.InheritedClassConverter<TriggerActionResource, TriggerActionType>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -573,6 +573,16 @@ Octopus.Client
     void SetParameter(String, IDictionary<String, String>)
   }
 }
+Octopus.Client.AutomationEnvironments
+{
+  class AutomationEnvironmentProvider
+    Octopus.Client.AutomationEnvironments.IAutomationEnvironmentProvider
+  {
+    .ctor()
+    Octopus.Client.Model.AutomationEnvironment DetermineAutomationEnvironment()
+    String DetermineAutomationEnvironmentWithVersion()
+  }
+}
 Octopus.Client.Editors
 {
   class AccountEditor`2
@@ -1717,6 +1727,36 @@ Octopus.Client.Model
     static IEqualityComparer<AutoDeployReleaseOverrideResource> EnvironmentIdTenantIdComparer { get; }
     String ReleaseId { get; }
     String TenantId { get; }
+  }
+  AutomationEnvironment
+  {
+      NoneOrUnknown = 0
+      Octopus = 1
+      Bamboo = 2
+      TeamCity = 3
+      AzureDevOps = 4
+      AppVeyor = 5
+      BitBucket = 6
+      Jenkins = 7
+      CircleCI = 8
+      GitLabCI = 9
+      Travis = 10
+      GoCD = 11
+      BitRise = 12
+      Buddy = 13
+      BuildKite = 14
+      CirrusCI = 15
+      AWSCodeBuild = 16
+      Codeship = 17
+      Drone = 18
+      Dsari = 19
+      Hudson = 20
+      MagnumCI = 21
+      SailCI = 22
+      Semaphore = 23
+      Shippable = 24
+      SolanoCI = 25
+      StriderCD = 26
   }
   class AwsElasticContainerRegistryFeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -390,7 +390,6 @@ Octopus.Client
     .ctor()
     Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint)
-    static void SetRequestingTool(String)
   }
   class OctopusClientOptions
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -390,6 +390,7 @@ Octopus.Client
     .ctor()
     Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint)
+    static void SetRequestingTool(String)
   }
   class OctopusClientOptions
   {
@@ -7200,6 +7201,12 @@ Octopus.Client.Serialization
     Boolean CanConvert(Type)
     Object ReadJson(JsonReader, Type, Object, JsonSerializer)
     void WriteJson(JsonWriter, Object, JsonSerializer)
+  }
+  abstract class Serializer
+  {
+    static IDictionary<String, Object> DeserializeObject(String)
+    static String Serialize(Object, Octopus.Client.Serialization.T)
+    static String Serialize(Object)
   }
   class TriggerActionConverter
     Octopus.Client.Serialization.InheritedClassConverter<TriggerActionResource, TriggerActionType>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -574,6 +574,16 @@ Octopus.Client
     void SetParameter(String, IDictionary<String, String>)
   }
 }
+Octopus.Client.AutomationEnvironments
+{
+  class AutomationEnvironmentProvider
+    Octopus.Client.AutomationEnvironments.IAutomationEnvironmentProvider
+  {
+    .ctor()
+    Octopus.Client.Model.AutomationEnvironment DetermineAutomationEnvironment()
+    String DetermineAutomationEnvironmentWithVersion()
+  }
+}
 Octopus.Client.Editors
 {
   class AccountEditor`2
@@ -1732,6 +1742,36 @@ Octopus.Client.Model
     static IEqualityComparer<AutoDeployReleaseOverrideResource> EnvironmentIdTenantIdComparer { get; }
     String ReleaseId { get; }
     String TenantId { get; }
+  }
+  AutomationEnvironment
+  {
+      NoneOrUnknown = 0
+      Octopus = 1
+      Bamboo = 2
+      TeamCity = 3
+      AzureDevOps = 4
+      AppVeyor = 5
+      BitBucket = 6
+      Jenkins = 7
+      CircleCI = 8
+      GitLabCI = 9
+      Travis = 10
+      GoCD = 11
+      BitRise = 12
+      Buddy = 13
+      BuildKite = 14
+      CirrusCI = 15
+      AWSCodeBuild = 16
+      Codeship = 17
+      Drone = 18
+      Dsari = 19
+      Hudson = 20
+      MagnumCI = 21
+      SailCI = 22
+      Semaphore = 23
+      Shippable = 24
+      SolanoCI = 25
+      StriderCD = 26
   }
   class AwsElasticContainerRegistryFeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7204,7 +7204,7 @@ Octopus.Client.Serialization
   }
   abstract class Serializer
   {
-    static IDictionary<String, Object> DeserializeObject(String)
+    static Object Deserialize(String)
     static String Serialize(Object, Octopus.Client.Serialization.T)
     static String Serialize(Object)
   }

--- a/source/Octopus.Client/AutomationEnvironments/AutomationEnvironmentProvider.cs
+++ b/source/Octopus.Client/AutomationEnvironments/AutomationEnvironmentProvider.cs
@@ -7,7 +7,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.AutomationEnvironments
 {
-    internal class AutomationEnvironmentProvider : IAutomationEnvironmentProvider
+    public class AutomationEnvironmentProvider : IAutomationEnvironmentProvider
     {
         private static readonly ILog Logger = LogProvider.For<AutomationEnvironmentProvider>();
 

--- a/source/Octopus.Client/Model/AutomationEnvironment.cs
+++ b/source/Octopus.Client/Model/AutomationEnvironment.cs
@@ -1,6 +1,6 @@
 ﻿namespace Octopus.Client.Model
 {
-    internal enum AutomationEnvironment
+    public enum AutomationEnvironment
     {
         NoneOrUnknown,
         Octopus,

--- a/source/Octopus.Client/OctopusClientFactory.cs
+++ b/source/Octopus.Client/OctopusClientFactory.cs
@@ -36,7 +36,7 @@ namespace Octopus.Client
         private string DetermineRequestingTool()
         {
             var launchAssembly = Assembly.GetEntryAssembly();
-            if (launchAssembly.GetTypes().Any(x => x.FullName == "Octopus.Cli.CliProgram"))
+            if (launchAssembly.GetTypes().Any(x => x.FullName == "Octo.Program"))
             {
                 var octoExtensionVersion = Environment.GetEnvironmentVariable("OCTOEXTENSION");
                 if (!string.IsNullOrWhiteSpace(octoExtensionVersion))

--- a/source/Octopus.Client/OctopusClientFactory.cs
+++ b/source/Octopus.Client/OctopusClientFactory.cs
@@ -36,6 +36,10 @@ namespace Octopus.Client
         private string DetermineRequestingTool()
         {
             var launchAssembly = Assembly.GetEntryAssembly();
+            Console.WriteLine(launchAssembly.FullName);
+            foreach(var t in launchAssembly.GetTypes())
+                Console.WriteLine(t.FullName);
+                
             if (launchAssembly.GetTypes().Any(x => x.FullName == "Octo.Program"))
             {
                 var octoExtensionVersion = Environment.GetEnvironmentVariable("OCTOEXTENSION");

--- a/source/Octopus.Client/OctopusClientFactory.cs
+++ b/source/Octopus.Client/OctopusClientFactory.cs
@@ -10,7 +10,7 @@ namespace Octopus.Client
     {
         private static string requestingTool;
 
-        internal static void SetRequestingTool(string toolName)
+        public static void SetRequestingTool(string toolName)
         {
             requestingTool = toolName;
         }

--- a/source/Octopus.Client/OctopusClientFactory.cs
+++ b/source/Octopus.Client/OctopusClientFactory.cs
@@ -36,9 +36,6 @@ namespace Octopus.Client
         private string DetermineRequestingTool()
         {
             var launchAssembly = Assembly.GetEntryAssembly();
-            Console.WriteLine(launchAssembly.FullName);
-            foreach(var t in launchAssembly.GetTypes())
-                Console.WriteLine(t.FullName);
                 
             if (launchAssembly.GetTypes().Any(x => x.FullName == "Octo.Program"))
             {

--- a/source/Octopus.Client/OctopusClientFactory.cs
+++ b/source/Octopus.Client/OctopusClientFactory.cs
@@ -37,7 +37,7 @@ namespace Octopus.Client
         {
             var launchAssembly = Assembly.GetEntryAssembly();
                 
-            if (launchAssembly.GetTypes().Any(x => x.FullName == "Octo.Program"))
+            if (launchAssembly.GetTypes().Any(x => x.FullName == "Octo.Program" || x.FullName == "Octopus.DotNet.Cli.Program"))
             {
                 var octoExtensionVersion = Environment.GetEnvironmentVariable("OCTOEXTENSION");
                 if (!string.IsNullOrWhiteSpace(octoExtensionVersion))

--- a/source/Octopus.Client/OctopusClientFactory.cs
+++ b/source/Octopus.Client/OctopusClientFactory.cs
@@ -37,7 +37,7 @@ namespace Octopus.Client
         {
             var launchAssembly = Assembly.GetEntryAssembly();
                 
-            if (launchAssembly.GetTypes().Any(x => x.FullName == "Octo.Program" || x.FullName == "Octopus.DotNet.Cli.Program"))
+            if (launchAssembly != null && launchAssembly.GetTypes().Any(x => x.FullName == "Octo.Program" || x.FullName == "Octopus.DotNet.Cli.Program"))
             {
                 var octoExtensionVersion = Environment.GetEnvironmentVariable("OCTOEXTENSION");
                 if (!string.IsNullOrWhiteSpace(octoExtensionVersion))

--- a/source/Octopus.Client/Properties/AssemblyInfo.cs
+++ b/source/Octopus.Client/Properties/AssemblyInfo.cs
@@ -3,6 +3,4 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Octopus.Client")]
-[assembly: InternalsVisibleTo("Octopus.Cli")]
 [assembly: InternalsVisibleTo("Octopus.Client.Tests")]
-[assembly: InternalsVisibleTo("Octo.Tests")]

--- a/source/Octopus.Client/Serialization/Serializer.cs
+++ b/source/Octopus.Client/Serialization/Serializer.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Text;
+using Newtonsoft.Json;
+using Octopus.Cli.Extensions;
+
+namespace Octopus.Client.Serialization
+{
+    public static class Serializer
+    {
+        public static string Serialize<T>(object metadata, T exportObject)
+        {
+            var x = exportObject.ToDynamic(metadata);
+
+            var serializerSettings = JsonSerialization.GetDefaultSerializerSettings();
+            var serializedObject = JsonConvert.SerializeObject(x, serializerSettings);
+
+            return serializedObject;
+        }
+        
+        public static string Serialize<T>(object obj)
+        {
+            var serializerSettings = JsonSerialization.GetDefaultSerializerSettings();
+            var serializedObject = JsonConvert.SerializeObject(obj, serializerSettings);
+
+            return serializedObject;
+        }
+        
+        public static IDictionary<string, object> DeserializeObject<T>(string input)
+        {
+            var expando = JsonConvert.DeserializeObject<ExpandoObject>(input, JsonSerialization.GetDefaultSerializerSettings());
+            var importedObject = expando as IDictionary<string, object>;
+
+            return importedObject;
+        }
+    }
+}

--- a/source/Octopus.Client/Serialization/Serializer.cs
+++ b/source/Octopus.Client/Serialization/Serializer.cs
@@ -1,11 +1,12 @@
-using System.Collections.Generic;
-using System.Dynamic;
-using System.Text;
 using Newtonsoft.Json;
-using Octopus.Cli.Extensions;
+using Octopus.Client.Util;
 
 namespace Octopus.Client.Serialization
 {
+    /// <summary>
+    /// A wrapper over the required Json serialization that sets up the serializer settings to
+    /// speak to Octopus correctly. 
+    /// </summary>
     public static class Serializer
     {
         public static string Serialize<T>(object metadata, T exportObject)

--- a/source/Octopus.Client/Serialization/Serializer.cs
+++ b/source/Octopus.Client/Serialization/Serializer.cs
@@ -28,10 +28,7 @@ namespace Octopus.Client.Serialization
         
         public static object Deserialize<T>(string input)
         {
-            var expando = JsonConvert.DeserializeObject<ExpandoObject>(input, JsonSerialization.GetDefaultSerializerSettings());
-            var importedObject = expando as IDictionary<string, object>;
-
-            return importedObject;
+            return JsonConvert.DeserializeObject<T>(input, JsonSerialization.GetDefaultSerializerSettings());
         }
     }
 }

--- a/source/Octopus.Client/Serialization/Serializer.cs
+++ b/source/Octopus.Client/Serialization/Serializer.cs
@@ -18,7 +18,7 @@ namespace Octopus.Client.Serialization
             return serializedObject;
         }
         
-        public static string Serialize<T>(object obj)
+        public static string Serialize(object obj)
         {
             var serializerSettings = JsonSerialization.GetDefaultSerializerSettings();
             var serializedObject = JsonConvert.SerializeObject(obj, serializerSettings);

--- a/source/Octopus.Client/Serialization/Serializer.cs
+++ b/source/Octopus.Client/Serialization/Serializer.cs
@@ -26,7 +26,7 @@ namespace Octopus.Client.Serialization
             return serializedObject;
         }
         
-        public static IDictionary<string, object> DeserializeObject<T>(string input)
+        public static object Deserialize<T>(string input)
         {
             var expando = JsonConvert.DeserializeObject<ExpandoObject>(input, JsonSerialization.GetDefaultSerializerSettings());
             var importedObject = expando as IDictionary<string, object>;

--- a/source/Octopus.Client/Util/DynamicExtensions.cs
+++ b/source/Octopus.Client/Util/DynamicExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Dynamic;
 
-namespace Octopus.Cli.Extensions
+namespace Octopus.Client.Util
 {
     static class DynamicExtensions
     {

--- a/source/Octopus.Client/Util/DynamicExtensions.cs
+++ b/source/Octopus.Client/Util/DynamicExtensions.cs
@@ -5,7 +5,7 @@ using System.Dynamic;
 
 namespace Octopus.Cli.Extensions
 {
-    public static class DynamicExtensions
+    static class DynamicExtensions
     {
         public static dynamic ToDynamic(this object value, object metadata)
         {

--- a/source/Octopus.Client/Util/DynamicExtensions.cs
+++ b/source/Octopus.Client/Util/DynamicExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Dynamic;
+
+namespace Octopus.Cli.Extensions
+{
+    public static class DynamicExtensions
+    {
+        public static dynamic ToDynamic(this object value, object metadata)
+        {
+            IDictionary<string, object> expando = new ExpandoObject();
+            if (value is IEnumerable)
+            {
+                var items = new List<object>();
+                var values = value as IEnumerable;
+                foreach (var v in values)
+                {
+                    items.Add(GetExpandoObject(v));
+                }
+                expando.Add("Items", items);
+                expando.Add("$Meta", metadata);
+            }
+            else
+            {
+                expando = GetExpandoObject(value);
+                expando.Add("$Meta", metadata);
+            }
+            return expando;
+        }
+
+        static IDictionary<string, object> GetExpandoObject(object value)
+        {
+            IDictionary<string, object> expando = new ExpandoObject();
+            foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(value.GetType()))
+                expando.Add(property.Name, property.GetValue(value));
+            return expando;
+        }
+    }
+}


### PR DESCRIPTION
We historically had ilmerged newtonsoft.json into Octopus.Clients, but when the repo was split to move octo.exe into it's own repo, this ilmerge was removed.

As lots of our sample scripts (eg https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/Octopus.Client/PowerShell/Projects/CreateProject.ps1) just go
```
Add-Type -Path 'Octopus.Client.dll' 
```

and dont highlight that we need to go 
```
Add-Type -Path 'NewtonSoft.Json.dll' 
```
as well, this has broken a bunch of use cases.

