### PR TITLE
Add deployedby to deployment resource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2433,6 +2433,7 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    String DeployedBy { get; set; }
     String EnvironmentId { get; set; }
     Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
     Boolean ForcePackageDownload { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2449,6 +2449,7 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    String DeployedBy { get; set; }
     String EnvironmentId { get; set; }
     Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
     Boolean ForcePackageDownload { get; set; }

--- a/source/Octopus.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Client/Model/DeploymentResource.cs
@@ -93,5 +93,7 @@ namespace Octopus.Client.Model
         public DateTimeOffset Created { get; set; }
 
         public string SpaceId { get; set; }
+        
+        public string DeployedBy { get; set; }
     }
 }


### PR DESCRIPTION
We store deployed by on a deployment, but we were making people jump through hoops to get it from the events endpoint.

Relates to https://github.com/OctopusDeploy/Issues/issues/5925