### PR TITLE
Add missing AmazonWebServicesAccount to ControlType

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1486,6 +1486,8 @@ Octopus.Client.Model
     String Label { get; set; }
     String Name { get; set; }
     String GetControlType()
+    Boolean IsAmazonWebServicesAccount()
+    Boolean IsAzureAccount()
     Boolean IsCertificate()
     Boolean IsControlType(String)
     Boolean IsSensitive()
@@ -2138,6 +2140,7 @@ Octopus.Client.Model
   }
   abstract class ControlType
   {
+    static System.String AmazonWebServicesAccount
     static System.String AzureAccount
     static System.String Certificate
     static System.String Checkbox

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1501,6 +1501,8 @@ Octopus.Client.Model
     String Label { get; set; }
     String Name { get; set; }
     String GetControlType()
+    Boolean IsAmazonWebServicesAccount()
+    Boolean IsAzureAccount()
     Boolean IsCertificate()
     Boolean IsControlType(String)
     Boolean IsSensitive()
@@ -2154,6 +2156,7 @@ Octopus.Client.Model
   }
   abstract class ControlType
   {
+    static System.String AmazonWebServicesAccount
     static System.String AzureAccount
     static System.String Certificate
     static System.String Checkbox

--- a/source/Octopus.Client/Model/ActionTemplateParameterResource.cs
+++ b/source/Octopus.Client/Model/ActionTemplateParameterResource.cs
@@ -39,6 +39,16 @@ namespace Octopus.Client.Model
         {
             return IsControlType(ControlType.Sensitive);
         }
+        
+        public bool IsAmazonWebServicesAccount()
+        {
+            return IsControlType(ControlType.AmazonWebServicesAccount);
+        }
+        
+        public bool IsAzureAccount()
+        {
+            return IsControlType(ControlType.AzureAccount);
+        }
 
         public string GetControlType()
         {

--- a/source/Octopus.Client/Model/ControlType.cs
+++ b/source/Octopus.Client/Model/ControlType.cs
@@ -13,6 +13,7 @@ namespace Octopus.Client.Model
         public const string Sensitive = "Sensitive";
         public const string StepName = "StepName";
         public const string AzureAccount = "AzureAccount";
+        public const string AmazonWebServicesAccount = "AmazonWebServicesAccount";
         public const string Certificate = "Certificate";
 
         public static Dictionary<string, string> AsDisplaySettings(string controlType)


### PR DESCRIPTION
Needed for some tests in server - see https://github.com/OctopusDeploy/OctopusDeploy/pull/4400/files#diff-ff3d599cf4037ea089a39cf5a9320979R191

Relates to https://github.com/OctopusDeploy/OctopusDeploy/pull/4400
Relates to OctopusDeploy/Issues#5835