### PR TITLE
Support fetching the Release Log.

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3110,6 +3110,21 @@ Octopus.Client.Model
     Octopus.Client.Model.LifecycleResource WithReleaseRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
     Octopus.Client.Model.LifecycleResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
   }
+  LogCategory
+  {
+      Trace = 1
+      Verbose = 100
+      Info = 200
+      Planned = 201
+      Highlight = 210
+      Abandoned = 220
+      Wait = 225
+      Progress = 230
+      Finished = 240
+      Warning = 300
+      Error = 400
+      Fatal = 500
+  }
   class LoginCommand
   {
     .ctor()
@@ -3951,6 +3966,27 @@ Octopus.Client.Model
     .ctor()
     String ChannelId { get; set; }
     Octopus.Client.Model.DeploymentActionPackageResource ReleaseCreationPackage { get; set; }
+  }
+  class ReleaseLogEntry
+  {
+    .ctor()
+    Octopus.Client.Model.LogCategory Category { get; set; }
+    String MessageText { get; set; }
+    DateTimeOffset Occurred { get; set; }
+    String Source { get; set; }
+  }
+  class ReleaseLogResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    List<ReleaseLogEntry> Entries { get; set; }
+    DateTimeOffset Occurred { get; set; }
+    String ReleaseId { get; set; }
+    Guid RequestId { get; set; }
+    String SpaceId { get; set; }
   }
   class ReleaseProgressionResource
   {
@@ -6592,6 +6628,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean)
     Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<ReleaseLogResource> GetLog(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.DeploymentPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
     Octopus.Client.Model.LifecycleProgressionResource GetProgression(Octopus.Client.Model.ReleaseResource)
     Octopus.Client.Model.DeploymentTemplateResource GetTemplate(Octopus.Client.Model.ReleaseResource)
@@ -7269,6 +7306,7 @@ Octopus.Client.Repositories.Async
     Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<ReleaseLogResource>> GetLog(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
     Task<LifecycleProgressionResource> GetProgression(Octopus.Client.Model.ReleaseResource)
     Task<DeploymentTemplateResource> GetTemplate(Octopus.Client.Model.ReleaseResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3126,6 +3126,21 @@ Octopus.Client.Model
     Octopus.Client.Model.LifecycleResource WithReleaseRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
     Octopus.Client.Model.LifecycleResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
   }
+  LogCategory
+  {
+      Trace = 1
+      Verbose = 100
+      Info = 200
+      Planned = 201
+      Highlight = 210
+      Abandoned = 220
+      Wait = 225
+      Progress = 230
+      Finished = 240
+      Warning = 300
+      Error = 400
+      Fatal = 500
+  }
   class LoginCommand
   {
     .ctor()
@@ -3970,6 +3985,27 @@ Octopus.Client.Model
     .ctor()
     String ChannelId { get; set; }
     Octopus.Client.Model.DeploymentActionPackageResource ReleaseCreationPackage { get; set; }
+  }
+  class ReleaseLogEntry
+  {
+    .ctor()
+    Octopus.Client.Model.LogCategory Category { get; set; }
+    String MessageText { get; set; }
+    DateTimeOffset Occurred { get; set; }
+    String Source { get; set; }
+  }
+  class ReleaseLogResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    List<ReleaseLogEntry> Entries { get; set; }
+    DateTimeOffset Occurred { get; set; }
+    String ReleaseId { get; set; }
+    Guid RequestId { get; set; }
+    String SpaceId { get; set; }
   }
   class ReleaseProgressionResource
   {
@@ -6617,6 +6653,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean)
     Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<ReleaseLogResource> GetLog(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.DeploymentPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
     Octopus.Client.Model.LifecycleProgressionResource GetProgression(Octopus.Client.Model.ReleaseResource)
     Octopus.Client.Model.DeploymentTemplateResource GetTemplate(Octopus.Client.Model.ReleaseResource)
@@ -7294,6 +7331,7 @@ Octopus.Client.Repositories.Async
     Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<ReleaseLogResource>> GetLog(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
     Task<LifecycleProgressionResource> GetProgression(Octopus.Client.Model.ReleaseResource)
     Task<DeploymentTemplateResource> GetTemplate(Octopus.Client.Model.ReleaseResource)

--- a/source/Octopus.Client/Exceptions/OctopusExceptionFactory.cs
+++ b/source/Octopus.Client/Exceptions/OctopusExceptionFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -95,6 +96,11 @@ namespace Octopus.Client.Exceptions
                     if (!string.IsNullOrWhiteSpace(errors.FullException))
                     {
                         fullDetails += Environment.NewLine + "Server exception: " + Environment.NewLine + errors.FullException + Environment.NewLine + "-----------------------" + Environment.NewLine;
+                    }
+
+                    foreach (var cause in (errors.Errors ?? new string[0]).Where(c => !string.IsNullOrWhiteSpace(c)))
+                    {
+                        fullDetails += Environment.NewLine + "- " + cause;
                     }
                 }
             }

--- a/source/Octopus.Client/Model/ReleaseLogResource.cs
+++ b/source/Octopus.Client/Model/ReleaseLogResource.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
+{
+    public class ReleaseLogResource : Resource, IHaveSpaceResource
+    {
+        public string SpaceId { get; set; }
+        public string ReleaseId { get; set; }
+        public Guid RequestId { get; set; }
+        public DateTimeOffset Occurred { get; set; }
+        public List<ReleaseLogEntry> Entries { get; set; } = new List<ReleaseLogEntry>();
+    }
+
+    public class ReleaseLogEntry
+    {
+        public DateTimeOffset Occurred { get; set; }
+        public LogCategory Category { get; set; }
+        public string Source { get; set; }
+        public string MessageText { get; set; }
+    }
+
+    /// <summary>
+    /// Equivalent to Octopus.Diagnostics.LogCategory. Duplicated here to minimize dependencies.
+    /// </summary>
+    public enum LogCategory
+    {
+        Trace = 1,
+        Verbose = 100,
+        Info = 200,
+        Planned = 201,
+        Highlight = 210,
+        Abandoned = 220,
+        Wait = 225,
+        Progress = 230,
+        Finished = 240,
+        Warning = 300,
+        Error = 400,
+        Fatal = 500
+    }
+}

--- a/source/Octopus.Client/Model/ReleaseLogResource.cs
+++ b/source/Octopus.Client/Model/ReleaseLogResource.cs
@@ -6,6 +6,9 @@ namespace Octopus.Client.Model
 {
     public class ReleaseLogResource : Resource, IHaveSpaceResource
     {
+        internal static string RequiresOctopusVersion = "2019.10.1";
+        internal static string RequiresOctopusVersionMessage = $"Fetching release logs requires Octopus version {RequiresOctopusVersion} or newer";
+
         public string SpaceId { get; set; }
         public string ReleaseId { get; set; }
         public Guid RequestId { get; set; }

--- a/source/Octopus.Client/Model/ReleaseLogResource.cs
+++ b/source/Octopus.Client/Model/ReleaseLogResource.cs
@@ -6,7 +6,7 @@ namespace Octopus.Client.Model
 {
     public class ReleaseLogResource : Resource, IHaveSpaceResource
     {
-        internal static string RequiresOctopusVersion = "2019.10.1";
+        internal static string RequiresOctopusVersion = "2019.11.0";
         internal static string RequiresOctopusVersionMessage = $"Fetching release logs requires Octopus version {RequiresOctopusVersion} or newer";
 
         public string SpaceId { get; set; }

--- a/source/Octopus.Client/Repositories/Async/ReleaseRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ReleaseRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
@@ -75,6 +76,12 @@ namespace Octopus.Client.Repositories.Async
 
         public Task<ResourceCollection<ReleaseLogResource>> GetLog(ReleaseResource release, int skip = 0, int? take = null)
         {
+            if (!release.HasLink("Log"))
+            {
+                throw new OperationNotSupportedByOctopusServerException(
+                    ReleaseLogResource.RequiresOctopusVersionMessage, ReleaseLogResource.RequiresOctopusVersion);
+            }
+
             return Client.List<ReleaseLogResource>(release.Link("Log"), new {skip, take});
         }
     }

--- a/source/Octopus.Client/Repositories/Async/ReleaseRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ReleaseRepository.cs
@@ -24,9 +24,10 @@ namespace Octopus.Client.Repositories.Async
         Task<ResourceCollection<ArtifactResource>> GetArtifacts(ReleaseResource release, int skip = 0, int? take = null);
         Task<DeploymentTemplateResource> GetTemplate(ReleaseResource release);
         Task<DeploymentPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget);
-        Task<ReleaseResource> SnapshotVariables(ReleaseResource release);    
+        Task<ReleaseResource> SnapshotVariables(ReleaseResource release);
         Task<ReleaseResource> Create(ReleaseResource release, bool ignoreChannelRules = false);
         Task<LifecycleProgressionResource> GetProgression(ReleaseResource release);
+        Task<ResourceCollection<ReleaseLogResource>> GetLog(ReleaseResource release, int skip = 0, int? take = null);
     }
 
     class ReleaseRepository : BasicRepository<ReleaseResource>, IReleaseRepository
@@ -66,10 +67,15 @@ namespace Octopus.Client.Repositories.Async
         {
             return await Client.Create(await Repository.Link(CollectionLinkName).ConfigureAwait(false), release, new { ignoreChannelRules }).ConfigureAwait(false);
         }
-        
+
         public Task<LifecycleProgressionResource> GetProgression(ReleaseResource release)
         {
             return Client.Get<LifecycleProgressionResource>(release.Links["Progression"]);
+        }
+
+        public Task<ResourceCollection<ReleaseLogResource>> GetLog(ReleaseResource release, int skip = 0, int? take = null)
+        {
+            return Client.List<ReleaseLogResource>(release.Link("Log"), new {skip, take});
         }
     }
 }

--- a/source/Octopus.Client/Repositories/ReleaseRepository.cs
+++ b/source/Octopus.Client/Repositories/ReleaseRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
@@ -74,6 +75,11 @@ namespace Octopus.Client.Repositories
 
         public ResourceCollection<ReleaseLogResource> GetLog(ReleaseResource release, int skip = 0, int? take = null)
         {
+            if (!release.HasLink("Log"))
+            {
+                throw new OperationNotSupportedByOctopusServerException(
+                    ReleaseLogResource.RequiresOctopusVersionMessage, ReleaseLogResource.RequiresOctopusVersion);
+            }
             return Client.List<ReleaseLogResource>(release.Link("Log"), new {skip, take});
         }
     }

--- a/source/Octopus.Client/Repositories/ReleaseRepository.cs
+++ b/source/Octopus.Client/Repositories/ReleaseRepository.cs
@@ -26,6 +26,7 @@ namespace Octopus.Client.Repositories
         ReleaseResource SnapshotVariables(ReleaseResource release);    
         ReleaseResource Create(ReleaseResource release, bool ignoreChannelRules = false);
         LifecycleProgressionResource GetProgression(ReleaseResource release);
+        ResourceCollection<ReleaseLogResource> GetLog(ReleaseResource release, int skip = 0, int? take = null);
     }
     
     class ReleaseRepository : BasicRepository<ReleaseResource>, IReleaseRepository
@@ -69,6 +70,11 @@ namespace Octopus.Client.Repositories
         public LifecycleProgressionResource GetProgression(ReleaseResource release)
         {
             return Client.Get<LifecycleProgressionResource>(release.Links["Progression"]);
+        }
+
+        public ResourceCollection<ReleaseLogResource> GetLog(ReleaseResource release, int skip = 0, int? take = null)
+        {
+            return Client.List<ReleaseLogResource>(release.Link("Log"), new {skip, take});
         }
     }
 }


### PR DESCRIPTION
Adds and implements `IReleaseRepository.GetLog()`.

Part of a solution to OctopusDeploy/Issues#5869.