### PR TITLE
ILMerge octodiff, and fix nupkg package to remove unneeded dependencies

### DIFF
--- a/source/Octopus.Client/Octopus.Client.nuspec
+++ b/source/Octopus.Client/Octopus.Client.nuspec
@@ -14,11 +14,18 @@
         <copyright>Octopus Deploy Pty Ltd</copyright>
         <repository type="git" url="https://github.com/OctopusDeploy/OctopusClients" />
         <dependencies>
+            <group targetFramework=".NETFramework4.5">
+            </group>
             <group targetFramework=".NETStandard2.0">
                 <dependency id="Microsoft.CSharp" version="4.5.0" exclude="Build,Analyzers" />
                 <dependency id="System.ComponentModel.Annotations" version="4.5.0" exclude="Build,Analyzers" />
             </group>
         </dependencies>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework=".NETFramework4.5" />
+            <frameworkAssembly assemblyName="System.Net.Http" targetFramework=".NETFramework4.5" />
+            <frameworkAssembly assemblyName="System.Numerics" targetFramework=".NETFramework4.5" />
+        </frameworkAssemblies>
     </metadata>
     <files>
         <file src="bin\release\net45\Octopus.Client.dll" target="lib\net45" />

--- a/source/Octopus.Client/Octopus.Client.nuspec
+++ b/source/Octopus.Client/Octopus.Client.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+    <metadata>
+        <id>Octopus.Client</id>
+        <version>$version$</version>
+        <authors>Octopus Deploy</authors>
+        <owners>Octopus Deploy</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <licenseUrl>http://octopusdeploy.com/pricing</licenseUrl>
+        <projectUrl>http://octopusdeploy.com/</projectUrl>
+        <iconUrl>http://i.octopusdeploy.com/resources/Avatar3-32x32.png</iconUrl>
+        <description>Octopus Deploy is an automated release management tool for modern developers and DevOps teams. 
+            This package contains the client library for the HTTP API in Octopus.</description>
+        <copyright>Octopus Deploy Pty Ltd</copyright>
+        <repository type="git" url="https://github.com/OctopusDeploy/OctopusClients" />
+        <dependencies>
+            <group targetFramework=".NETStandard2.0">
+                <dependency id="Microsoft.CSharp" version="4.5.0" exclude="Build,Analyzers" />
+                <dependency id="System.ComponentModel.Annotations" version="4.5.0" exclude="Build,Analyzers" />
+            </group>
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="bin\release\net45\Octopus.Client.dll" target="lib\net45" />
+        <file src="bin\release\net45\Octopus.Client.xml" target="lib\net45" />
+        <file src="bin\release\netstandard2.0\Octopus.Client.dll" target="lib\netstandard2.0" />
+        <file src="bin\release\netstandard2.0\Octopus.Client.xml" target="lib\netstandard2.0" />
+    </files>
+</package>


### PR DESCRIPTION
Because we were using raw `dotnet pack` to create the dll, it was assuming that all the dependencies from the project file should be used as dependencies of the nuget package. However, it didn't know that we'd already ILMerged the `newtonsoft.json` dependency in.

This PR modifies the nupkg so that it no longer lists these dependencies.

We also spotted that octodiff was not being inlined anymore, so this is now being inlined again.

Fixes https://github.com/OctopusDeploy/OctopusClients/issues/453