### PR TITLE
Update scope resource changes for runbook process scoping

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4237,6 +4237,8 @@ Octopus.Client.Model
       Channel = 8
       TenantTag = 9
       Tenant = 10
+      DeploymentProcessOwner = 11
+      RunbookProcessOwner = 12
   }
   class ScopeSpecification
     IDictionary<ScopeField, ScopeValue>
@@ -4943,9 +4945,11 @@ Octopus.Client.Model
     .ctor()
     List<ReferenceDataItem> Actions { get; set; }
     List<ReferenceDataItem> Channels { get; set; }
+    List<ReferenceDataItem> DeploymentProcesses { get; set; }
     List<ReferenceDataItem> Environments { get; set; }
     List<ReferenceDataItem> Machines { get; set; }
     List<ReferenceDataItem> Roles { get; set; }
+    List<ReferenceDataItem> RunbookProcesses { get; set; }
     List<ReferenceDataItem> TenantTags { get; set; }
   }
   VariableSetContentType

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3731,6 +3731,12 @@ Octopus.Client.Model
     Octopus.Client.Model.PhaseResource WithReleaseRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
     Octopus.Client.Model.PhaseResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
   }
+  class ProcessReferenceDataItem
+    Octopus.Client.Model.ReferenceDataItem
+  {
+    .ctor(String, String, Octopus.Client.Model.ProcessType)
+    Octopus.Client.Model.ProcessType ProcessType { get; set; }
+  }
   ProcessType
   {
       Deployment = 0
@@ -4237,8 +4243,7 @@ Octopus.Client.Model
       Channel = 8
       TenantTag = 9
       Tenant = 10
-      DeploymentProcessOwner = 11
-      RunbookProcessOwner = 12
+      ProcessOwner = 11
   }
   class ScopeSpecification
     IDictionary<ScopeField, ScopeValue>
@@ -4945,11 +4950,10 @@ Octopus.Client.Model
     .ctor()
     List<ReferenceDataItem> Actions { get; set; }
     List<ReferenceDataItem> Channels { get; set; }
-    List<ReferenceDataItem> DeploymentProcesses { get; set; }
     List<ReferenceDataItem> Environments { get; set; }
     List<ReferenceDataItem> Machines { get; set; }
+    List<ProcessReferenceDataItem> Processes { get; set; }
     List<ReferenceDataItem> Roles { get; set; }
-    List<ReferenceDataItem> RunbookProcesses { get; set; }
     List<ReferenceDataItem> TenantTags { get; set; }
   }
   VariableSetContentType

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3750,6 +3750,12 @@ Octopus.Client.Model
     Octopus.Client.Model.PhaseResource WithReleaseRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
     Octopus.Client.Model.PhaseResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
   }
+  class ProcessReferenceDataItem
+    Octopus.Client.Model.ReferenceDataItem
+  {
+    .ctor(String, String, Octopus.Client.Model.ProcessType)
+    Octopus.Client.Model.ProcessType ProcessType { get; set; }
+  }
   ProcessType
   {
       Deployment = 0
@@ -4256,6 +4262,7 @@ Octopus.Client.Model
       Channel = 8
       TenantTag = 9
       Tenant = 10
+      ProcessOwner = 11
   }
   class ScopeSpecification
     IDictionary<ScopeField, ScopeValue>
@@ -4969,6 +4976,7 @@ Octopus.Client.Model
     List<ReferenceDataItem> Channels { get; set; }
     List<ReferenceDataItem> Environments { get; set; }
     List<ReferenceDataItem> Machines { get; set; }
+    List<ProcessReferenceDataItem> Processes { get; set; }
     List<ReferenceDataItem> Roles { get; set; }
     List<ReferenceDataItem> TenantTags { get; set; }
   }

--- a/source/Octopus.Client/Model/ProcessReferenceDataItem.cs
+++ b/source/Octopus.Client/Model/ProcessReferenceDataItem.cs
@@ -1,0 +1,11 @@
+namespace Octopus.Client.Model
+{
+    public class ProcessReferenceDataItem: ReferenceDataItem {
+        public ProcessType ProcessType { get; set; }
+
+        public ProcessReferenceDataItem(string id, string name, ProcessType processType) : base(id, name)
+        {
+            ProcessType = processType;
+        }
+    }
+}

--- a/source/Octopus.Client/Model/ScopeField.cs
+++ b/source/Octopus.Client/Model/ScopeField.cs
@@ -15,7 +15,6 @@ namespace Octopus.Client.Model
         Channel,
         TenantTag,
         Tenant, 
-        DeploymentProcessOwner,
-        RunbookProcessOwner
+        ProcessOwner,
     }
 }

--- a/source/Octopus.Client/Model/ScopeField.cs
+++ b/source/Octopus.Client/Model/ScopeField.cs
@@ -14,6 +14,8 @@ namespace Octopus.Client.Model
         Private, // Allows inbuilt vars to override user ones
         Channel,
         TenantTag,
-        Tenant
+        Tenant, 
+        DeploymentProcessOwner,
+        RunbookProcessOwner
     }
 }

--- a/source/Octopus.Client/Model/ScopeSpecification.cs
+++ b/source/Octopus.Client/Model/ScopeSpecification.cs
@@ -18,6 +18,7 @@ namespace Octopus.Client.Model
             return copy;
         }
 
+        [Obsolete("Rank usage is deprecated. Please see https://octopus.com/docs/deployment-process/variables for variable specificity rules.")]
         public int Rank()
         {
             var score = 0;

--- a/source/Octopus.Client/Model/VariableScopeValues.cs
+++ b/source/Octopus.Client/Model/VariableScopeValues.cs
@@ -12,8 +12,7 @@ namespace Octopus.Client.Model
             Roles = new List<ReferenceDataItem>();
             Channels = new List<ReferenceDataItem>();
             TenantTags = new List<ReferenceDataItem>();
-            RunbookProcesses = new List<ReferenceDataItem>();
-            DeploymentProcesses = new List<ReferenceDataItem>();
+            Processes = new List<ProcessReferenceDataItem>();
         }
 
         public List<ReferenceDataItem> Environments { get; set; }
@@ -22,7 +21,6 @@ namespace Octopus.Client.Model
         public List<ReferenceDataItem> Roles { get; set; }
         public List<ReferenceDataItem> Channels { get; set; }
         public List<ReferenceDataItem> TenantTags { get; set; }
-        public List<ReferenceDataItem> DeploymentProcesses { get; set; }
-        public List<ReferenceDataItem> RunbookProcesses { get; set; }
+        public List<ProcessReferenceDataItem> Processes { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/VariableScopeValues.cs
+++ b/source/Octopus.Client/Model/VariableScopeValues.cs
@@ -12,6 +12,8 @@ namespace Octopus.Client.Model
             Roles = new List<ReferenceDataItem>();
             Channels = new List<ReferenceDataItem>();
             TenantTags = new List<ReferenceDataItem>();
+            RunbookProcesses = new List<ReferenceDataItem>();
+            DeploymentProcesses = new List<ReferenceDataItem>();
         }
 
         public List<ReferenceDataItem> Environments { get; set; }
@@ -19,7 +21,8 @@ namespace Octopus.Client.Model
         public List<ReferenceDataItem> Actions { get; set; }
         public List<ReferenceDataItem> Roles { get; set; }
         public List<ReferenceDataItem> Channels { get; set; }
-
         public List<ReferenceDataItem> TenantTags { get; set; }
+        public List<ReferenceDataItem> DeploymentProcesses { get; set; }
+        public List<ReferenceDataItem> RunbookProcesses { get; set; }
     }
 }


### PR DESCRIPTION
In the previous cycle for runbooks we did not deal with scoping variables to particular runbooks which prevented us from enabling prompted variables. This PR adds the client resource changes needed to support scoping variables to runbooks and deployment processes
