### PR TITLE
Change xmldoc for UseGuidedFailure field

### DIFF
--- a/source/Octopus.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Client/Model/DeploymentResource.cs
@@ -56,8 +56,7 @@ namespace Octopus.Client.Model
 
         /// <summary>
         /// If set to true, the deployment will prompt for manual intervention (Fail/Retry/Ignore) when
-        /// failures are encountered in activities that support it. May be overridden with the
-        /// Octopus.UseGuidedFailure special variable.
+        /// failures are encountered in activities that support it.
         /// </summary>
         [WriteableOnCreate]
         public bool UseGuidedFailure { get; set; }

--- a/source/Octopus.Client/Model/EnvironmentResource.cs
+++ b/source/Octopus.Client/Model/EnvironmentResource.cs
@@ -34,8 +34,7 @@ namespace Octopus.Client.Model
 
         /// <summary>
         /// If set to true, deployments will prompt for manual intervention (Fail/Retry/Ignore) when
-        /// failures are encountered in activities that support it. May be overridden with the
-        /// Octopus.UseGuidedFailure special variable.
+        /// failures are encountered in activities that support it.
         /// </summary>
         [Writeable]
         public bool UseGuidedFailure { get; set; }


### PR DESCRIPTION
# Background
There is misleading information in xmldoc for UseGuidedFailure filed  in EnvironmentResource and DeploymentResource. It says that behaviour can be overriden with Octopus.UseGuidedFailure variable, but according to https://github.com/OctopusDeploy/Issues/issues/3588 - this variable was removed in `3.0`

## Before

![Снимок экрана 2019-07-30 в 15 15 39](https://user-images.githubusercontent.com/16535165/62513321-15cc5180-b835-11e9-9837-629f626cef9c.png)

## After
![Снимок экрана 2019-08-02 в 18 47 25](https://user-images.githubusercontent.com/16535165/62513327-19f86f00-b835-11e9-9bf3-dd4b3df5f526.png)
