### PR TITLE
Add project trigger filtering by runbook

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6658,6 +6658,7 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.ProjectTriggerEditor CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
     Octopus.Client.Model.ProjectTriggerResource FindByName(Octopus.Client.Model.ProjectResource, String)
+    Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> FindByRunbook(String[])
   }
   interface IProxyRepository
     Octopus.Client.Repositories.IGet<ProxyResource>
@@ -7339,6 +7340,7 @@ Octopus.Client.Repositories.Async
   {
     Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
     Task<ProjectTriggerResource> FindByName(Octopus.Client.Model.ProjectResource, String)
+    Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(String[])
   }
   interface IProxyRepository
     Octopus.Client.Repositories.Async.IGet<ProxyResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6683,6 +6683,7 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.ProjectTriggerEditor CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
     Octopus.Client.Model.ProjectTriggerResource FindByName(Octopus.Client.Model.ProjectResource, String)
+    Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> FindByRunbook(String[])
   }
   interface IProxyRepository
     Octopus.Client.Repositories.IGet<ProxyResource>
@@ -7364,6 +7365,7 @@ Octopus.Client.Repositories.Async
   {
     Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
     Task<ProjectTriggerResource> FindByName(Octopus.Client.Model.ProjectResource, String)
+    Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(String[])
   }
   interface IProxyRepository
     Octopus.Client.Repositories.Async.IGet<ProxyResource>

--- a/source/Octopus.Client/Model/ProjectTriggerResource.cs
+++ b/source/Octopus.Client/Model/ProjectTriggerResource.cs
@@ -16,7 +16,6 @@ namespace Octopus.Client.Model
         [Writeable]
         public bool IsDisabled { get; set; }
 
-
         [Writeable]
         public TriggerFilterResource Filter { get; set; }
 

--- a/source/Octopus.Client/Repositories/Async/ProjectTriggerRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectTriggerRepository.cs
@@ -11,6 +11,7 @@ namespace Octopus.Client.Repositories.Async
         Task<ProjectTriggerResource> FindByName(ProjectResource project, string name);
 
         Task<ProjectTriggerEditor> CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action);
+        Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(params string[] runbookIds);
     }
 
     class ProjectTriggerRepository : BasicRepository<ProjectTriggerResource>, IProjectTriggerRepository
@@ -29,5 +30,11 @@ namespace Octopus.Client.Repositories.Async
         {
             return new ProjectTriggerEditor(this).CreateOrModify(project, name, filter, action);
         }
+
+        public async Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(params string[] runbookIds)
+        {
+            return await Client.List<ProjectTriggerResource>(await Repository.Link("Triggers"), new { runbooks = runbookIds });
+        }
+
     }
 }

--- a/source/Octopus.Client/Repositories/ProjectTriggerRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectTriggerRepository.cs
@@ -1,4 +1,3 @@
-using System;
 using Octopus.Client.Editors;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Triggers;
@@ -9,6 +8,7 @@ namespace Octopus.Client.Repositories
     {
         ProjectTriggerResource FindByName(ProjectResource project, string name);
         ProjectTriggerEditor CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action);
+        ResourceCollection<ProjectTriggerResource> FindByRunbook(params string[] runbookIds);
     }
     
     class ProjectTriggerRepository : BasicRepository<ProjectTriggerResource>, IProjectTriggerRepository
@@ -26,6 +26,11 @@ namespace Octopus.Client.Repositories
         public ProjectTriggerEditor CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action)
         {
             return new ProjectTriggerEditor(this).CreateOrModify(project, name, filter, action);
+        }
+
+        public ResourceCollection<ProjectTriggerResource> FindByRunbook(params string[] runbookIds)
+        {
+            return Client.List<ProjectTriggerResource>(Repository.Link("ProjectTriggers"), new { runbooks = runbookIds });
         }
     }
 }


### PR DESCRIPTION
Provide runbook ids to the method `FindByRunbook` and the result will be any project triggers matching those ids.