### PR TITLE
Deployment changes (notes)

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2402,7 +2402,6 @@ Octopus.Client.Model
     Dictionary<String, String> FormValues { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
-    String Notes { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2343,8 +2343,9 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
+    List<ReleaseChanges> Changes { get; set; }
+    String ChangesMarkdown { get; set; }
     Octopus.Client.Model.Forms.Form Form { get; set; }
-    List<ReleaseChanges> ReleaseNotes { get; set; }
     List<DeploymentTemplateStep> StepsToExecute { get; set; }
     Boolean UseGuidedFailureModeByDefault { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3671,6 +3671,7 @@ Octopus.Client.Model
     String ClonedFromProjectId { get; set; }
     Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
     Boolean DefaultToSkipIfAlreadyInstalled { get; set; }
+    String DeploymentChangesTemplate { get; set; }
     String DeploymentProcessId { get; set; }
     String Description { get; set; }
     Boolean DiscreteChannelRelease { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2394,7 +2394,6 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    String DeploymentNotes { get; set; }
     String DeploymentProcessId { get; set; }
     String EnvironmentId { get; set; }
     Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
@@ -2403,6 +2402,7 @@ Octopus.Client.Model
     Dictionary<String, String> FormValues { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
+    String Notes { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2355,6 +2355,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
+    String DeploymentNotesTemplate { get; set; }
     String LastSnapshotId { get; set; }
     String ProjectId { get; set; }
     String SpaceId { get; set; }
@@ -2393,6 +2394,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    String DeploymentNotes { get; set; }
     String DeploymentProcessId { get; set; }
     String EnvironmentId { get; set; }
     Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2355,7 +2355,6 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    String DeploymentNotesTemplate { get; set; }
     String LastSnapshotId { get; set; }
     String ProjectId { get; set; }
     String SpaceId { get; set; }
@@ -2391,6 +2390,7 @@ Octopus.Client.Model
   {
     .ctor()
     List<ReleaseChanges> Changes { get; set; }
+    String ChangesMarkdown { get; set; }
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2371,7 +2371,6 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    String DeploymentNotesTemplate { get; set; }
     String LastSnapshotId { get; set; }
     String ProjectId { get; set; }
     String SpaceId { get; set; }
@@ -2407,6 +2406,7 @@ Octopus.Client.Model
   {
     .ctor()
     List<ReleaseChanges> Changes { get; set; }
+    String ChangesMarkdown { get; set; }
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2410,7 +2410,6 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    String DeploymentNotes { get; set; }
     String DeploymentProcessId { get; set; }
     String EnvironmentId { get; set; }
     Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
@@ -2419,6 +2418,7 @@ Octopus.Client.Model
     Dictionary<String, String> FormValues { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
+    String Notes { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2371,6 +2371,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
+    String DeploymentNotesTemplate { get; set; }
     String LastSnapshotId { get; set; }
     String ProjectId { get; set; }
     String SpaceId { get; set; }
@@ -2409,6 +2410,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    String DeploymentNotes { get; set; }
     String DeploymentProcessId { get; set; }
     String EnvironmentId { get; set; }
     Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2418,7 +2418,6 @@ Octopus.Client.Model
     Dictionary<String, String> FormValues { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
-    String Notes { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3690,6 +3690,7 @@ Octopus.Client.Model
     String ClonedFromProjectId { get; set; }
     Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
     Boolean DefaultToSkipIfAlreadyInstalled { get; set; }
+    String DeploymentChangesTemplate { get; set; }
     String DeploymentProcessId { get; set; }
     String Description { get; set; }
     Boolean DiscreteChannelRelease { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2359,8 +2359,9 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
+    List<ReleaseChanges> Changes { get; set; }
+    String ChangesMarkdown { get; set; }
     Octopus.Client.Model.Forms.Form Form { get; set; }
-    List<ReleaseChanges> ReleaseNotes { get; set; }
     List<DeploymentTemplateStep> StepsToExecute { get; set; }
     Boolean UseGuidedFailureModeByDefault { get; set; }
   }

--- a/source/Octopus.Client/Model/DeploymentPreviewResource.cs
+++ b/source/Octopus.Client/Model/DeploymentPreviewResource.cs
@@ -10,6 +10,7 @@ namespace Octopus.Client.Model
         public Form Form { get; set; }
         public bool UseGuidedFailureModeByDefault { get; set; }
 
-        public List<ReleaseChanges> ReleaseNotes { get; set; }
+        public List<ReleaseChanges> Changes { get; set; }
+        public string ChangesMarkdown { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/DeploymentProcessResource.cs
+++ b/source/Octopus.Client/Model/DeploymentProcessResource.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Octopus.Client.Extensibility;
-using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model
 {

--- a/source/Octopus.Client/Model/DeploymentProcessResource.cs
+++ b/source/Octopus.Client/Model/DeploymentProcessResource.cs
@@ -22,9 +22,6 @@ namespace Octopus.Client.Model
         public int Version { get; set; }
 
         public string LastSnapshotId { get; set; }
-        
-        [Writeable]
-        public string DeploymentNotesTemplate { get; set; }
 
         public DeploymentStepResource FindStep(string name)
         {

--- a/source/Octopus.Client/Model/DeploymentProcessResource.cs
+++ b/source/Octopus.Client/Model/DeploymentProcessResource.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Octopus.Client.Extensibility;
+using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model
 {
@@ -21,6 +22,9 @@ namespace Octopus.Client.Model
         public int Version { get; set; }
 
         public string LastSnapshotId { get; set; }
+        
+        [Writeable]
+        public string DeploymentNotesTemplate { get; set; }
 
         public DeploymentStepResource FindStep(string name)
         {

--- a/source/Octopus.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Client/Model/DeploymentResource.cs
@@ -63,6 +63,8 @@ namespace Octopus.Client.Model
 
         [WriteableOnCreate]
         public string Comments { get; set; }
+        
+        public string DeploymentNotes { get; set; }
 
         [WriteableOnCreate]
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]

--- a/source/Octopus.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Client/Model/DeploymentResource.cs
@@ -64,7 +64,7 @@ namespace Octopus.Client.Model
         [WriteableOnCreate]
         public string Comments { get; set; }
         
-        public string DeploymentNotes { get; set; }
+        public string Notes { get; set; }
 
         [WriteableOnCreate]
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]

--- a/source/Octopus.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Client/Model/DeploymentResource.cs
@@ -76,7 +76,7 @@ namespace Octopus.Client.Model
 
         [WriteableOnCreate]
         public string Comments { get; set; }
-        
+
         [WriteableOnCreate]
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]
         public Dictionary<string, string> FormValues { get; set; }

--- a/source/Octopus.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Client/Model/DeploymentResource.cs
@@ -64,8 +64,6 @@ namespace Octopus.Client.Model
         [WriteableOnCreate]
         public string Comments { get; set; }
         
-        public string Notes { get; set; }
-
         [WriteableOnCreate]
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]
         public Dictionary<string, string> FormValues { get; set; }
@@ -84,5 +82,7 @@ namespace Octopus.Client.Model
         public string SpaceId { get; set; }
 
         public List<ReleaseChanges> Changes { get; set; }
+
+        public string ChangesMarkdown { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/ProjectResource.cs
+++ b/source/Octopus.Client/Model/ProjectResource.cs
@@ -106,6 +106,9 @@ namespace Octopus.Client.Model
         
         [Writeable]
         public string ReleaseNotesTemplate { get; set; }
+        
+        [Writeable]
+        public string DeploymentChangesTemplate { get; set; }
 
         public ProjectResource Clear()
         {


### PR DESCRIPTION
New fields to allow setting of a deployment changes template. This is used during the deployment creation to generate ChangesMarkdown, which is used to render in the portal and can be used from email templates etc.

Relates to OctopusDeploy/Issues#5604