### PR TITLE
Improve development experience in non-windows environments

### DIFF
--- a/source/Octopus.Client.E2ETests/NuSpecDependenciesFixture.cs
+++ b/source/Octopus.Client.E2ETests/NuSpecDependenciesFixture.cs
@@ -27,7 +27,7 @@ namespace Octopus.Client.E2ETests
         public void OneTimeSetUp()
         {
             var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().FullLocalPath());
-            var artifactsFolder = Path.GetFullPath(Path.Combine(path, @"..\..\..\..\..\artifacts"));
+            var artifactsFolder = Path.GetFullPath(Path.Combine(path, "..", "..", "..", "..", "..", "artifacts"));
             var package = Directory.EnumerateFiles(artifactsFolder , "Octopus.Client.*.nupkg").FirstOrDefault();
             if (package == null)
                 Assert.Fail($"Couldn't find built nuget package with name 'Octopus.Client.*.nupkg' at '{artifactsFolder }'");
@@ -47,7 +47,7 @@ namespace Octopus.Client.E2ETests
                 }
             }
             
-            var sourceFolder = Path.GetFullPath(Path.Combine(path, @"..\..\..\..\..\source\Octopus.Client"));
+            var sourceFolder = Path.GetFullPath(Path.Combine(path, "..", "..", "..", "..", "..", "source", "Octopus.Client"));
             var projectFile = Directory.EnumerateFiles(sourceFolder , "Octopus.Client.csproj").FirstOrDefault();
             if (projectFile == null)
                 Assert.Fail($"Couldn't find built c# project file with name 'Octopus.Client.csproj' at '{artifactsFolder }'");

--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -1,13 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
         <AssemblyName>Octopus.Client.E2ETests</AssemblyName>
         <PackageId>Octopus.Client.E2ETests</PackageId>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    </PropertyGroup>
+    <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+        <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+        <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
         <DefineConstants>$(DefineConstants);SUPPORTS_ILMERGE</DefineConstants>

--- a/source/Octopus.Client.E2ETests/TestHelpers.cs
+++ b/source/Octopus.Client.E2ETests/TestHelpers.cs
@@ -10,7 +10,7 @@ namespace Octopus.Client.E2ETests
         internal static string GetNuGetPackage()
         {
             var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().FullLocalPath());
-            var artifactsFolder = Path.GetFullPath(Path.Combine(path, @"..\..\..\..\..\artifacts"));
+            var artifactsFolder = Path.GetFullPath(Path.Combine(path, "..", "..", "..", "..", "..", "artifacts"));
             var package = Directory.EnumerateFiles(artifactsFolder, "Octopus.Client.*.nupkg").FirstOrDefault();
             if (package == null)
                 Assert.Fail($"Couldn't find built nuget package with name 'Octopus.Client.*.nupkg' at '{artifactsFolder}'");

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -1,13 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Octopus.Client.Tests</AssemblyName>
     <PackageId>Octopus.Client.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+  <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/source/Octopus.Client/Octopus.Client.csproj
+++ b/source/Octopus.Client/Octopus.Client.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -17,6 +16,12 @@
     <Description>Octopus Deploy is an automated release management tool for modern developers and DevOps teams.
 
 This package contains the client library for the HTTP API in Octopus.</Description>
+  </PropertyGroup>
+  <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
This PR makes it possible to do basic development of this library in non-windows OSes like linux or macOS. Only the compatible target frameworks are compiled in those OSes.