### PR TITLE
Remove SYNC_CLIENT compile time constant

### DIFF
--- a/source/Octopus.Client.Tests/Conventions/ClientConventions.cs
+++ b/source/Octopus.Client.Tests/Conventions/ClientConventions.cs
@@ -197,11 +197,9 @@ namespace Octopus.Client.Tests.Conventions
         {
             var denied = new[]
             {
-#if SYNC_CLIENT
                 typeof (Sync.IChannelRepository),
                 typeof (Sync.IDeploymentProcessRepository),
                 typeof (Sync.ITaskRepository),
-#endif
                 typeof (IChannelRepository),
                 typeof (IDeploymentProcessRepository),
                 typeof (ITaskRepository)
@@ -247,7 +245,6 @@ namespace Octopus.Client.Tests.Conventions
             }
         }
 
-#if SYNC_CLIENT
         [Test]
         public void SyncRepositoriesThatGetNamedResourcesShouldUsuallyImplementIFindByName()
         {
@@ -279,7 +276,6 @@ namespace Octopus.Client.Tests.Conventions
                 Assert.Fail($"Repositories that implement IGet<INamedResource> should usually implement IFindByName<INamedResource>, unless that named resource is a singleton or owned by another aggregate.{Environment.NewLine}{missingFindByName.Select(t => t.Name).NewLineSeperate()}");
             }
         }
-#endif
 
         [Test]
         public void MostAsyncRepositoriesThatGetResourcesShouldImplementIPaginate()
@@ -309,7 +305,6 @@ namespace Octopus.Client.Tests.Conventions
             }
         }
 
-#if SYNC_CLIENT
         [Test]
         public void MostSyncRepositoriesThatGetResourcesShouldImplementIPaginate()
         {
@@ -337,7 +332,6 @@ namespace Octopus.Client.Tests.Conventions
                 Assert.Fail($"Most repositories that get resources should implement IPaginate<TResource> unless the repository should target one specific resource like a singleton or child of another aggregate.{Environment.NewLine}{missing.Select(t => t.Name).NewLineSeperate()}");
             }
         }
-#endif
 
         [Test]
         public void AsyncRepositoriesThatImplementCreateShouldAlsoImplementModify()
@@ -365,7 +359,6 @@ namespace Octopus.Client.Tests.Conventions
             }
         }
 
-#if SYNC_CLIENT
         [Test]
         public void SyncRepositoriesThatImplementCreateShouldAlsoImplementModify()
         {
@@ -391,7 +384,6 @@ namespace Octopus.Client.Tests.Conventions
                 Assert.Fail($"Repositories that implement ICreate<IResource> should usually implement IModify<IResource>.{Environment.NewLine}{missingModify.Select(t => t.Name).NewLineSeperate()}");
             }
         }
-#endif
 
         [Test]
         public void AsyncRepositoriesThatImplementCreateShouldAlsoImplementDelete()
@@ -419,7 +411,6 @@ namespace Octopus.Client.Tests.Conventions
             }
         }
 
-#if SYNC_CLIENT
         [Test]
         public void SyncRepositoriesThatImplementCreateShouldAlsoImplementDelete()
         {
@@ -445,7 +436,6 @@ namespace Octopus.Client.Tests.Conventions
                 Assert.Fail($"Repositories that implement ICreate<IResource> should usually implement IDelete<IResource>.{Environment.NewLine}{missingDelete.Select(t => t.Name).NewLineSeperate()}");
             }
         }
-#endif
 
 #if HAS_BEST_CONVENTIONAL
 

--- a/source/Octopus.Client.Tests/Conventions/ClientConventions.cs
+++ b/source/Octopus.Client.Tests/Conventions/ClientConventions.cs
@@ -10,11 +10,8 @@ using Nancy.Extensions;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Repositories.Async;
 using Sync = Octopus.Client.Repositories;
-
-#if HAS_BEST_CONVENTIONAL
 using Conventional;
 using Conventional.Conventions;
-#endif
 
 namespace Octopus.Client.Tests.Conventions
 {
@@ -437,8 +434,6 @@ namespace Octopus.Client.Tests.Conventions
             }
         }
 
-#if HAS_BEST_CONVENTIONAL
-
         [Test]
         public void AllSyncRepositoryInterfacesShouldFollowTheseConventions()
         {
@@ -501,6 +496,5 @@ namespace Octopus.Client.Tests.Conventions
                 return ConventionResult.NotSatisfied(type.FullName, string.Format(FailureMessage, parentNamespace, type.Namespace));
             }
         }
-#endif
     }
 }

--- a/source/Octopus.Client.Tests/Conventions/RepositorySymmetryConventions.cs
+++ b/source/Octopus.Client.Tests/Conventions/RepositorySymmetryConventions.cs
@@ -1,5 +1,4 @@
-﻿#if SYNC_CLIENT
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -181,4 +180,3 @@ namespace Octopus.Client.Tests.Conventions
         }
     }
 }
-#endif

--- a/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
+++ b/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
@@ -48,9 +48,7 @@ namespace Octopus.Client.Tests.Integration
         static IWebHost currentHost;
 
         protected IOctopusAsyncClient AsyncClient { get; private set; }
-#if SYNC_CLIENT
         protected IOctopusClient SyncClient { get; private set; }
-#endif
         [OneTimeSetUp]
         public static void OneTimeSetup()
         {
@@ -152,9 +150,7 @@ namespace Octopus.Client.Tests.Integration
         {
             SetupEnvironmentVariables();
             AsyncClient = await Octopus.Client.OctopusAsyncClient.Create(new OctopusServerEndpoint(HostBaseUri + TestRootPath), GetClientOptions()).ConfigureAwait(false);
-#if SYNC_CLIENT
             SyncClient = new Octopus.Client.OctopusClient(new OctopusServerEndpoint(HostBaseUri + TestRootPath));
-#endif
         }
 
         protected virtual void SetupEnvironmentVariables()
@@ -170,9 +166,7 @@ namespace Octopus.Client.Tests.Integration
         public virtual void TearDown()
         {
             AsyncClient?.Dispose();
-#if SYNC_CLIENT
             SyncClient?.Dispose();
-#endif
             CleanupEnvironmentVariables();
         }
 
@@ -208,11 +202,7 @@ namespace Octopus.Client.Tests.Integration
 
         protected string GetCannedResponse(dynamic parameters)
         {
-#if SYNC_CLIENT
             var assembly = typeof(HttpIntegrationTestBase).Assembly;
-#else
-            var assembly = typeof(HttpIntegrationTestBase).GetTypeInfo().Assembly;
-#endif
             var resourceName = GetResourceNameFromtRequestUri(parameters);
 
             using (var responseStream = assembly.GetManifestResourceStream(resourceName))

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/AntiforgeryTokenTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/AntiforgeryTokenTests.cs
@@ -57,7 +57,6 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
                 .Be(AntiforgeryCookieValue, $"The antiforgery cookie should have been copied to the {ApiConstants.AntiforgeryTokenHttpHeaderName} header.");
         }
 
-#if SYNC_CLIENT
         [Test]
         public void SyncClient_ShouldCopyAntiforgeryCookieToHeader()
         {
@@ -71,7 +70,6 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             secondResponse.AntiforgeryTokenValue.Should()
                 .Be(AntiforgeryCookieValue, $"The antiforgery cookie should have been copied to the {ApiConstants.AntiforgeryTokenHttpHeaderName} header.");
         }
-#endif
 
         public class TestDto
         {

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/BuildServerHeadersBaseTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/BuildServerHeadersBaseTests.cs
@@ -71,7 +71,6 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             response.AutomationContext.Should().Be(ExpectedAutomationEnvironment.ToString(), $"We should set the User-Agent header to have {ExpectedAutomationEnvironment} when {EnvironmentVariableName} is set");
         }
 
-#if SYNC_CLIENT
         [Test]
         public void SyncClient_ShouldProvideBuildServer_WithCorrectValue()
         {
@@ -79,7 +78,6 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             var response = client.Get<TestDto>(TestRootPath);
             response.AutomationContext.Should().Be(ExpectedAutomationEnvironment.ToString(), $"We should set the User-Agent header to have {ExpectedAutomationEnvironment} when {EnvironmentVariableName} is set");
         }
-#endif
 
         public class TestDto
         {

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/UserAgentTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/UserAgentTests.cs
@@ -61,7 +61,6 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             response.UserAgentValue.Should().Be($"{ApiConstants.OctopusUserAgentProductName}/{GetType().GetSemanticVersion().ToNormalizedString()} (TestOS; x64) NoneOrUnknown", "We should set the standard User-Agent header");
         }
 
-#if SYNC_CLIENT
         [Test]
         public void SyncClient_ShouldProvideUserAgent_WithNameAndVersion()
         {
@@ -69,7 +68,6 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             var response = client.Get<TestDto>(TestRootPath);
             response.UserAgentValue.Should().Be($"{ApiConstants.OctopusUserAgentProductName}/{GetType().GetSemanticVersion().ToNormalizedString()} (TestOS; x64) NoneOrUnknown", "We should set the standard User-Agent header");
         }
-#endif
 
         public class TestDto
         {

--- a/source/Octopus.Client.Tests/Integration/Repository/MachineRepositoryTest.cs
+++ b/source/Octopus.Client.Tests/Integration/Repository/MachineRepositoryTest.cs
@@ -41,4 +41,4 @@ namespace Octopus.Client.Tests.Integration.Repository
             Assert.That(tasks.Count, Is.EqualTo(139));
         }
     }
-}    
+}

--- a/source/Octopus.Client.Tests/Integration/Repository/MachineRepositoryTest.cs
+++ b/source/Octopus.Client.Tests/Integration/Repository/MachineRepositoryTest.cs
@@ -31,16 +31,14 @@ namespace Octopus.Client.Tests.Integration.Repository
             Assert.That(tasks.Count, Is.EqualTo(139));
         }
 
-#if SYNC_CLIENT
         [Test]
         public void SyncGetTasksReturnsAllPages()
         {
-            var machine = new MachineResource { Links = new LinkCollection { { "TasksTemplate", $"{TestRootPath}api/machines/Machines-1/tasks{{?skip}}" } } };
+            var machine = new MachineResource { Links = new LinkCollection {{"TasksTemplate", $"{TestRootPath}api/machines/Machines-1/tasks{{?skip}}"}} };
             var repository = new Client.Repositories.MachineRepository(SyncClient.Repository);
             var tasks = repository.GetTasks(machine);
 
             Assert.That(tasks.Count, Is.EqualTo(139));
         }
-#endif
     }
-}
+}    

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);HAS_BEST_CONVENTIONAL</DefineConstants>
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier> <!-- So that libuv is copied correctly -->
     <BaseNuGetRuntimeIdentifier>win7-x86</BaseNuGetRuntimeIdentifier> <!-- So that libuv is copied correctly -->
   </PropertyGroup>
@@ -46,31 +45,29 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Libuv" Version="1.10.0" />
-    <PackageReference Include="Best.Conventional" Version="1.3.0.122" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Best.Conventional" Version="1.3.0.122" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Best.Conventional" Version="5.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
   </ItemGroup>
 
-
   <ItemGroup>
     <EmbeddedResource Include="**\*.pfx" />
     <EmbeddedResource Include="CannedResponses\**\*.json" />
   </ItemGroup>
 
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);HAS_BEST_CONVENTIONAL;SYNC_CLIENT</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_BEST_CONVENTIONAL</DefineConstants>
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier> <!-- So that libuv is copied correctly -->
     <BaseNuGetRuntimeIdentifier>win7-x86</BaseNuGetRuntimeIdentifier> <!-- So that libuv is copied correctly -->
   </PropertyGroup>

--- a/source/Octopus.Client.Tests/Repositories/OctopusRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/OctopusRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿#if SYNC_CLIENT
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -62,4 +61,3 @@ namespace Octopus.Client.Tests.Repositories
         }
     }
 }
-#endif


### PR DESCRIPTION
As we now ship a sync client for both net452 and netcore

Also remove `HAS BEST_CONVENTIONAL` as that is also available for netcore.
