### PR TITLE
WIP - Client update to add ShouldRedeployWhenReleaseIsCurrent flag

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6074,6 +6074,7 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     .ctor()
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     String DestinationEnvironmentId { get; set; }
+    Boolean ShouldRedeployWhenReleaseIsCurrent { get; set; }
     String SourceEnvironmentId { get; set; }
     String Variables { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6099,6 +6099,7 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     .ctor()
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     String DestinationEnvironmentId { get; set; }
+    Boolean ShouldRedeployWhenReleaseIsCurrent { get; set; }
     String SourceEnvironmentId { get; set; }
     String Variables { get; set; }
   }

--- a/source/Octopus.Client/Model/Triggers/DeployLatestReleaseActionResource.cs
+++ b/source/Octopus.Client/Model/Triggers/DeployLatestReleaseActionResource.cs
@@ -14,5 +14,8 @@ namespace Octopus.Client.Model.Triggers.ScheduledTriggers
 
         [Writeable]
         public string DestinationEnvironmentId { get; set; }
+
+        [Writeable]
+        public bool ShouldRedeployWhenReleaseIsCurrent { get; set; } = true;
     }
 }


### PR DESCRIPTION
Working on Octopus Client changes for:

**Private link**
https://trello.com/c/64dGj9aQ/78-dont-re-deploy-release

Server changes at: https://github.com/OctopusDeploy/OctopusDeploy/pull/4748