### PR TITLE
Backwards Compat Check

### DIFF
--- a/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
+++ b/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
@@ -113,6 +113,7 @@ namespace Octopus.Client.Tests.Integration
                  new RootResource()
                  {
                      ApiVersion = "3.0.0",
+                     Version = "2099.0.0",
                      InstallationId = InstallationId,
                      Links = new LinkCollection()
                      {

--- a/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
@@ -41,6 +41,7 @@ namespace Octopus.Client.Tests.Operations
             var rootDocument = new RootResource
             {
                 ApiVersion = "3.0.0",
+                Version = "2099.0.0",
                 Links = LinkCollection.Self("/api")
                     .Add("Environments", "/api/environments")
                     .Add("Machines", "/api/machines")

--- a/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
@@ -28,6 +28,8 @@ namespace Octopus.Client.Tests.Repositories.Async
             repoForMixedScopedResource = new TestMixedResourceAsyncRepository(mockRepo, "");
             repoForSystemScopedResource = new TestSystemResourceAsyncRepository(mockRepo, "", async repo => await Task.FromResult(""));
             
+            mockRepo.LoadRootDocument().Returns(GetRootResource());
+            
             someSpace = new SpaceResource
             {
                 Id = "Spaces-1",
@@ -43,6 +45,15 @@ namespace Octopus.Client.Tests.Repositories.Async
             };
             
             mockRepo.Scope.Returns(RepositoryScope.ForSpace(someSpace));
+            
+            RootResource GetRootResource()
+            {
+                return new RootResource
+                {
+                    ApiVersion = "3.0.0",
+                    Version = "2099.0.0"
+                };
+            }
         }
         
         [Test]

--- a/source/Octopus.Client.Tests/Repositories/Async/TaskRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/TaskRepositoryTests.cs
@@ -110,6 +110,7 @@ namespace Octopus.Client.Tests.Repositories.Async
             client.Repository.LoadRootDocument().Returns(new RootResource()
             {
                 ApiVersion = "3.0.0",
+                Version = "2099.0.0",
                 Links = LinkCollection.Self("/api")
                     .Add("CurrentUser", "/api/users/me")
             });

--- a/source/Octopus.Client.Tests/Repositories/OctopusAsyncRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/OctopusAsyncRepositoryTests.cs
@@ -14,7 +14,10 @@ namespace Octopus.Client.Tests.Repositories
         public void AllPropertiesAreNotNullExceptDelayInitialised()
         {
             var client = Substitute.For<IOctopusAsyncClient>();
-            client.Repository.LoadRootDocument().Returns(new RootResource());
+            client.Repository.LoadRootDocument().Returns(new RootResource
+            {
+                Version = "2099.0.0"
+            });
             var repository = new OctopusAsyncRepository(client);
             var nullPropertiesQ = from p in typeof(OctopusAsyncRepository).GetTypeInfo().GetProperties()
                 where !delayInitialisedProperties.Contains(p.Name)

--- a/source/Octopus.Client.Tests/Repositories/OctopusRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/OctopusRepositoryTests.cs
@@ -24,6 +24,7 @@ namespace Octopus.Client.Tests.Repositories
             client.Get<RootResource>(Arg.Any<string>()).Returns(new RootResource()
             {
                 ApiVersion = "3.0.0",
+                Version = "2099.0.0",
                 Links =
                 {
                     {"CurrentUser",  ""},
@@ -40,6 +41,7 @@ namespace Octopus.Client.Tests.Repositories
             client.Get<RootResource>(Arg.Any<string>()).Returns(new RootResource()
             {
                 ApiVersion = "3.0.0",
+                Version = "2099.0.0",
                 Links = LinkCollection.Self("/api")
                     .Add("CurrentUser", "/api/users/me")
             });

--- a/source/Octopus.Client.Tests/Spaces/MixedScopeSpaceContextExtensionTests.cs
+++ b/source/Octopus.Client.Tests/Spaces/MixedScopeSpaceContextExtensionTests.cs
@@ -17,6 +17,7 @@ namespace Octopus.Client.Tests.Spaces
         {
             var repository = Substitute.For<IOctopusAsyncRepository>();
             repository.Scope.Returns(scope);
+            repository.LoadRootDocument().Returns(GetRootResource());
             ITeamsRepository teamRepo = new TeamsRepository(repository);
             Action switchContext = () => teamRepo.UsingContext(SpaceContext.AllSpaces());
             switchContext.ShouldThrow<SpaceContextSwitchException>();
@@ -27,6 +28,7 @@ namespace Octopus.Client.Tests.Spaces
         {
             var repository = Substitute.For<IOctopusAsyncRepository>();
             repository.Scope.Returns(RepositoryScope.Unspecified());
+            repository.LoadRootDocument().Returns(GetRootResource());
             repository.Teams.UsingContext(SpaceContext.AllSpaces());
         }
 
@@ -36,6 +38,15 @@ namespace Octopus.Client.Tests.Spaces
             {
                 new TestCaseData(RepositoryScope.ForSystem()),
                 new TestCaseData(RepositoryScope.ForSpace(new SpaceResource {Id = "Spaces-1", Links = new LinkCollection {{ "SpaceHome", String.Empty}}}))
+            };
+        }
+
+        static RootResource GetRootResource()
+        {
+            return new RootResource
+            {
+                ApiVersion = "3.0.0",
+                Version = "2099.0.0"
             };
         }
     }

--- a/source/Octopus.Client.Tests/Spaces/SpaceIdAsyncTests.cs
+++ b/source/Octopus.Client.Tests/Spaces/SpaceIdAsyncTests.cs
@@ -22,6 +22,7 @@ namespace Octopus.Client.Tests.Spaces
             client.Get<RootResource>(Arg.Any<string>()).Returns(new RootResource()
             {
                 ApiVersion = "3.0.0",
+                Version = "2099.0.0",
                 Links =
                 {
                     { "Teams", "" },

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Extensibility;
@@ -17,6 +19,8 @@ namespace Octopus.Client.Repositories.Async
     {
         private readonly Func<IOctopusAsyncRepository, Task<string>> getCollectionLinkName;
         protected string CollectionLinkName;
+        private SemanticVersion minimumRequiredVersion;
+        private bool hasMinimumRequiredVersion;
 
         protected BasicRepository(IOctopusAsyncRepository repository, string collectionLinkName, Func<IOctopusAsyncRepository, Task<string>> getCollectionLinkName = null)
         {
@@ -55,14 +59,35 @@ namespace Octopus.Client.Repositories.Async
                 });
         } 
 
+        protected void MinimumCompatibleVersion(string version)
+        {
+            minimumRequiredVersion = SemanticVersion.Parse(version);
+            hasMinimumRequiredVersion = true;
+        }
+        
         private void AssertSpaceIdMatchesResource(TResource resource)
         {
             if (resource is IHaveSpaceResource spaceResource)
                 CheckSpaceResource(spaceResource);
         }
         
+        protected async void ThrowIfServerVersionIsNotCompatible()
+        {
+            if (!hasMinimumRequiredVersion) return;
+
+            var currentServerVersion = SemanticVersion.Parse((await Repository.LoadRootDocument()).Version);
+
+            if (currentServerVersion < minimumRequiredVersion)
+            {
+                throw new NotSupportedException(
+                    $"The version of the Octopus Server ('{currentServerVersion}') you are connecting to is not compatible with this version of Octopus.Client for this API call. Please upgrade your Octopus Server to a version greater than '{minimumRequiredVersion}'");
+            }
+        }
+        
         public virtual async Task<TResource> Create(TResource resource, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             var link = await ResolveLink().ConfigureAwait(false);
             AssertSpaceIdMatchesResource(resource);
             EnrichSpaceId(resource);
@@ -71,18 +96,24 @@ namespace Octopus.Client.Repositories.Async
 
         public virtual Task<TResource> Modify(TResource resource)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             AssertSpaceIdMatchesResource(resource);
             return Client.Update(resource.Links["Self"], resource);
         }
 
         public Task Delete(TResource resource)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             AssertSpaceIdMatchesResource(resource);
             return Client.Delete(resource.Links["Self"]);
         }
 
         public async Task Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path = null, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             var link = await ResolveLink().ConfigureAwait(false);
             var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), pathParameters);
             await Client.Paginate(path ?? link, parameters, getNextPage).ConfigureAwait(false);
@@ -90,6 +121,8 @@ namespace Octopus.Client.Repositories.Async
 
         public async Task<TResource> FindOne(Func<TResource, bool> search, string path = null, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             TResource resource = null;
             await Paginate(page =>
             {
@@ -102,6 +135,8 @@ namespace Octopus.Client.Repositories.Async
 
         public async Task<List<TResource>> FindMany(Func<TResource, bool> search, string path = null, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             var resources = new List<TResource>();
             await Paginate(page =>
             {
@@ -114,11 +149,15 @@ namespace Octopus.Client.Repositories.Async
 
         public Task<List<TResource>> FindAll(string path = null, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             return FindMany(r => true, path, pathParameters);
         }
 
         public async Task<List<TResource>> GetAll()
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             var link = await ResolveLink().ConfigureAwait(false);
             var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new { id = IdValueConstant.IdAll });
             return await Client.Get<List<TResource>>(link, parameters).ConfigureAwait(false);
@@ -126,6 +165,8 @@ namespace Octopus.Client.Repositories.Async
 
         public Task<TResource> FindByName(string name, string path = null, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             name = (name ?? string.Empty).Trim();
 
             // Some endpoints allow a Name query param which greatly increases efficiency
@@ -142,6 +183,8 @@ namespace Octopus.Client.Repositories.Async
 
         public Task<List<TResource>> FindByNames(IEnumerable<string> names, string path = null, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             var nameSet = new HashSet<string>((names ?? new string[0]).Select(n => (n ?? string.Empty).Trim()), StringComparer.OrdinalIgnoreCase);
             return FindMany(r =>
             {
@@ -153,6 +196,8 @@ namespace Octopus.Client.Repositories.Async
 
         public async Task<TResource> Get(string idOrHref)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             if (string.IsNullOrWhiteSpace(idOrHref))
                 return null;
 
@@ -167,6 +212,8 @@ namespace Octopus.Client.Repositories.Async
 
         public virtual async Task<List<TResource>> Get(params string[] ids)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             if (ids == null) return new List<TResource>();
             var actualIds = ids.Where(id => !string.IsNullOrWhiteSpace(id)).ToArray();
             if (actualIds.Length == 0) return new List<TResource>();
@@ -193,12 +240,16 @@ namespace Octopus.Client.Repositories.Async
 
         public Task<TResource> Refresh(TResource resource)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             if (resource == null) throw new ArgumentNullException("resource");
             return Get(resource.Id);
         }
 
         protected virtual void EnrichSpaceId(TResource resource)
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             if (resource is IHaveSpaceResource spaceResource)
             {
                 spaceResource.SpaceId = Repository.Scope.Apply(space => space.Id,
@@ -209,6 +260,8 @@ namespace Octopus.Client.Repositories.Async
 
         protected async Task<string> ResolveLink()
         {
+            ThrowIfServerVersionIsNotCompatible();
+
             if (CollectionLinkName == null && getCollectionLinkName != null)
                 CollectionLinkName = await getCollectionLinkName(Repository).ConfigureAwait(false);
             return await Repository.Link(CollectionLinkName).ConfigureAwait(false);

--- a/source/Octopus.Client/Repositories/Async/ProjectTriggerRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectTriggerRepository.cs
@@ -18,15 +18,20 @@ namespace Octopus.Client.Repositories.Async
         public ProjectTriggerRepository(IOctopusAsyncRepository repository)
             : base(repository, "ProjectTriggers")
         {
+            MinimumCompatibleVersion("2019.11.0");
         }
 
         public Task<ProjectTriggerResource> FindByName(ProjectResource project, string name)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             return FindByName(name, path: project.Link("Triggers"));
         }
 
         public Task<ProjectTriggerEditor> CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             return new ProjectTriggerEditor(this).CreateOrModify(project, name, filter, action);
         }
     }

--- a/source/Octopus.Client/Repositories/Async/ScopedUserRoleRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ScopedUserRoleRepository.cs
@@ -18,15 +18,18 @@ namespace Octopus.Client.Repositories.Async
         public ScopedUserRoleRepository(IOctopusAsyncRepository repository)
             : base(repository, "ScopedUserRoles")
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         ScopedUserRoleRepository(IOctopusAsyncRepository repository, SpaceContext spaceContext)
             : base(repository, "ScopedUserRoles", spaceContext)
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         public IScopedUserRoleRepository UsingContext(SpaceContext spaceContext)
         {
+            ThrowIfServerVersionIsNotCompatible();
             return new ScopedUserRoleRepository(Repository, spaceContext);
         }
     }

--- a/source/Octopus.Client/Repositories/Async/TeamsRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/TeamsRepository.cs
@@ -22,15 +22,19 @@ namespace Octopus.Client.Repositories.Async
         public TeamsRepository(IOctopusAsyncRepository repository)
             : base(repository, "Teams")
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         TeamsRepository(IOctopusAsyncRepository repository, SpaceContext spaceContext)
             : base(repository, "Teams", spaceContext)
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         public async Task<List<ScopedUserRoleResource>> GetScopedUserRoles(TeamResource team)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             if (team == null) throw new ArgumentNullException(nameof(team));
             var resources = new List<ScopedUserRoleResource>();
 
@@ -45,6 +49,8 @@ namespace Octopus.Client.Repositories.Async
 
         public ITeamsRepository UsingContext(SpaceContext spaceContext)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             return new TeamsRepository(Repository, spaceContext);
         }
     }

--- a/source/Octopus.Client/Repositories/Async/UserRolesRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRolesRepository.cs
@@ -14,16 +14,21 @@ namespace Octopus.Client.Repositories.Async
         public UserRolesRepository(IOctopusAsyncRepository repository)
             : base(repository, "UserRoles")
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         public override async Task<UserRoleResource> Create(UserRoleResource resource, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             await RemoveInvalidPermissions(resource).ConfigureAwait(false);
             return await base.Create(resource, pathParameters).ConfigureAwait(false);
         }
 
         public override async Task<UserRoleResource> Modify(UserRoleResource resource)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             await RemoveInvalidPermissions(resource).ConfigureAwait(false);
             return await base.Modify(resource).ConfigureAwait(false);
         }

--- a/source/Octopus.Client/Repositories/ProjectTriggerRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectTriggerRepository.cs
@@ -16,15 +16,20 @@ namespace Octopus.Client.Repositories
         public ProjectTriggerRepository(IOctopusRepository repository)
             : base(repository, "ProjectTriggers")
         {
+            MinimumCompatibleVersion("2019.11.0");
         }
 
         public ProjectTriggerResource FindByName(ProjectResource project, string name)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             return FindByName(name, path: project.Link("Triggers"));
         }
 
         public ProjectTriggerEditor CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             return new ProjectTriggerEditor(this).CreateOrModify(project, name, filter, action);
         }
     }

--- a/source/Octopus.Client/Repositories/ScopedUserRoleRepository.cs
+++ b/source/Octopus.Client/Repositories/ScopedUserRoleRepository.cs
@@ -18,11 +18,13 @@ namespace Octopus.Client.Repositories
         public ScopedUserRoleRepository(IOctopusRepository repository)
             : base(repository, "ScopedUserRoles")
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         ScopedUserRoleRepository(IOctopusRepository repository, SpaceContext userDefinedSpaceContext)
             : base(repository, "ScopedUserRoles", userDefinedSpaceContext)
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         public IScopedUserRoleRepository UsingContext(SpaceContext userDefinedSpaceContext)

--- a/source/Octopus.Client/Repositories/TeamsRepository.cs
+++ b/source/Octopus.Client/Repositories/TeamsRepository.cs
@@ -21,15 +21,19 @@ namespace Octopus.Client.Repositories
         public TeamsRepository(IOctopusRepository repository)
             : base(repository, "Teams")
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         TeamsRepository(IOctopusRepository repository, SpaceContext userDefinedSpaceContext)
             : base(repository, "Teams", userDefinedSpaceContext)
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         public List<ScopedUserRoleResource> GetScopedUserRoles(TeamResource team)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             if (team == null) throw new ArgumentNullException(nameof(team));
             var resources = new List<ScopedUserRoleResource>();
 
@@ -44,6 +48,8 @@ namespace Octopus.Client.Repositories
 
         public ITeamsRepository UsingContext(SpaceContext userDefinedSpaceContext)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             return new TeamsRepository(Repository, userDefinedSpaceContext);
         }
     }

--- a/source/Octopus.Client/Repositories/UserRolesRepository.cs
+++ b/source/Octopus.Client/Repositories/UserRolesRepository.cs
@@ -13,16 +13,21 @@ namespace Octopus.Client.Repositories
         public UserRolesRepository(IOctopusRepository repository)
             : base(repository, "UserRoles")
         {
+            MinimumCompatibleVersion("2019.1.0");
         }
 
         public override UserRoleResource Create(UserRoleResource resource, object pathParameters = null)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             RemoveInvalidPermissions(resource);
             return base.Create(resource, pathParameters);
         }
 
         public override UserRoleResource Modify(UserRoleResource resource)
         {
+            ThrowIfServerVersionIsNotCompatible();
+            
             RemoveInvalidPermissions(resource);
             return base.Modify(resource);
         }


### PR DESCRIPTION
For the cases where we have decided we must make a breaking change in Server and Octopus.Client.

The client will have a resource that's no longer compatible with *old versions of server*. We want to alert/protect the customer in this scenario.

- We want this check to only happen at the time of calling specific API (method) on specific repositories (not at repository creation time).
- It may often impact the entire repository.
   - This is the case with this most recent upcoming change.
   - This is also the case with the historic  Team/ScopedUserRole/UserRole change made for 2019.1.0

Here is the start of this idea.

### Future breaking changes to the same resources/repositories
 - Would be fine, as the `versionThreshold` would just be bumped up higher again.

### Results

Using client against:
 1. Server 2019.10 no error
 2. Server 2018.10 expected to see error

### Sync client
![image](https://user-images.githubusercontent.com/119096/69120913-f2c96300-0aee-11ea-8442-376d5bd546b3.png)

### Async client
![image](https://user-images.githubusercontent.com/119096/69398783-d07a5400-0d3f-11ea-9772-7905858e1212.png)
