### PR TITLE
Changed scheduled triggers to use an enum for days of week

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2344,6 +2344,24 @@ Octopus.Client.Model
     IDictionary<String, ReferenceCollection> ProjectEnvironments { get; set; }
     Octopus.Client.Model.ReferenceCollection TenantTags { get; set; }
   }
+  DaysOfWeek
+  {
+      Sunday = 1
+      Monday = 2
+      Tuesday = 4
+      Wednesday = 8
+      Thursday = 16
+      Friday = 32
+      Saturday = 64
+  }
+  class DaysOfWeekFlagConverter
+    JsonConverter
+  {
+    .ctor()
+    Boolean CanConvert(Type)
+    Object ReadJson(JsonReader, Type, Object, JsonSerializer)
+    void WriteJson(JsonWriter, Object, JsonSerializer)
+  }
   class Defect
   {
     .ctor()
@@ -6027,20 +6045,13 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.ScheduledTriggers.ScheduledTriggerFilterResource
   {
     .ctor()
+    Octopus.Client.Model.DaysOfWeek DaysOfWeek { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
-    Boolean Friday { get; set; }
     Nullable<Int16> HourInterval { get; set; }
     Octopus.Client.Model.Triggers.ScheduledTriggers.DailyScheduledTriggerInterval Interval { get; set; }
     Nullable<Int16> MinuteInterval { get; set; }
-    Boolean Monday { get; set; }
     Nullable<DateTime> RunAfter { get; set; }
     Nullable<DateTime> RunUntil { get; set; }
-    Boolean Saturday { get; set; }
-    Boolean Sunday { get; set; }
-    Boolean Thursday { get; set; }
-    Boolean Tuesday { get; set; }
-    Boolean Wednesday { get; set; }
-    void SetDayFromString(String)
   }
   class CronScheduledTriggerFilterResource
     Octopus.Client.Extensibility.IResource
@@ -6112,16 +6123,9 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.ScheduledTriggers.ScheduledTriggerFilterResource
   {
     .ctor()
+    Octopus.Client.Model.DaysOfWeek DaysOfWeek { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
-    Boolean Friday { get; set; }
-    Boolean Monday { get; set; }
-    Boolean Saturday { get; set; }
     DateTime StartTime { get; set; }
-    Boolean Sunday { get; set; }
-    Boolean Thursday { get; set; }
-    Boolean Tuesday { get; set; }
-    Boolean Wednesday { get; set; }
-    void SetDayFromString(String)
   }
   abstract class ScheduledTriggerFilterResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2360,6 +2360,24 @@ Octopus.Client.Model
     IDictionary<String, ReferenceCollection> ProjectEnvironments { get; set; }
     Octopus.Client.Model.ReferenceCollection TenantTags { get; set; }
   }
+  DaysOfWeek
+  {
+      Sunday = 1
+      Monday = 2
+      Tuesday = 4
+      Wednesday = 8
+      Thursday = 16
+      Friday = 32
+      Saturday = 64
+  }
+  class DaysOfWeekFlagConverter
+    JsonConverter
+  {
+    .ctor()
+    Boolean CanConvert(Type)
+    Object ReadJson(JsonReader, Type, Object, JsonSerializer)
+    void WriteJson(JsonWriter, Object, JsonSerializer)
+  }
   class Defect
   {
     .ctor()
@@ -6052,20 +6070,13 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.ScheduledTriggers.ScheduledTriggerFilterResource
   {
     .ctor()
+    Octopus.Client.Model.DaysOfWeek DaysOfWeek { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
-    Boolean Friday { get; set; }
     Nullable<Int16> HourInterval { get; set; }
     Octopus.Client.Model.Triggers.ScheduledTriggers.DailyScheduledTriggerInterval Interval { get; set; }
     Nullable<Int16> MinuteInterval { get; set; }
-    Boolean Monday { get; set; }
     Nullable<DateTime> RunAfter { get; set; }
     Nullable<DateTime> RunUntil { get; set; }
-    Boolean Saturday { get; set; }
-    Boolean Sunday { get; set; }
-    Boolean Thursday { get; set; }
-    Boolean Tuesday { get; set; }
-    Boolean Wednesday { get; set; }
-    void SetDayFromString(String)
   }
   class CronScheduledTriggerFilterResource
     Octopus.Client.Extensibility.IResource
@@ -6137,16 +6148,9 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.ScheduledTriggers.ScheduledTriggerFilterResource
   {
     .ctor()
+    Octopus.Client.Model.DaysOfWeek DaysOfWeek { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
-    Boolean Friday { get; set; }
-    Boolean Monday { get; set; }
-    Boolean Saturday { get; set; }
     DateTime StartTime { get; set; }
-    Boolean Sunday { get; set; }
-    Boolean Thursday { get; set; }
-    Boolean Tuesday { get; set; }
-    Boolean Wednesday { get; set; }
-    void SetDayFromString(String)
   }
   abstract class ScheduledTriggerFilterResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client/Model/DaysOfWeek.cs
+++ b/source/Octopus.Client/Model/DaysOfWeek.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Octopus.Client.Model
+{
+    [Flags]
+    [JsonConverter(typeof(DaysOfWeekFlagConverter))]
+    public enum DaysOfWeek
+    {
+        Sunday = 0x1,
+        Monday = 0x2,
+        Tuesday = 0x4,
+        Wednesday = 0x8,
+        Thursday = 0x10,
+        Friday = 0x20,
+        Saturday = 0x40
+    }
+
+    public class DaysOfWeekFlagConverter : JsonConverter
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var outVal = 0;
+            if (reader.TokenType != JsonToken.StartArray) return outVal;
+
+            reader.Read();
+            while (reader.TokenType != JsonToken.EndArray)
+            {
+                outVal += (int)Enum.Parse(objectType, reader.Value.ToString());
+                reader.Read();
+            }
+            return outVal;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var flags = value.ToString()
+                .Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(f => $"\"{f}\"");
+
+            writer.WriteRawValue($"[{string.Join(", ", flags)}]");
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(DaysOfWeek).IsAssignableFrom(objectType);
+        }
+    }
+}

--- a/source/Octopus.Client/Model/Triggers/ScheduledTriggers/ContinuousDailyScheduledTriggerFilterResource.cs
+++ b/source/Octopus.Client/Model/Triggers/ScheduledTriggers/ContinuousDailyScheduledTriggerFilterResource.cs
@@ -23,59 +23,6 @@ namespace Octopus.Client.Model.Triggers.ScheduledTriggers
         public short? MinuteInterval { get; set; }
 
         [Writeable]
-        public bool Monday { get; set; }
-
-        [Writeable]
-        public bool Tuesday { get; set; }
-
-        [Writeable]
-        public bool Wednesday { get; set; }
-
-        [Writeable]
-        public bool Thursday { get; set; }
-
-        [Writeable]
-        public bool Friday { get; set; }
-
-        [Writeable]
-        public bool Saturday { get; set; }
-
-        [Writeable]
-        public bool Sunday { get; set; }
-
-        public void SetDayFromString(string day)
-        {
-            switch (day.ToLowerInvariant())
-            {
-                case "sun":
-                case "0":
-                    Sunday = true;
-                    break;
-                case "mon":
-                case "1":
-                    Monday = true;
-                    break;
-                case "tue":
-                case "2":
-                    Tuesday = true;
-                    break;
-                case "wed":
-                case "3":
-                    Wednesday = true;
-                    break;
-                case "thu":
-                case "4":
-                    Thursday = true;
-                    break;
-                case "fri":
-                case "5":
-                    Friday = true;
-                    break;
-                case "sat":
-                case "6":
-                    Saturday = true;
-                    break;
-            }
-        }
+        public DaysOfWeek DaysOfWeek { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/Triggers/ScheduledTriggers/OnceDailyScheduledTriggerFilterResource.cs
+++ b/source/Octopus.Client/Model/Triggers/ScheduledTriggers/OnceDailyScheduledTriggerFilterResource.cs
@@ -11,59 +11,6 @@ namespace Octopus.Client.Model.Triggers.ScheduledTriggers
         public DateTime StartTime { get; set; }
 
         [Writeable]
-        public bool Monday { get; set; }
-
-        [Writeable]
-        public bool Tuesday { get; set; }
-
-        [Writeable]
-        public bool Wednesday { get; set; }
-
-        [Writeable]
-        public bool Thursday { get; set; }
-
-        [Writeable]
-        public bool Friday { get; set; }
-
-        [Writeable]
-        public bool Saturday { get; set; }
-
-        [Writeable]
-        public bool Sunday { get; set; }
-
-        public void SetDayFromString(string day)
-        {
-            switch (day.ToLowerInvariant())
-            {
-                case "sun":
-                case "0":
-                    Sunday = true;
-                    break;
-                case "mon":
-                case "1":
-                    Monday = true;
-                    break;
-                case "tue":
-                case "2":
-                    Tuesday = true;
-                    break;
-                case "wed":
-                case "3":
-                    Wednesday = true;
-                    break;
-                case "thu":
-                case "4":
-                    Thursday = true;
-                    break;
-                case "fri":
-                case "5":
-                    Friday = true;
-                    break;
-                case "sat":
-                case "6":
-                    Saturday = true;
-                    break;
-            }
-        }
+        public DaysOfWeek DaysOfWeek { get; set; }
     }
 }


### PR DESCRIPTION
This PR removes the individual Boolean day properties from `OnceDailyScheduledTriggerFilterResource` and `ContinuousDailyScheduledTriggerFilterResource` and replaces it with a bitmask enum.

when serializing DaysOfWeek to JSON, it will serialize to an array of strings e.g. `"DaysOfWeek": ["Monday", "Tuesday", "Wednesday"]`