### PR TITLE
OverwriteMode warning when using older server

### DIFF
--- a/source/Octopus.Client/Model/OverwriteMode.cs
+++ b/source/Octopus.Client/Model/OverwriteMode.cs
@@ -1,3 +1,5 @@
+using Octopus.Client.Logging;
+
 namespace Octopus.Client.Model
 {
     public enum OverwriteMode
@@ -10,5 +12,16 @@ namespace Octopus.Client.Model
     internal static class OverwriteModeLink
     {
         public static string Link = "overwriteMode";
+
+        public static bool AsLegacyReplaceFlag(this OverwriteMode @this, ILog logger)
+        {
+            if (@this == OverwriteMode.IgnoreIfExists)
+            {
+                logger.Warn("You have selected to ignore existing versions but the Octopus server you are connected to doesn't not support this. Falling back to default value of `replace=false`");
+                return false;
+            }
+
+            return @this == OverwriteMode.OverwriteExisting;
+        }
     }
 }

--- a/source/Octopus.Client/Model/OverwriteMode.cs
+++ b/source/Octopus.Client/Model/OverwriteMode.cs
@@ -13,11 +13,11 @@ namespace Octopus.Client.Model
     {
         public static string Link = "overwriteMode";
 
-        public static bool AsLegacyReplaceFlag(this OverwriteMode @this, ILog logger)
+        public static bool ConvertToLegacyReplaceFlag(this OverwriteMode @this, ILog logger)
         {
             if (@this == OverwriteMode.IgnoreIfExists)
             {
-                logger.Warn("You have selected to ignore existing versions but the Octopus server you are connected to doesn't not support this. Falling back to default value of `replace=false`");
+                logger.Warn("The option to ignore existing versions is only supported by Octopus Server 2019.7.8 or newer. If you want to use this option please upgrade your Octopus Server. In the meantime we are automatically falling back to the default option `replace=false` for this request.");
                 return false;
             }
 

--- a/source/Octopus.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Client/OctopusAsyncRepository.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
+using Octopus.Client.Logging;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
 

--- a/source/Octopus.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Client/OctopusAsyncRepository.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
-using Octopus.Client.Logging;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
 

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -81,7 +81,7 @@ namespace Octopus.Client.Repositories.Async
             }
             else
             {
-                pathParameters = new { replace = overwriteMode.AsLegacyReplaceFlag(Logger) };
+                pathParameters = new { replace = overwriteMode.ConvertToLegacyReplaceFlag(Logger) };
             }
 
             contents.Seek(0, SeekOrigin.Begin);
@@ -139,7 +139,7 @@ namespace Octopus.Client.Repositories.Async
                     }
                     else
                     {
-                        pathParameters = new { replace = overwriteMode.AsLegacyReplaceFlag(Logger), packageId, signatureResult.BaseVersion };
+                        pathParameters = new { replace = overwriteMode.ConvertToLegacyReplaceFlag(Logger), packageId, signatureResult.BaseVersion };
                     }
 
                     var result = await repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -81,7 +81,7 @@ namespace Octopus.Client.Repositories.Async
             }
             else
             {
-                pathParameters = new { replace = overwriteMode == OverwriteMode.OverwriteExisting };
+                pathParameters = new { replace = overwriteMode.AsLegacyReplaceFlag(Logger) };
             }
 
             contents.Seek(0, SeekOrigin.Begin);
@@ -139,7 +139,7 @@ namespace Octopus.Client.Repositories.Async
                     }
                     else
                     {
-                        pathParameters = new { replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion };
+                        pathParameters = new { replace = overwriteMode.AsLegacyReplaceFlag(Logger), packageId, signatureResult.BaseVersion };
                     }
 
                     var result = await repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
@@ -50,7 +50,7 @@ namespace Octopus.Client.Repositories.Async
             }
             else
             {
-                return await repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { replace = overwriteMode.AsLegacyReplaceFlag(Logger) });
+                return await repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { replace = overwriteMode.ConvertToLegacyReplaceFlag(Logger) });
             }
         }
     }

--- a/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Octopus.Client.Logging;
 using Octopus.Client.Model;
 using Octopus.Client.Model.PackageMetadata;
 
 namespace Octopus.Client.Repositories.Async
 {
-    public class PackageMetadataRepository : IPackageMetadataRepository
+    class PackageMetadataRepository : IPackageMetadataRepository
     {
         private readonly IOctopusAsyncRepository repository;
+        private static readonly ILog Logger = LogProvider.For<PackageMetadataRepository>();
 
         public PackageMetadataRepository(IOctopusAsyncRepository repository)
         {
@@ -48,7 +50,7 @@ namespace Octopus.Client.Repositories.Async
             }
             else
             {
-                return await repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { replace = overwriteMode == OverwriteMode.OverwriteExisting });
+                return await repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { replace = overwriteMode.AsLegacyReplaceFlag(Logger) });
             }
         }
     }

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -80,7 +80,7 @@ namespace Octopus.Client.Repositories
             }
             else
             {
-                pathParameters = new { replace = overwriteMode.AsLegacyReplaceFlag(Logger) };
+                pathParameters = new { replace = overwriteMode.ConvertToLegacyReplaceFlag(Logger) };
             }
             
             
@@ -138,7 +138,7 @@ namespace Octopus.Client.Repositories
                     }
                     else
                     {
-                        pathParameters = new { replace = overwriteMode.AsLegacyReplaceFlag(Logger), packageId, signatureResult.BaseVersion };
+                        pathParameters = new { replace = overwriteMode.ConvertToLegacyReplaceFlag(Logger), packageId, signatureResult.BaseVersion };
                     }
 
                     var result = repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -80,7 +80,7 @@ namespace Octopus.Client.Repositories
             }
             else
             {
-                pathParameters = new { replace = overwriteMode == OverwriteMode.OverwriteExisting };
+                pathParameters = new { replace = overwriteMode.AsLegacyReplaceFlag(Logger) };
             }
             
             
@@ -138,7 +138,7 @@ namespace Octopus.Client.Repositories
                     }
                     else
                     {
-                        pathParameters = new { replace = overwriteMode == OverwriteMode.OverwriteExisting, packageId, signatureResult.BaseVersion };
+                        pathParameters = new { replace = overwriteMode.AsLegacyReplaceFlag(Logger), packageId, signatureResult.BaseVersion };
                     }
 
                     var result = repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(

--- a/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Octopus.Client.Logging;
 using Octopus.Client.Model;
 using Octopus.Client.Model.PackageMetadata;
 
@@ -7,6 +8,7 @@ namespace Octopus.Client.Repositories
     public class PackageMetadataRepository : IPackageMetadataRepository
     {
         private readonly IOctopusRepository repository;
+        private static readonly ILog Logger = LogProvider.For<PackageMetadataRepository>();
 
         public PackageMetadataRepository(IOctopusRepository repository)
         {
@@ -47,7 +49,7 @@ namespace Octopus.Client.Repositories
             }
             else
             {
-                return repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { replace = overwriteMode == OverwriteMode.OverwriteExisting });
+                return repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { replace = overwriteMode.AsLegacyReplaceFlag(Logger) });
             }
         }
     }

--- a/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
@@ -49,7 +49,7 @@ namespace Octopus.Client.Repositories
             }
             else
             {
-                return repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { replace = overwriteMode.AsLegacyReplaceFlag(Logger) });
+                return repository.Client.Post<OctopusPackageMetadataVersionResource, OctopusPackageMetadataMappedResource>(link, resource, new { replace = overwriteMode.ConvertToLegacyReplaceFlag(Logger) });
             }
         }
     }


### PR DESCRIPTION
Log a warning if `OverwriteMode.IgnoreIfExists` gets used when connected to an older version of server

Relates to OctopusDeploy/Octopus-TeamCity#18