### PR TITLE
Refactoring Runbook-related resources

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3995,6 +3995,7 @@ Octopus.Client.Model
   {
     .ctor()
     .ctor(String, String, String)
+    .ctor(String, String)
     DateTimeOffset Assembled { get; set; }
     List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -160,7 +160,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IProxyRepository Proxies { get; }
     Octopus.Client.Repositories.Async.IReleaseRepository Releases { get; }
     Octopus.Client.Repositories.Async.IRetentionPolicyRepository RetentionPolicies { get; }
-    Octopus.Client.Repositories.Async.IRunbookProcessRepository RunbookProcess { get; }
+    Octopus.Client.Repositories.Async.IRunbookProcessRepository RunbookProcesses { get; }
     Octopus.Client.Repositories.Async.IRunbookRunRepository RunbookRuns { get; }
     Octopus.Client.Repositories.Async.IRunbookRepository Runbooks { get; }
     Octopus.Client.Repositories.Async.IRunbookSnapshotRepository RunbookSnapshots { get; }
@@ -204,7 +204,7 @@ Octopus.Client
     Octopus.Client.Repositories.IProxyRepository Proxies { get; }
     Octopus.Client.Repositories.IReleaseRepository Releases { get; }
     Octopus.Client.Repositories.IRetentionPolicyRepository RetentionPolicies { get; }
-    Octopus.Client.Repositories.IRunbookProcessRepository RunbookProcess { get; }
+    Octopus.Client.Repositories.IRunbookProcessRepository RunbookProcesses { get; }
     Octopus.Client.Repositories.IRunbookRunRepository RunbookRuns { get; }
     Octopus.Client.Repositories.IRunbookRepository Runbooks { get; }
     Octopus.Client.Repositories.IRunbookSnapshotRepository RunbookSnapshots { get; }
@@ -335,7 +335,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IProxyRepository Proxies { get; }
     Octopus.Client.Repositories.Async.IReleaseRepository Releases { get; }
     Octopus.Client.Repositories.Async.IRetentionPolicyRepository RetentionPolicies { get; }
-    Octopus.Client.Repositories.Async.IRunbookProcessRepository RunbookProcess { get; }
+    Octopus.Client.Repositories.Async.IRunbookProcessRepository RunbookProcesses { get; }
     Octopus.Client.Repositories.Async.IRunbookRunRepository RunbookRuns { get; }
     Octopus.Client.Repositories.Async.IRunbookRepository Runbooks { get; }
     Octopus.Client.Repositories.Async.IRunbookSnapshotRepository RunbookSnapshots { get; }
@@ -466,7 +466,7 @@ Octopus.Client
     Octopus.Client.Repositories.IProxyRepository Proxies { get; }
     Octopus.Client.Repositories.IReleaseRepository Releases { get; }
     Octopus.Client.Repositories.IRetentionPolicyRepository RetentionPolicies { get; }
-    Octopus.Client.Repositories.IRunbookProcessRepository RunbookProcess { get; }
+    Octopus.Client.Repositories.IRunbookProcessRepository RunbookProcesses { get; }
     Octopus.Client.Repositories.IRunbookRunRepository RunbookRuns { get; }
     Octopus.Client.Repositories.IRunbookRepository Runbooks { get; }
     Octopus.Client.Repositories.IRunbookSnapshotRepository RunbookSnapshots { get; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3996,6 +3996,7 @@ Octopus.Client.Model
     .ctor()
     .ctor(String, String, String)
     .ctor(String, String)
+    .ctor(String)
     DateTimeOffset Assembled { get; set; }
     List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2424,33 +2424,6 @@ Octopus.Client.Model
       Approved = 0
       Rejected = 1
   }
-  class DeploymentBaseResource
-    Octopus.Client.Extensibility.IResource
-    Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.Resource
-  {
-    .ctor()
-    String Comments { get; set; }
-    DateTimeOffset Created { get; set; }
-    String DeployedBy { get; set; }
-    String EnvironmentId { get; set; }
-    Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
-    Boolean ForcePackageDownload { get; set; }
-    Boolean ForcePackageRedeployment { get; set; }
-    Dictionary<String, String> FormValues { get; set; }
-    String ManifestVariableSetId { get; set; }
-    String Name { get; set; }
-    String ProjectId { get; set; }
-    Nullable<DateTimeOffset> QueueTime { get; set; }
-    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
-    Octopus.Client.Model.ReferenceCollection SkipActions { get; set; }
-    String SpaceId { get; set; }
-    Octopus.Client.Model.ReferenceCollection SpecificMachineIds { get; set; }
-    String TaskId { get; set; }
-    String TenantId { get; set; }
-    Boolean UseGuidedFailure { get; set; }
-  }
   class DeploymentPreviewBaseResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -2470,9 +2443,10 @@ Octopus.Client.Model
     List<ReleaseChanges> Changes { get; set; }
     String ChangesMarkdown { get; set; }
   }
-  class DeploymentProcessBaseResource
+  class DeploymentProcessResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IProcessResource
     Octopus.Client.Extensibility.IHaveSpaceResource
     Octopus.Client.Model.Resource
   {
@@ -2483,17 +2457,9 @@ Octopus.Client.Model
     IList<DeploymentStepResource> Steps { get; }
     Int32 Version { get; set; }
     Octopus.Client.Model.DeploymentStepResource AddOrUpdateStep(String)
-    Octopus.Client.Model.DeploymentProcessBaseResource ClearSteps()
+    Octopus.Client.Model.IProcessResource ClearSteps()
     Octopus.Client.Model.DeploymentStepResource FindStep(String)
-    Octopus.Client.Model.DeploymentProcessBaseResource RemoveStep(String)
-  }
-  class DeploymentProcessResource
-    Octopus.Client.Extensibility.IResource
-    Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.DeploymentProcessBaseResource
-  {
-    .ctor()
+    Octopus.Client.Model.IProcessResource RemoveStep(String)
   }
   class DeploymentPromomotionTenant
     Octopus.Client.Extensibility.IResource
@@ -2515,15 +2481,39 @@ Octopus.Client.Model
   class DeploymentResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IExecutionResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.DeploymentBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
     List<ReleaseChanges> Changes { get; set; }
     String ChangesMarkdown { get; set; }
     String ChannelId { get; set; }
+    String Comments { get; set; }
+    DateTimeOffset Created { get; set; }
+    String DeployedBy { get; set; }
+    String DeployedById { get; set; }
+    Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
     String DeploymentProcessId { get; set; }
+    String EnvironmentId { get; set; }
+    Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
+    Boolean FailureEncountered { get; set; }
+    Boolean ForcePackageDownload { get; set; }
+    Boolean ForcePackageRedeployment { get; set; }
+    Dictionary<String, String> FormValues { get; set; }
+    String ManifestVariableSetId { get; set; }
+    String Name { get; set; }
+    String ProjectId { get; set; }
+    Nullable<DateTimeOffset> QueueTime { get; set; }
+    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
     String ReleaseId { get; set; }
+    Octopus.Client.Model.ReferenceCollection SkipActions { get; set; }
+    String SpaceId { get; set; }
+    Octopus.Client.Model.ReferenceCollection SpecificMachineIds { get; set; }
+    String TaskId { get; set; }
+    String TenantId { get; set; }
+    Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
+    Boolean UseGuidedFailure { get; set; }
   }
   DeploymentStepCondition
   {
@@ -2907,6 +2897,32 @@ Octopus.Client.Model
     Dictionary<String, IdentityClaimResource> Claims { get; }
     String IdentityProviderName { get; set; }
   }
+  interface IExecutionResource
+    Octopus.Client.Extensibility.IResource
+  {
+    String Comments { get; set; }
+    DateTimeOffset Created { get; set; }
+    String DeployedBy { get; set; }
+    String DeployedById { get; set; }
+    Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
+    String EnvironmentId { get; set; }
+    Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
+    Boolean FailureEncountered { get; }
+    Boolean ForcePackageDownload { get; set; }
+    Boolean ForcePackageRedeployment { get; set; }
+    Dictionary<String, String> FormValues { get; set; }
+    String ManifestVariableSetId { get; set; }
+    String Name { get; set; }
+    String ProjectId { get; set; }
+    Nullable<DateTimeOffset> QueueTime { get; set; }
+    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
+    Octopus.Client.Model.ReferenceCollection SkipActions { get; set; }
+    Octopus.Client.Model.ReferenceCollection SpecificMachineIds { get; set; }
+    String TaskId { get; set; }
+    String TenantId { get; set; }
+    Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
+    Boolean UseGuidedFailure { get; set; }
+  }
   class InterruptionResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -2939,6 +2955,27 @@ Octopus.Client.Model
     DateTimeOffset Expires { get; set; }
     String InvitationCode { get; set; }
     String SpaceId { get; set; }
+  }
+  interface IProcessResource
+    Octopus.Client.Extensibility.IResource
+  {
+    String LastSnapshotId { get; set; }
+    String ProjectId { get; set; }
+    IList<DeploymentStepResource> Steps { get; }
+    Int32 Version { get; set; }
+    Octopus.Client.Model.DeploymentStepResource AddOrUpdateStep(String)
+    Octopus.Client.Model.IProcessResource ClearSteps()
+    Octopus.Client.Model.DeploymentStepResource FindStep(String)
+    Octopus.Client.Model.IProcessResource RemoveStep(String)
+  }
+  interface ISnapshotResource
+    Octopus.Client.Extensibility.IResource
+  {
+    DateTimeOffset Assembled { get; set; }
+    List<String> LibraryVariableSetSnapshotIds { get; set; }
+    String ProjectId { get; set; }
+    String ProjectVariableSetSnapshotId { get; set; }
+    List<SelectedPackage> SelectedPackages { get; }
   }
   interface IVariableTemplateContainer
   {
@@ -3923,20 +3960,6 @@ Octopus.Client.Model
     .ctor()
     String InvitationCode { get; set; }
   }
-  class ReleaseBaseResource
-    Octopus.Client.Extensibility.IResource
-    Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.Resource
-  {
-    .ctor()
-    .ctor(String)
-    DateTimeOffset Assembled { get; set; }
-    List<String> LibraryVariableSetSnapshotIds { get; set; }
-    String ProjectId { get; set; }
-    List<SelectedPackage> SelectedPackages { get; set; }
-    String SpaceId { get; set; }
-  }
   class ReleaseChanges
   {
     .ctor()
@@ -3966,18 +3989,23 @@ Octopus.Client.Model
   class ReleaseResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.ISnapshotResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.ReleaseBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
     .ctor(String, String, String)
-    .ctor(String, String)
-    List<ReleaseBuildInformationResource> BuildInformation { get; set; }
+    DateTimeOffset Assembled { get; set; }
+    List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }
     Boolean IgnoreChannelRules { get; set; }
+    List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }
+    String ProjectId { get; set; }
     String ProjectVariableSetSnapshotId { get; set; }
     String ReleaseNotes { get; set; }
+    List<SelectedPackage> SelectedPackages { get; set; }
+    String SpaceId { get; set; }
     String Version { get; set; }
   }
   class ReleaseSummaryResource
@@ -4115,11 +4143,21 @@ Octopus.Client.Model
   class RunbookProcessResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IProcessResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.DeploymentProcessBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
+    String LastSnapshotId { get; set; }
+    String ProjectId { get; set; }
     String RunbookId { get; set; }
+    String SpaceId { get; set; }
+    IList<DeploymentStepResource> Steps { get; }
+    Int32 Version { get; set; }
+    Octopus.Client.Model.DeploymentStepResource AddOrUpdateStep(String)
+    Octopus.Client.Model.IProcessResource ClearSteps()
+    Octopus.Client.Model.DeploymentStepResource FindStep(String)
+    Octopus.Client.Model.IProcessResource RemoveStep(String)
   }
   class RunbookResource
     Octopus.Client.Extensibility.IResource
@@ -4145,13 +4183,37 @@ Octopus.Client.Model
   class RunbookRunResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IExecutionResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.DeploymentBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
+    String Comments { get; set; }
+    DateTimeOffset Created { get; set; }
+    String DeployedBy { get; set; }
+    String DeployedById { get; set; }
+    Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
+    String EnvironmentId { get; set; }
+    Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
+    Boolean FailureEncountered { get; set; }
+    Boolean ForcePackageDownload { get; set; }
+    Boolean ForcePackageRedeployment { get; set; }
+    Dictionary<String, String> FormValues { get; set; }
     String FrozenRunbookProcessId { get; set; }
+    String ManifestVariableSetId { get; set; }
+    String Name { get; set; }
+    String ProjectId { get; set; }
+    Nullable<DateTimeOffset> QueueTime { get; set; }
+    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
     String RunbookId { get; set; }
     String RunbookSnapshotId { get; set; }
+    Octopus.Client.Model.ReferenceCollection SkipActions { get; set; }
+    String SpaceId { get; set; }
+    Octopus.Client.Model.ReferenceCollection SpecificMachineIds { get; set; }
+    String TaskId { get; set; }
+    String TenantId { get; set; }
+    Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
+    Boolean UseGuidedFailure { get; set; }
   }
   class RunbookRunTemplateResource
     Octopus.Client.Extensibility.IResource
@@ -4164,15 +4226,23 @@ Octopus.Client.Model
   class RunbookSnapshotResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.ISnapshotResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.ReleaseBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
     .ctor(String)
+    DateTimeOffset Assembled { get; set; }
     String FrozenProjectVariableSetId { get; set; }
     String FrozenRunbookProcessId { get; set; }
+    List<String> LibraryVariableSetSnapshotIds { get; set; }
     String Name { get; set; }
+    String Notes { get; set; }
+    String ProjectId { get; set; }
+    String ProjectVariableSetSnapshotId { get; set; }
     String RunbookId { get; set; }
+    List<SelectedPackage> SelectedPackages { get; set; }
+    String SpaceId { get; set; }
   }
   class RunbookSnapshotTemplateResource
     Octopus.Client.Extensibility.IResource
@@ -5389,7 +5459,7 @@ Octopus.Client.Model.BuildInformation
     String PackageId { get; set; }
     String Version { get; set; }
   }
-  class ReleaseBuildInformationResource
+  class ReleasePackageVersionBuildInformationResource
   {
     .ctor()
     String Branch { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -160,7 +160,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IProxyRepository Proxies { get; }
     Octopus.Client.Repositories.Async.IReleaseRepository Releases { get; }
     Octopus.Client.Repositories.Async.IRetentionPolicyRepository RetentionPolicies { get; }
-    Octopus.Client.Repositories.Async.IRunbookProcessRepository RunbookProcess { get; }
+    Octopus.Client.Repositories.Async.IRunbookProcessRepository RunbookProcesses { get; }
     Octopus.Client.Repositories.Async.IRunbookRunRepository RunbookRuns { get; }
     Octopus.Client.Repositories.Async.IRunbookRepository Runbooks { get; }
     Octopus.Client.Repositories.Async.IRunbookSnapshotRepository RunbookSnapshots { get; }
@@ -204,7 +204,7 @@ Octopus.Client
     Octopus.Client.Repositories.IProxyRepository Proxies { get; }
     Octopus.Client.Repositories.IReleaseRepository Releases { get; }
     Octopus.Client.Repositories.IRetentionPolicyRepository RetentionPolicies { get; }
-    Octopus.Client.Repositories.IRunbookProcessRepository RunbookProcess { get; }
+    Octopus.Client.Repositories.IRunbookProcessRepository RunbookProcesses { get; }
     Octopus.Client.Repositories.IRunbookRunRepository RunbookRuns { get; }
     Octopus.Client.Repositories.IRunbookRepository Runbooks { get; }
     Octopus.Client.Repositories.IRunbookSnapshotRepository RunbookSnapshots { get; }
@@ -335,7 +335,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IProxyRepository Proxies { get; }
     Octopus.Client.Repositories.Async.IReleaseRepository Releases { get; }
     Octopus.Client.Repositories.Async.IRetentionPolicyRepository RetentionPolicies { get; }
-    Octopus.Client.Repositories.Async.IRunbookProcessRepository RunbookProcess { get; }
+    Octopus.Client.Repositories.Async.IRunbookProcessRepository RunbookProcesses { get; }
     Octopus.Client.Repositories.Async.IRunbookRunRepository RunbookRuns { get; }
     Octopus.Client.Repositories.Async.IRunbookRepository Runbooks { get; }
     Octopus.Client.Repositories.Async.IRunbookSnapshotRepository RunbookSnapshots { get; }
@@ -464,7 +464,7 @@ Octopus.Client
     Octopus.Client.Repositories.IProxyRepository Proxies { get; }
     Octopus.Client.Repositories.IReleaseRepository Releases { get; }
     Octopus.Client.Repositories.IRetentionPolicyRepository RetentionPolicies { get; }
-    Octopus.Client.Repositories.IRunbookProcessRepository RunbookProcess { get; }
+    Octopus.Client.Repositories.IRunbookProcessRepository RunbookProcesses { get; }
     Octopus.Client.Repositories.IRunbookRunRepository RunbookRuns { get; }
     Octopus.Client.Repositories.IRunbookRepository Runbooks { get; }
     Octopus.Client.Repositories.IRunbookSnapshotRepository RunbookSnapshots { get; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4015,6 +4015,7 @@ Octopus.Client.Model
     .ctor()
     .ctor(String, String, String)
     .ctor(String, String)
+    .ctor(String)
     DateTimeOffset Assembled { get; set; }
     List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2440,33 +2440,6 @@ Octopus.Client.Model
       Approved = 0
       Rejected = 1
   }
-  class DeploymentBaseResource
-    Octopus.Client.Extensibility.IResource
-    Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.Resource
-  {
-    .ctor()
-    String Comments { get; set; }
-    DateTimeOffset Created { get; set; }
-    String DeployedBy { get; set; }
-    String EnvironmentId { get; set; }
-    Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
-    Boolean ForcePackageDownload { get; set; }
-    Boolean ForcePackageRedeployment { get; set; }
-    Dictionary<String, String> FormValues { get; set; }
-    String ManifestVariableSetId { get; set; }
-    String Name { get; set; }
-    String ProjectId { get; set; }
-    Nullable<DateTimeOffset> QueueTime { get; set; }
-    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
-    Octopus.Client.Model.ReferenceCollection SkipActions { get; set; }
-    String SpaceId { get; set; }
-    Octopus.Client.Model.ReferenceCollection SpecificMachineIds { get; set; }
-    String TaskId { get; set; }
-    String TenantId { get; set; }
-    Boolean UseGuidedFailure { get; set; }
-  }
   class DeploymentPreviewBaseResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -2486,9 +2459,10 @@ Octopus.Client.Model
     List<ReleaseChanges> Changes { get; set; }
     String ChangesMarkdown { get; set; }
   }
-  class DeploymentProcessBaseResource
+  class DeploymentProcessResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IProcessResource
     Octopus.Client.Extensibility.IHaveSpaceResource
     Octopus.Client.Model.Resource
   {
@@ -2499,17 +2473,9 @@ Octopus.Client.Model
     IList<DeploymentStepResource> Steps { get; }
     Int32 Version { get; set; }
     Octopus.Client.Model.DeploymentStepResource AddOrUpdateStep(String)
-    Octopus.Client.Model.DeploymentProcessBaseResource ClearSteps()
+    Octopus.Client.Model.IProcessResource ClearSteps()
     Octopus.Client.Model.DeploymentStepResource FindStep(String)
-    Octopus.Client.Model.DeploymentProcessBaseResource RemoveStep(String)
-  }
-  class DeploymentProcessResource
-    Octopus.Client.Extensibility.IResource
-    Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.DeploymentProcessBaseResource
-  {
-    .ctor()
+    Octopus.Client.Model.IProcessResource RemoveStep(String)
   }
   class DeploymentPromomotionTenant
     Octopus.Client.Extensibility.IResource
@@ -2531,15 +2497,39 @@ Octopus.Client.Model
   class DeploymentResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IExecutionResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.DeploymentBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
     List<ReleaseChanges> Changes { get; set; }
     String ChangesMarkdown { get; set; }
     String ChannelId { get; set; }
+    String Comments { get; set; }
+    DateTimeOffset Created { get; set; }
+    String DeployedBy { get; set; }
+    String DeployedById { get; set; }
+    Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
     String DeploymentProcessId { get; set; }
+    String EnvironmentId { get; set; }
+    Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
+    Boolean FailureEncountered { get; set; }
+    Boolean ForcePackageDownload { get; set; }
+    Boolean ForcePackageRedeployment { get; set; }
+    Dictionary<String, String> FormValues { get; set; }
+    String ManifestVariableSetId { get; set; }
+    String Name { get; set; }
+    String ProjectId { get; set; }
+    Nullable<DateTimeOffset> QueueTime { get; set; }
+    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
     String ReleaseId { get; set; }
+    Octopus.Client.Model.ReferenceCollection SkipActions { get; set; }
+    String SpaceId { get; set; }
+    Octopus.Client.Model.ReferenceCollection SpecificMachineIds { get; set; }
+    String TaskId { get; set; }
+    String TenantId { get; set; }
+    Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
+    Boolean UseGuidedFailure { get; set; }
   }
   DeploymentStepCondition
   {
@@ -2923,6 +2913,32 @@ Octopus.Client.Model
     Dictionary<String, IdentityClaimResource> Claims { get; }
     String IdentityProviderName { get; set; }
   }
+  interface IExecutionResource
+    Octopus.Client.Extensibility.IResource
+  {
+    String Comments { get; set; }
+    DateTimeOffset Created { get; set; }
+    String DeployedBy { get; set; }
+    String DeployedById { get; set; }
+    Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
+    String EnvironmentId { get; set; }
+    Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
+    Boolean FailureEncountered { get; }
+    Boolean ForcePackageDownload { get; set; }
+    Boolean ForcePackageRedeployment { get; set; }
+    Dictionary<String, String> FormValues { get; set; }
+    String ManifestVariableSetId { get; set; }
+    String Name { get; set; }
+    String ProjectId { get; set; }
+    Nullable<DateTimeOffset> QueueTime { get; set; }
+    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
+    Octopus.Client.Model.ReferenceCollection SkipActions { get; set; }
+    Octopus.Client.Model.ReferenceCollection SpecificMachineIds { get; set; }
+    String TaskId { get; set; }
+    String TenantId { get; set; }
+    Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
+    Boolean UseGuidedFailure { get; set; }
+  }
   class InterruptionResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -2955,6 +2971,27 @@ Octopus.Client.Model
     DateTimeOffset Expires { get; set; }
     String InvitationCode { get; set; }
     String SpaceId { get; set; }
+  }
+  interface IProcessResource
+    Octopus.Client.Extensibility.IResource
+  {
+    String LastSnapshotId { get; set; }
+    String ProjectId { get; set; }
+    IList<DeploymentStepResource> Steps { get; }
+    Int32 Version { get; set; }
+    Octopus.Client.Model.DeploymentStepResource AddOrUpdateStep(String)
+    Octopus.Client.Model.IProcessResource ClearSteps()
+    Octopus.Client.Model.DeploymentStepResource FindStep(String)
+    Octopus.Client.Model.IProcessResource RemoveStep(String)
+  }
+  interface ISnapshotResource
+    Octopus.Client.Extensibility.IResource
+  {
+    DateTimeOffset Assembled { get; set; }
+    List<String> LibraryVariableSetSnapshotIds { get; set; }
+    String ProjectId { get; set; }
+    String ProjectVariableSetSnapshotId { get; set; }
+    List<SelectedPackage> SelectedPackages { get; }
   }
   interface IVariableTemplateContainer
   {
@@ -3942,20 +3979,6 @@ Octopus.Client.Model
     .ctor()
     String InvitationCode { get; set; }
   }
-  class ReleaseBaseResource
-    Octopus.Client.Extensibility.IResource
-    Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.Resource
-  {
-    .ctor()
-    .ctor(String)
-    DateTimeOffset Assembled { get; set; }
-    List<String> LibraryVariableSetSnapshotIds { get; set; }
-    String ProjectId { get; set; }
-    List<SelectedPackage> SelectedPackages { get; set; }
-    String SpaceId { get; set; }
-  }
   class ReleaseChanges
   {
     .ctor()
@@ -3985,18 +4008,23 @@ Octopus.Client.Model
   class ReleaseResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.ISnapshotResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.ReleaseBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
     .ctor(String, String, String)
-    .ctor(String, String)
-    List<ReleaseBuildInformationResource> BuildInformation { get; set; }
+    DateTimeOffset Assembled { get; set; }
+    List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }
     Boolean IgnoreChannelRules { get; set; }
+    List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }
+    String ProjectId { get; set; }
     String ProjectVariableSetSnapshotId { get; set; }
     String ReleaseNotes { get; set; }
+    List<SelectedPackage> SelectedPackages { get; set; }
+    String SpaceId { get; set; }
     String Version { get; set; }
   }
   class ReleaseSummaryResource
@@ -4134,11 +4162,21 @@ Octopus.Client.Model
   class RunbookProcessResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IProcessResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.DeploymentProcessBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
+    String LastSnapshotId { get; set; }
+    String ProjectId { get; set; }
     String RunbookId { get; set; }
+    String SpaceId { get; set; }
+    IList<DeploymentStepResource> Steps { get; }
+    Int32 Version { get; set; }
+    Octopus.Client.Model.DeploymentStepResource AddOrUpdateStep(String)
+    Octopus.Client.Model.IProcessResource ClearSteps()
+    Octopus.Client.Model.DeploymentStepResource FindStep(String)
+    Octopus.Client.Model.IProcessResource RemoveStep(String)
   }
   class RunbookResource
     Octopus.Client.Extensibility.IResource
@@ -4164,13 +4202,37 @@ Octopus.Client.Model
   class RunbookRunResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IExecutionResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.DeploymentBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
+    String Comments { get; set; }
+    DateTimeOffset Created { get; set; }
+    String DeployedBy { get; set; }
+    String DeployedById { get; set; }
+    Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
+    String EnvironmentId { get; set; }
+    Octopus.Client.Model.ReferenceCollection ExcludedMachineIds { get; set; }
+    Boolean FailureEncountered { get; set; }
+    Boolean ForcePackageDownload { get; set; }
+    Boolean ForcePackageRedeployment { get; set; }
+    Dictionary<String, String> FormValues { get; set; }
     String FrozenRunbookProcessId { get; set; }
+    String ManifestVariableSetId { get; set; }
+    String Name { get; set; }
+    String ProjectId { get; set; }
+    Nullable<DateTimeOffset> QueueTime { get; set; }
+    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
     String RunbookId { get; set; }
     String RunbookSnapshotId { get; set; }
+    Octopus.Client.Model.ReferenceCollection SkipActions { get; set; }
+    String SpaceId { get; set; }
+    Octopus.Client.Model.ReferenceCollection SpecificMachineIds { get; set; }
+    String TaskId { get; set; }
+    String TenantId { get; set; }
+    Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
+    Boolean UseGuidedFailure { get; set; }
   }
   class RunbookRunTemplateResource
     Octopus.Client.Extensibility.IResource
@@ -4183,15 +4245,23 @@ Octopus.Client.Model
   class RunbookSnapshotResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.ISnapshotResource
     Octopus.Client.Extensibility.IHaveSpaceResource
-    Octopus.Client.Model.ReleaseBaseResource
+    Octopus.Client.Model.Resource
   {
     .ctor()
     .ctor(String)
+    DateTimeOffset Assembled { get; set; }
     String FrozenProjectVariableSetId { get; set; }
     String FrozenRunbookProcessId { get; set; }
+    List<String> LibraryVariableSetSnapshotIds { get; set; }
     String Name { get; set; }
+    String Notes { get; set; }
+    String ProjectId { get; set; }
+    String ProjectVariableSetSnapshotId { get; set; }
     String RunbookId { get; set; }
+    List<SelectedPackage> SelectedPackages { get; set; }
+    String SpaceId { get; set; }
   }
   class RunbookSnapshotTemplateResource
     Octopus.Client.Extensibility.IResource
@@ -5414,7 +5484,7 @@ Octopus.Client.Model.BuildInformation
     String PackageId { get; set; }
     String Version { get; set; }
   }
-  class ReleaseBuildInformationResource
+  class ReleasePackageVersionBuildInformationResource
   {
     .ctor()
     String Branch { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4014,6 +4014,7 @@ Octopus.Client.Model
   {
     .ctor()
     .ctor(String, String, String)
+    .ctor(String, String)
     DateTimeOffset Assembled { get; set; }
     List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }

--- a/source/Octopus.Client/IOctopusSpaceAsyncRepository.cs
+++ b/source/Octopus.Client/IOctopusSpaceAsyncRepository.cs
@@ -35,7 +35,7 @@ namespace Octopus.Client
         IProjectGroupRepository ProjectGroups { get; }
         IProjectRepository Projects { get; }
         IRunbookRepository Runbooks { get; }
-        IRunbookProcessRepository RunbookProcess { get; }
+        IRunbookProcessRepository RunbookProcesses { get; }
         IRunbookSnapshotRepository RunbookSnapshots { get; }
         IRunbookRunRepository RunbookRuns { get; }
         IProjectTriggerRepository ProjectTriggers { get; }

--- a/source/Octopus.Client/IOctopusSpaceRepository.cs
+++ b/source/Octopus.Client/IOctopusSpaceRepository.cs
@@ -35,7 +35,7 @@ namespace Octopus.Client
         IProjectGroupRepository ProjectGroups { get; }
         IProjectRepository Projects { get; }
         IRunbookRepository Runbooks { get; }
-        IRunbookProcessRepository RunbookProcess { get; }
+        IRunbookProcessRepository RunbookProcesses { get; }
         IRunbookSnapshotRepository RunbookSnapshots { get; }
         IRunbookRunRepository RunbookRuns { get; }
         IProjectTriggerRepository ProjectTriggers { get; }

--- a/source/Octopus.Client/Model/BuildInformation/ReleasePackageVersionBuildInformationResource.cs
+++ b/source/Octopus.Client/Model/BuildInformation/ReleasePackageVersionBuildInformationResource.cs
@@ -2,7 +2,7 @@ using Octopus.Client.Model.IssueTrackers;
 
 namespace Octopus.Client.Model.BuildInformation
 {
-    public class ReleaseBuildInformationResource
+    public class ReleasePackageVersionBuildInformationResource
     {
         public string PackageId { get; set; }
         public string Version { get; set; }

--- a/source/Octopus.Client/Model/DeploymentProcessResource.cs
+++ b/source/Octopus.Client/Model/DeploymentProcessResource.cs
@@ -6,13 +6,9 @@ using Octopus.Client.Extensibility;
 
 namespace Octopus.Client.Model
 {
-    public class DeploymentProcessResource : DeploymentProcessBaseResource
+    public class DeploymentProcessResource : Resource, IProcessResource, IHaveSpaceResource
     {
-    }
-
-    public class DeploymentProcessBaseResource : Resource, IHaveSpaceResource
-    {
-        public DeploymentProcessBaseResource()
+        public DeploymentProcessResource()
         {
             Steps = new List<DeploymentStepResource>();
         }
@@ -56,13 +52,13 @@ namespace Octopus.Client.Model
             return step;
         }
 
-        public DeploymentProcessBaseResource RemoveStep(string name)
+        public IProcessResource RemoveStep(string name)
         {
             Steps.Remove(FindStep(name));
             return this;
         }
 
-        public DeploymentProcessBaseResource ClearSteps()
+        public IProcessResource ClearSteps()
         {
             Steps.Clear();
             return this;

--- a/source/Octopus.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Client/Model/DeploymentResource.cs
@@ -7,11 +7,12 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model
 {
-    public class DeploymentResource : DeploymentBaseResource
+    public class DeploymentResource : Resource, IExecutionResource, IHaveSpaceResource
     {
         public DeploymentResource()
         {
             Changes = new List<ReleaseChanges>();
+            FormValues = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
         }
 
         [Required(ErrorMessage = "Please specify the release to deploy.")]
@@ -19,18 +20,8 @@ namespace Octopus.Client.Model
         public string ReleaseId { get; set; }
         public string ChannelId { get; set; }
         public string DeploymentProcessId { get; set; }
-
         public List<ReleaseChanges> Changes { get; set; }
-
         public string ChangesMarkdown { get; set; }
-    }
-
-    public class DeploymentBaseResource : Resource, IHaveSpaceResource
-    {
-        public DeploymentBaseResource()
-        {
-            FormValues = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
-        }
 
         [Required(ErrorMessage = "Please provide a target environment to deploy to.")]
         [WriteableOnCreate]
@@ -93,7 +84,15 @@ namespace Octopus.Client.Model
         public DateTimeOffset Created { get; set; }
 
         public string SpaceId { get; set; }
-        
+
+        public RetentionPeriod TentacleRetentionPeriod { get; set; }
+
         public string DeployedBy { get; set; }
+
+        public string DeployedById { get; set; }
+
+        public bool FailureEncountered { get; set; }
+
+        public ReferenceCollection DeployedToMachineIds { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/IExecutionResource.cs
+++ b/source/Octopus.Client/Model/IExecutionResource.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
+{
+    public interface IExecutionResource : IResource
+    {
+        string Name { get; set; }
+        DateTimeOffset Created { get; set; }
+        bool ForcePackageDownload { get; set; }
+        bool ForcePackageRedeployment { get; set; }
+        string Comments { get; set; }
+        ReferenceCollection SkipActions { get; set; }
+        ReferenceCollection SpecificMachineIds { get; set; }
+        ReferenceCollection ExcludedMachineIds { get; set; }
+        bool UseGuidedFailure { get; set; }
+        RetentionPeriod TentacleRetentionPeriod { get; set; }
+        string EnvironmentId { get; set; }
+        string TenantId { get; set; }
+        string TaskId { get; set; }
+        string ProjectId { get; set; }
+        string ManifestVariableSetId { get; set; }
+        string DeployedBy { get; set; }
+        string DeployedById { get; set; }
+        bool FailureEncountered { get; }
+        ReferenceCollection DeployedToMachineIds { get; set; }
+        Dictionary<string, string> FormValues { get; set; }
+        DateTimeOffset? QueueTime { get; set; }
+        DateTimeOffset? QueueTimeExpiry { get; set; }
+    }
+}

--- a/source/Octopus.Client/Model/IProcessResource.cs
+++ b/source/Octopus.Client/Model/IProcessResource.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
+{
+    public interface IProcessResource : IResource
+    {
+        string ProjectId { get; set; }
+        IList<DeploymentStepResource> Steps { get; }
+        int Version { get; set; }
+        string LastSnapshotId { get; set; }
+
+        DeploymentStepResource FindStep(string name);
+        DeploymentStepResource AddOrUpdateStep(string name);
+        IProcessResource RemoveStep(string name);
+        IProcessResource ClearSteps();
+    }
+}

--- a/source/Octopus.Client/Model/ISnapshotResource.cs
+++ b/source/Octopus.Client/Model/ISnapshotResource.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
+{
+    public interface ISnapshotResource : IResource
+    {
+        DateTimeOffset Assembled { get; set; }
+        string ProjectId { get; set; }
+        List<string> LibraryVariableSetSnapshotIds { get; set; }
+        List<SelectedPackage> SelectedPackages { get; }
+        string ProjectVariableSetSnapshotId { get; set; }
+    }
+}

--- a/source/Octopus.Client/Model/ReleaseResource.cs
+++ b/source/Octopus.Client/Model/ReleaseResource.cs
@@ -8,13 +8,13 @@ using Octopus.Client.Model.BuildInformation;
 
 namespace Octopus.Client.Model
 {
-    public class ReleaseResource : ReleaseBaseResource
+    public class ReleaseResource : Resource, ISnapshotResource, IHaveSpaceResource
     {
         [JsonConstructor]
         public ReleaseResource()
         {
             SelectedPackages = new List<SelectedPackage>();
-            BuildInformation = new List<ReleaseBuildInformationResource>();
+            BuildInformation = new List<ReleasePackageVersionBuildInformationResource>();
         }
 
         public ReleaseResource(string version, string projectId, string channelId) : base()
@@ -22,11 +22,6 @@ namespace Octopus.Client.Model
             Version = version;
             ProjectId = projectId;
             ChannelId = channelId;
-        }
-
-        public ReleaseResource(string version, string projectId)
-            : this(version, projectId, null)
-        {
         }
 
         [Required(ErrorMessage = "Please provide a version number for this release.")]
@@ -40,7 +35,7 @@ namespace Octopus.Client.Model
 
         [Writeable]
         public string ReleaseNotes { get; set; }
-        
+
         public string ProjectDeploymentProcessSnapshotId { get; set; }
 
         public string ProjectVariableSetSnapshotId { get; set; }
@@ -51,21 +46,7 @@ namespace Octopus.Client.Model
         public bool IgnoreChannelRules { get; set; }
 
         [WriteableOnCreate]
-        public List<ReleaseBuildInformationResource> BuildInformation { get; set; }
-    }
-
-    public class ReleaseBaseResource : Resource, IHaveSpaceResource
-    {
-        [JsonConstructor]
-        public ReleaseBaseResource()
-        {
-            SelectedPackages = new List<SelectedPackage>();
-        }
-
-        public ReleaseBaseResource(string projectId) : this()
-        {
-            ProjectId = projectId;
-        }
+        public List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
 
         public DateTimeOffset Assembled { get; set; }
 

--- a/source/Octopus.Client/Model/ReleaseResource.cs
+++ b/source/Octopus.Client/Model/ReleaseResource.cs
@@ -17,7 +17,8 @@ namespace Octopus.Client.Model
             BuildInformation = new List<ReleasePackageVersionBuildInformationResource>();
         }
 
-        public ReleaseResource(string version, string projectId, string channelId) : base()
+        public ReleaseResource(string version, string projectId, string channelId)
+            : this()
         {
             Version = version;
             ProjectId = projectId;

--- a/source/Octopus.Client/Model/ReleaseResource.cs
+++ b/source/Octopus.Client/Model/ReleaseResource.cs
@@ -24,6 +24,11 @@ namespace Octopus.Client.Model
             ChannelId = channelId;
         }
 
+        public ReleaseResource(string version, string projectId)
+            : this(version, projectId, null)
+        {
+        }
+
         [Required(ErrorMessage = "Please provide a version number for this release.")]
         [StringLength(349, ErrorMessage = "The version number is too long. Please enter a shorter version number.")]
         [Trim]

--- a/source/Octopus.Client/Model/ReleaseResource.cs
+++ b/source/Octopus.Client/Model/ReleaseResource.cs
@@ -30,6 +30,11 @@ namespace Octopus.Client.Model
         {
         }
 
+        public ReleaseResource(string projectId)
+            : this(null, projectId, null)
+        {
+        }
+
         [Required(ErrorMessage = "Please provide a version number for this release.")]
         [StringLength(349, ErrorMessage = "The version number is too long. Please enter a shorter version number.")]
         [Trim]

--- a/source/Octopus.Client/Model/RunbookProcessResource.cs
+++ b/source/Octopus.Client/Model/RunbookProcessResource.cs
@@ -1,7 +1,71 @@
-﻿namespace Octopus.Client.Model
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
 {
-    public class RunbookProcessResource : DeploymentProcessBaseResource
+    public class RunbookProcessResource : Resource, IProcessResource, IHaveSpaceResource
     {
+        public RunbookProcessResource()
+        {
+            Steps = new List<DeploymentStepResource>();
+        }
+
         public string RunbookId { get; set; }
+
+        public string ProjectId { get; set; }
+
+        public IList<DeploymentStepResource> Steps { get; }
+
+        [Required]
+        public int Version { get; set; }
+
+        public string LastSnapshotId { get; set; }
+
+        public DeploymentStepResource FindStep(string name)
+        {
+            return Steps.FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public DeploymentStepResource AddOrUpdateStep(string name)
+        {
+            var existing = FindStep(name);
+
+            DeploymentStepResource step;
+            if (existing == null)
+            {
+                step = new DeploymentStepResource
+                {
+                    Name = name
+                };
+
+                Steps.Add(step);
+            }
+            else
+            {
+                existing.Name = name;
+
+                step = existing;
+            }
+
+            // Return the step so you can add actions
+            return step;
+        }
+
+        public IProcessResource RemoveStep(string name)
+        {
+            Steps.Remove(FindStep(name));
+            return this;
+        }
+
+        public IProcessResource ClearSteps()
+        {
+            Steps.Clear();
+            return this;
+        }
+
+        public string SpaceId { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/RunbookRunResource.cs
+++ b/source/Octopus.Client/Model/RunbookRunResource.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+using Octopus.Client.Extensibility;
 using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model
 {
-    public class RunbookRunResource : DeploymentBaseResource
+    public class RunbookRunResource : Resource, IExecutionResource, IHaveSpaceResource
     {
         public RunbookRunResource()
         {
@@ -16,9 +18,81 @@ namespace Octopus.Client.Model
         public string RunbookSnapshotId { get; set; }
 
         public string FrozenRunbookProcessId { get; set; }
-        
+
         [Required(ErrorMessage = "Please specify the Runbook to run.")]
         [WriteableOnCreate]
         public string RunbookId { get; set; }
+
+        [Required(ErrorMessage = "Please provide a target environment to run to.")]
+        [WriteableOnCreate]
+        public string EnvironmentId { get; set; }
+
+        [WriteableOnCreate]
+        public string TenantId { get; set; }
+
+        [WriteableOnCreate]
+        public bool ForcePackageDownload { get; set; }
+
+        [WriteableOnCreate]
+        public bool ForcePackageRedeployment { get; set; }
+
+        [WriteableOnCreate]
+        public ReferenceCollection SkipActions { get; set; }
+
+        /// <summary>
+        /// A collection of machines in the target environment
+        /// that should be deployed to. If the collection is
+        /// empty, all enabled machines are deployed.
+        /// </summary>
+        [WriteableOnCreate]
+        public ReferenceCollection SpecificMachineIds { get; set; }
+
+        /// <summary>
+        /// A collection of machines in the target environment that should be excluded from the deployment.
+        /// </summary>
+        [WriteableOnCreate]
+        public ReferenceCollection ExcludedMachineIds { get; set; }
+
+        public string ManifestVariableSetId { get; set; }
+        public string TaskId { get; set; }
+        public string ProjectId { get; set; }
+
+        /// <summary>
+        /// If set to true, the deployment will prompt for manual intervention (Fail/Retry/Ignore) when
+        /// failures are encountered in activities that support it. May be overridden with the
+        /// Octopus.UseGuidedFailure special variable.
+        /// </summary>
+        [WriteableOnCreate]
+        public bool UseGuidedFailure { get; set; }
+
+        [WriteableOnCreate]
+        public string Comments { get; set; }
+
+        [WriteableOnCreate]
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]
+        public Dictionary<string, string> FormValues { get; set; }
+
+        /// <summary>
+        /// If set this time will be the used to schedule the deployment to a later time, null is assumed to mean the time will
+        /// be executed immediately.
+        /// </summary>
+        public DateTimeOffset? QueueTime { get; set; }
+
+        public DateTimeOffset? QueueTimeExpiry { get; set; }
+
+        public string Name { get; set; }
+        public DateTimeOffset Created { get; set; }
+
+        public string SpaceId { get; set; }
+
+        public RetentionPeriod TentacleRetentionPeriod { get; set; }
+
+        public string DeployedBy { get; set; }
+
+        public string DeployedById { get; set; }
+
+        public bool FailureEncountered { get; set; }
+
+        public ReferenceCollection DeployedToMachineIds { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/RunbookSnapshotResource.cs
+++ b/source/Octopus.Client/Model/RunbookSnapshotResource.cs
@@ -1,10 +1,12 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Octopus.Client.Extensibility;
 using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model
 {
-    public class RunbookSnapshotResource : ReleaseBaseResource
+    public class RunbookSnapshotResource : Resource, ISnapshotResource, IHaveSpaceResource
     {
         [JsonConstructor]
         public RunbookSnapshotResource()
@@ -23,8 +25,28 @@ namespace Octopus.Client.Model
         [WriteableOnCreate]
         public string RunbookId { get; set; }
 
+        [Writeable]
+        public string Notes { get; set; }
+
         public string FrozenRunbookProcessId { get; set; }
 
         public string FrozenProjectVariableSetId { get; set; }
+
+        public DateTimeOffset Assembled { get; set; }
+
+        [WriteableOnCreate]
+        public string ProjectId { get; set; }
+
+        /// <summary>
+        /// Snapshots of the project's included library variable sets. The
+        /// snapshots are <see cref="VariableSetResource" />s, not <see cref="LibraryVariableSetResource" />s.
+        /// </summary>
+        public List<string> LibraryVariableSetSnapshotIds { get; set; }
+
+        public List<SelectedPackage> SelectedPackages { get; set; }
+
+        public string ProjectVariableSetSnapshotId { get; set; }
+
+        public string SpaceId { get; set; }
     }
 }

--- a/source/Octopus.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Client/OctopusAsyncRepository.cs
@@ -86,7 +86,7 @@ namespace Octopus.Client
             ProjectGroups = new ProjectGroupRepository(this);
             Projects = new ProjectRepository(this);
             Runbooks = new RunbookRepository(this);
-            RunbookProcess = new RunbookProcessRepository(this);
+            RunbookProcesses = new RunbookProcessRepository(this);
             RunbookSnapshots = new RunbookSnapshotRepository(this);
             RunbookRuns = new RunbookRunRepository(this);
             ProjectTriggers = new ProjectTriggerRepository(this);
@@ -153,7 +153,7 @@ namespace Octopus.Client
         public IProjectGroupRepository ProjectGroups { get; }
         public IProjectRepository Projects { get; }
         public IRunbookRepository Runbooks { get; }
-        public IRunbookProcessRepository RunbookProcess { get; }
+        public IRunbookProcessRepository RunbookProcesses { get; }
         public IRunbookSnapshotRepository RunbookSnapshots { get; }
         public IRunbookRunRepository RunbookRuns { get; }
         public IProjectTriggerRepository ProjectTriggers { get; }

--- a/source/Octopus.Client/OctopusRepository.cs
+++ b/source/Octopus.Client/OctopusRepository.cs
@@ -84,7 +84,7 @@ namespace Octopus.Client
             ProjectGroups = new ProjectGroupRepository(this);
             Projects = new ProjectRepository(this);
             Runbooks = new RunbookRepository(this);
-            RunbookProcess = new RunbookProcessRepository(this);
+            RunbookProcesses = new RunbookProcessRepository(this);
             RunbookSnapshots = new RunbookSnapshotRepository(this);
             RunbookRuns = new RunbookRunRepository(this);
             ProjectTriggers = new ProjectTriggerRepository(this);
@@ -150,7 +150,7 @@ namespace Octopus.Client
         public IProjectGroupRepository ProjectGroups { get; }
         public IProjectRepository Projects { get; }
         public IRunbookRepository Runbooks { get; }
-        public IRunbookProcessRepository RunbookProcess { get; }
+        public IRunbookProcessRepository RunbookProcesses { get; }
         public IRunbookSnapshotRepository RunbookSnapshots { get; }
         public IRunbookRunRepository RunbookRuns { get; }
         public IProjectTriggerRepository ProjectTriggers { get; }

--- a/source/Octopus.Client/Repositories/Async/RunbookProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/RunbookProcessRepository.cs
@@ -11,7 +11,7 @@ namespace Octopus.Client.Repositories.Async
     class RunbookProcessRepository : BasicRepository<RunbookProcessResource>, IRunbookProcessRepository
     {
         public RunbookProcessRepository(IOctopusAsyncRepository repository)
-            : base(repository, "RunbookProcess")
+            : base(repository, "RunbookProcesses")
         {
         }
 

--- a/source/Octopus.Client/Repositories/RunbookProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/RunbookProcessRepository.cs
@@ -10,7 +10,7 @@ namespace Octopus.Client.Repositories
     class RunbookProcessRepository : BasicRepository<RunbookProcessResource>, IRunbookProcessRepository
     {
         public RunbookProcessRepository(IOctopusRepository repository)
-            : base(repository, "RunbookProcess")
+            : base(repository, "RunbookProcesses")
         {
         }
 


### PR DESCRIPTION
In phase 1 of Runbooks, we never got around to fully refactoring Runbook-related resources to match the same inheritance as the Core.Model classes. This PR does this, so these's less danger of changing one and accidentally breaking the other.