### PR TITLE
Push metadata error handling

### DIFF
--- a/source/Octopus.Client.Tests/Integration/OctopusClient/SslTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/SslTests.cs
@@ -1,5 +1,6 @@
 ﻿#if HTTP_CLIENT_SUPPORTS_SSL_OPTIONS
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -59,6 +60,13 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             catch (Exception ex) when (ex.Message == "This platform does not support ignoring SSL certificate errors")
             {
                 Console.WriteLine($"This test is running on '{RuntimeInformation.OSDescription}'");
+                if (File.Exists("/etc/os-release"))
+                {
+                    var file = File.ReadAllText("/etc/os-release");
+                    if (file.Contains("openSUSE Leap 15.1"))
+                        Assert.Inconclusive($"This test is known not to work on platform 'openSuse Leap 15.1'");
+                }
+
                 var os = RuntimeInformation.OSDescription;
                 if (
                     os.StartsWith("Darwin") || // Mac

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/SslTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/SslTests.cs
@@ -58,13 +58,16 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             }
             catch (Exception ex) when (ex.Message == "This platform does not support ignoring SSL certificate errors")
             {
+                Console.WriteLine($"This test is running on '{RuntimeInformation.OSDescription}'");
                 var os = RuntimeInformation.OSDescription;
                 if (
                     os.StartsWith("Darwin") || // Mac
                     os.Contains(".el7") || // Cent OS
                     os.Contains("fc23") // Fedora 23
                 )
-                    return;
+                {
+                    Assert.Inconclusive($"This test is known not to work on platform '{RuntimeInformation.OSDescription}'");
+                }
 
                 throw;
             }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1303,6 +1303,13 @@ Octopus.Client.Exceptions
     ReadOnlyCollection<String> Errors { get; }
     Octopus.Client.Exceptions.TDetails DetailsAs()
   }
+  class OperationNotSupportedByOctopusServerException
+    ISerializable
+    Octopus.Client.Exceptions.OctopusException
+  {
+    .ctor(String, String)
+    String RequiredOctopusVersion { get; }
+  }
   class ResourceSpaceDoesNotMatchRepositorySpaceException
     ISerializable
     Exception

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1312,6 +1312,14 @@ Octopus.Client.Exceptions
     ReadOnlyCollection<String> Errors { get; }
     Octopus.Client.Exceptions.TDetails DetailsAs()
   }
+  class OperationNotSupportedByOctopusServerException
+    ISerializable
+    _Exception
+    Octopus.Client.Exceptions.OctopusException
+  {
+    .ctor(String, String)
+    String RequiredOctopusVersion { get; }
+  }
   class ResourceSpaceDoesNotMatchRepositorySpaceException
     ISerializable
     _Exception

--- a/source/Octopus.Client/Exceptions/OperationNotSupportedByOctopusServerException.cs
+++ b/source/Octopus.Client/Exceptions/OperationNotSupportedByOctopusServerException.cs
@@ -1,0 +1,21 @@
+namespace Octopus.Client.Exceptions
+{
+    /// <summary>
+    /// An exception thrown when the Octopus Server does not support a given operation
+    /// </summary>
+    public class OperationNotSupportedByOctopusServerException : OctopusException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationNotSupportedByOctopusServerException" /> class.
+        /// </summary>
+        /// <param name="message">The detailed exception message.</param>
+        /// <param name="requiresVersion">The version required for the specified operation.</param>
+        public OperationNotSupportedByOctopusServerException(string message, string requiresVersion)
+            : base((int)System.Net.HttpStatusCode.NotImplemented, message)
+        {
+            RequiredOctopusVersion = requiresVersion;
+        }
+
+        public string RequiredOctopusVersion { get; }
+    }
+}

--- a/source/Octopus.Client/Model/PackageMetadata/OctopusPackageMetadata.cs
+++ b/source/Octopus.Client/Model/PackageMetadata/OctopusPackageMetadata.cs
@@ -7,6 +7,8 @@ namespace Octopus.Client.Model.PackageMetadata
     /// </summary>
     public class OctopusPackageMetadata
     {
+        public static string PackageMetadataRequiresOctopusVersion = "Pushing build information/package metadata requires Octopus version 2019.4.1 or newer";
+
         public OctopusPackageMetadata()
         {
             Commits = new Commit[0];

--- a/source/Octopus.Client/Model/PackageMetadata/OctopusPackageMetadata.cs
+++ b/source/Octopus.Client/Model/PackageMetadata/OctopusPackageMetadata.cs
@@ -7,7 +7,8 @@ namespace Octopus.Client.Model.PackageMetadata
     /// </summary>
     public class OctopusPackageMetadata
     {
-        public static string PackageMetadataRequiresOctopusVersion = "Pushing build information/package metadata requires Octopus version 2019.4.1 or newer";
+        internal static string PackageMetadataRequiresOctopusVersion = "2019.4.1";
+        internal static string PackageMetadataRequiresOctopusVersionMessage = $"Pushing build information/package metadata requires Octopus version {PackageMetadataRequiresOctopusVersion} or newer";
 
         public OctopusPackageMetadata()
         {

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -125,10 +125,10 @@ Certificate thumbprint:   {certificate.Thumbprint}";
             {
                 return await Create(serverEndpoint, options, true).ConfigureAwait(false);
             }
-            catch (PlatformNotSupportedException)
+            catch (PlatformNotSupportedException ex)
             {
                 if (options?.IgnoreSslErrors ?? false)
-                    throw new Exception("This platform does not support ignoring SSL certificate errors");
+                    throw new Exception("This platform does not support ignoring SSL certificate errors", ex);
                 return await Create(serverEndpoint, options, false).ConfigureAwait(false);
             }
 #else
@@ -143,10 +143,10 @@ Certificate thumbprint:   {certificate.Thumbprint}";
             {
                 return await Create(serverEndpoint, options, true, requestingTool);
             }
-            catch (PlatformNotSupportedException)
+            catch (PlatformNotSupportedException ex)
             {
                 if (options?.IgnoreSslErrors ?? false)
-                    throw new Exception("This platform does not support ignoring SSL certificate errors");
+                    throw new Exception("This platform does not support ignoring SSL certificate errors", ex);
                 return await Create(serverEndpoint, options, false, requestingTool);
             }
 #else

--- a/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Octopus.Client.Exceptions;
 using Octopus.Client.Logging;
 using Octopus.Client.Model;
 using Octopus.Client.Model.PackageMetadata;
@@ -43,8 +44,9 @@ namespace Octopus.Client.Repositories.Async
 
             if (!(await repository.HasLink("PackageMetadata")))
             {
-                Logger.Error(OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
-                throw new InvalidOperationException(OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
+                throw new OperationNotSupportedByOctopusServerException(
+                    OctopusPackageMetadata.PackageMetadataRequiresOctopusVersionMessage,
+                    OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
             }
 
             var link = await repository.Link("PackageMetadata");

--- a/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/PackageMetadataRepository.cs
@@ -41,6 +41,12 @@ namespace Octopus.Client.Repositories.Async
                 OctopusPackageMetadata = octopusMetadata
             };
 
+            if (!(await repository.HasLink("PackageMetadata")))
+            {
+                Logger.Error(OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
+                throw new InvalidOperationException(OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
+            }
+
             var link = await repository.Link("PackageMetadata");
 
             // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  

--- a/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
@@ -40,6 +40,12 @@ namespace Octopus.Client.Repositories
                 OctopusPackageMetadata = octopusMetadata,
             };
 
+            if (!repository.HasLink("PackageMetadata"))
+            {
+                Logger.Error(OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
+                throw new InvalidOperationException(OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
+            }
+
             var link = repository.Link("PackageMetadata");
             
             // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  

--- a/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
+++ b/source/Octopus.Client/Repositories/PackageMetadataRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Octopus.Client.Exceptions;
 using Octopus.Client.Logging;
 using Octopus.Client.Model;
 using Octopus.Client.Model.PackageMetadata;
@@ -42,8 +43,9 @@ namespace Octopus.Client.Repositories
 
             if (!repository.HasLink("PackageMetadata"))
             {
-                Logger.Error(OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
-                throw new InvalidOperationException(OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
+                throw new OperationNotSupportedByOctopusServerException(
+                    OctopusPackageMetadata.PackageMetadataRequiresOctopusVersionMessage,
+                    OctopusPackageMetadata.PackageMetadataRequiresOctopusVersion);
             }
 
             var link = repository.Link("PackageMetadata");


### PR DESCRIPTION
Throw a more meaningful exception if the server doesn't support pushing metadata.

Relates to OctopusDeploy/Octopus-TeamCity#31