### PR TITLE
Don't assume the file hasn't been uploaded

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6376,7 +6376,7 @@ Octopus.Client.Repositories
   {
     void DeletePackage(Octopus.Client.Model.PackageResource)
     void DeletePackages(IReadOnlyList<PackageResource>)
-    Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String, String)
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32, Int32)
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
@@ -7052,7 +7052,7 @@ Octopus.Client.Repositories.Async
   {
     Task DeletePackage(Octopus.Client.Model.PackageResource)
     Task DeletePackages(IReadOnlyList<PackageResource>)
-    Task<PackageFromBuiltInFeedResource> GetPackage(String)
+    Task<PackageFromBuiltInFeedResource> GetPackage(String, String)
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6376,6 +6376,7 @@ Octopus.Client.Repositories
   {
     void DeletePackage(Octopus.Client.Model.PackageResource)
     void DeletePackages(IReadOnlyList<PackageResource>)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String)
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32, Int32)
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
@@ -7051,6 +7052,7 @@ Octopus.Client.Repositories.Async
   {
     Task DeletePackage(Octopus.Client.Model.PackageResource)
     Task DeletePackages(IReadOnlyList<PackageResource>)
+    Task<PackageFromBuiltInFeedResource> GetPackage(String)
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6401,6 +6401,7 @@ Octopus.Client.Repositories
   {
     void DeletePackage(Octopus.Client.Model.PackageResource)
     void DeletePackages(IReadOnlyList<PackageResource>)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String)
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32, Int32)
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
@@ -7076,6 +7077,7 @@ Octopus.Client.Repositories.Async
   {
     Task DeletePackage(Octopus.Client.Model.PackageResource)
     Task DeletePackages(IReadOnlyList<PackageResource>)
+    Task<PackageFromBuiltInFeedResource> GetPackage(String)
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6401,7 +6401,7 @@ Octopus.Client.Repositories
   {
     void DeletePackage(Octopus.Client.Model.PackageResource)
     void DeletePackages(IReadOnlyList<PackageResource>)
-    Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String, String)
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32, Int32)
     Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
@@ -7077,7 +7077,7 @@ Octopus.Client.Repositories.Async
   {
     Task DeletePackage(Octopus.Client.Model.PackageResource)
     Task DeletePackages(IReadOnlyList<PackageResource>)
-    Task<PackageFromBuiltInFeedResource> GetPackage(String)
+    Task<PackageFromBuiltInFeedResource> GetPackage(String, String)
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
     Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -23,7 +23,7 @@ namespace Octopus.Client.Repositories.Async
         Task DeletePackage(PackageResource package);
         Task DeletePackages(IReadOnlyList<PackageResource> packages);
 
-        Task<PackageFromBuiltInFeedResource> GetPackage(string packageId);
+        Task<PackageFromBuiltInFeedResource> GetPackage(string packageId, string version);
     }
 
     class BuiltInPackageRepositoryRepository : IBuiltInPackageRepositoryRepository
@@ -131,7 +131,7 @@ namespace Octopus.Client.Repositories.Async
         {
             try
             {
-                return await repository.BuiltInPackageRepository.GetPackage($"{packageId}.{version}").ConfigureAwait(false);
+                return await repository.BuiltInPackageRepository.GetPackage(packageId, version.ToString()).ConfigureAwait(false);
             }
             catch (OctopusResourceNotFoundException)
             {
@@ -203,9 +203,9 @@ namespace Octopus.Client.Repositories.Async
             return await repository.Client.List<PackageFromBuiltInFeedResource>(await repository.Link("Packages").ConfigureAwait(false), new { nuGetPackageId = packageId, take, skip }).ConfigureAwait(false);
         }
 
-        public async Task<PackageFromBuiltInFeedResource> GetPackage(string packageId)
+        public async Task<PackageFromBuiltInFeedResource> GetPackage(string packageId, string version)
         {
-            return await repository.Client.Get<PackageFromBuiltInFeedResource>(await repository.Link("Packages").ConfigureAwait(false), new { id = packageId }).ConfigureAwait(false);
+            return await repository.Client.Get<PackageFromBuiltInFeedResource>(await repository.Link("Packages").ConfigureAwait(false), new { id = $"{packageId}.{version}" }).ConfigureAwait(false);
         }
 
         public async Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(int skip = 0, int take = 30)

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -127,11 +127,11 @@ namespace Octopus.Client.Repositories.Async
             return PackageContentComparer.AreSame(uploadedPackage, contents, Logger) ? uploadedPackage : null;
         }
 
-        private Task<PackageFromBuiltInFeedResource> TryFindPackage(string packageId, SemanticVersion version)
+        private async Task<PackageFromBuiltInFeedResource> TryFindPackage(string packageId, SemanticVersion version)
         {
             try
             {
-                return repository.BuiltInPackageRepository.GetPackage($"{packageId}.{version}");
+                return await repository.BuiltInPackageRepository.GetPackage($"{packageId}.{version}");
             }
             catch (OctopusResourceNotFoundException)
             {

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -122,28 +122,9 @@ namespace Octopus.Client.Repositories.Async
                 return null;
             }
 
-            var package = await TryFindPackage(packageId, version);
+            var uploadedPackage = await TryFindPackage(packageId, version);
 
-            if (package == null)
-            {
-                Logger.Info("Package hasn't been uploaded");
-                return null;
-            }
-
-            contents.Seek(0, SeekOrigin.Begin);
-
-            var localFileHash = HashCalculator.Hash(contents);
-
-            if (localFileHash != package.Hash)
-            {
-                Logger.Info("The hash of the local package and the hash of the uploaded package don't match");
-                return null;
-
-            }
-
-            Logger.Info("Package has been successfully uploaded");
-
-            return package;
+            return PackageContentComparer.AreSame(uploadedPackage, contents, Logger) ? uploadedPackage : null;
         }
 
         private Task<PackageFromBuiltInFeedResource> TryFindPackage(string packageId, SemanticVersion version)

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -65,7 +65,7 @@ namespace Octopus.Client.Repositories.Async
                 {
                     Logger.Info("Delta push timed out: " + ex.Message);
 
-                    var verificationResult = await VerifyTransfer(fileName, contents);
+                    var verificationResult = await VerifyTransfer(fileName, contents).ConfigureAwait(false);
                     if (verificationResult != null) return verificationResult;
                 }
                 catch (Exception ex) when (!(ex is OctopusValidationException))
@@ -131,7 +131,7 @@ namespace Octopus.Client.Repositories.Async
         {
             try
             {
-                return await repository.BuiltInPackageRepository.GetPackage($"{packageId}.{version}");
+                return await repository.BuiltInPackageRepository.GetPackage($"{packageId}.{version}").ConfigureAwait(false);
             }
             catch (OctopusResourceNotFoundException)
             {

--- a/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuiltInPackageRepositoryRepository.cs
@@ -38,7 +38,7 @@ namespace Octopus.Client.Repositories.Async
         {
             return await PushPackage(fileName, contents, overwriteMode, useDeltaCompression: true);
         }
-        
+
         public async Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, bool replaceExisting = false)
         {
             return await PushPackage(fileName, contents, replaceExisting ? OverwriteMode.OverwriteExisting : OverwriteMode.FailIfExists, useDeltaCompression: true);
@@ -48,7 +48,7 @@ namespace Octopus.Client.Repositories.Async
         {
             return await PushPackage(fileName, contents, replaceExisting ? OverwriteMode.OverwriteExisting : OverwriteMode.FailIfExists, useDeltaCompression);
         }
-        
+
         public async Task<PackageFromBuiltInFeedResource> PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode, bool useDeltaCompression)
         {
             if (useDeltaCompression)
@@ -62,6 +62,11 @@ namespace Octopus.Client.Repositories.Async
                 catch (Exception ex) when (!(ex is OctopusValidationException))
                 {
                     Logger.Info("Something went wrong while performing a delta transfer: " + ex.Message);
+
+                    var verificationResult = await VerifyTransfer(fileName, contents);
+                    if (verificationResult != null) return verificationResult;
+
+                    Logger.Info("Transfer verification failed");
                 }
 
                 Logger.Info("Falling back to pushing the complete package to the server");
@@ -74,7 +79,7 @@ namespace Octopus.Client.Repositories.Async
             var link = await repository.Link("PackageUpload").ConfigureAwait(false);
             object pathParameters;
 
-            // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
+            // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter
             if (link.Contains(OverwriteModeLink.Link))
             {
                 pathParameters = new { overwriteMode = overwriteMode };
@@ -89,10 +94,35 @@ namespace Octopus.Client.Repositories.Async
                 link,
                 new FileUpload() {Contents = contents, FileName = fileName},
                 pathParameters).ConfigureAwait(false);
-                
+
             Logger.Info("Package transfer completed");
 
             return result;
+        }
+
+        private async Task<PackageFromBuiltInFeedResource> VerifyTransfer(string fileName, Stream contents)
+        {
+            if (!PackageIdentityParser.TryParsePackageIdAndVersion(Path.GetFileNameWithoutExtension(fileName),
+                out var packageId, out var version))
+            {
+                Logger.Info("Can't check whether the delta transfer actually worked");
+                return null;
+            }
+
+            var package = (await repository.BuiltInPackageRepository.ListPackages($"{packageId}.{version}")).Items
+                .SingleOrDefault();
+
+            if (package == null)
+            {
+                Logger.Info("Packaged hasn't been uploaded");
+                return null;
+            }
+
+            contents.Seek(0, SeekOrigin.Begin);
+
+            var localFileHash = HashCalculator.Hash(contents);
+
+            return localFileHash == package.Hash ? package : null;
         }
 
         private async Task<PackageFromBuiltInFeedResource> AttemptDeltaPush(string fileName, Stream contents, OverwriteMode overwriteMode)
@@ -108,7 +138,7 @@ namespace Octopus.Client.Repositories.Async
                 Logger.Info("Could not determine the package ID and/or version based on the supplied filename");
                 return null;
             }
-            
+
             PackageSignatureResource signatureResult;
             try
             {
@@ -120,19 +150,19 @@ namespace Octopus.Client.Repositories.Async
                 Logger.Info("No package with the same ID exists on the server");
                 return null;
             }
-                
+
             using(var deltaTempFile = new TemporaryFile())
             {
                 var shouldUpload = DeltaCompression.CreateDelta(contents, signatureResult, deltaTempFile.FileName);
                 if (!shouldUpload)
                     return null;
-                
+
                 using (var delta = File.OpenRead(deltaTempFile.FileName))
                 {
                     var link = await repository.Link("PackageDeltaUpload").ConfigureAwait(false);
                     object pathParameters;
-                    
-                    // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
+
+                    // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter
                     if (link.Contains(OverwriteModeLink.Link))
                     {
                         pathParameters = new { overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion };
@@ -170,6 +200,6 @@ namespace Octopus.Client.Repositories.Async
 
         public async Task DeletePackages(IReadOnlyList<PackageResource> packages)
             => await repository.Client.Delete(await repository.Link("PackagesBulk").ConfigureAwait(false), new { ids = packages.Select(p => p.Id).ToArray() }).ConfigureAwait(false);
-        
+
     }
 }

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Features;
 using Octopus.Client.Logging;
@@ -36,7 +37,7 @@ namespace Octopus.Client.Repositories
         {
             return PushPackage(fileName, contents, overwriteMode, useDeltaCompression: true);
         }
-        
+
         public PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, bool replaceExisting = false)
         {
             return PushPackage(fileName, contents, replaceExisting ? OverwriteMode.OverwriteExisting : OverwriteMode.FailIfExists, useDeltaCompression: true);
@@ -46,7 +47,7 @@ namespace Octopus.Client.Repositories
         {
             return PushPackage(fileName, contents, replaceExisting ? OverwriteMode.OverwriteExisting : OverwriteMode.FailIfExists, useDeltaCompression);
         }
-        
+
         public PackageFromBuiltInFeedResource PushPackage(string fileName, Stream contents, OverwriteMode overwriteMode, bool useDeltaCompression)
         {
             if (useDeltaCompression)
@@ -60,6 +61,11 @@ namespace Octopus.Client.Repositories
                 catch(Exception ex) when (!(ex is OctopusValidationException))
                 {
                     Logger.Info("Something went wrong while performing a delta transfer: " + ex.Message);
+
+                    var verificationResult = VerifyTransfer(fileName, contents);
+                    if (verificationResult != null) return verificationResult;
+
+                    Logger.Info("Transfer verification failed");
                 }
                 Logger.Info("Falling back to pushing the complete package to the server");
             }
@@ -67,13 +73,13 @@ namespace Octopus.Client.Repositories
             {
                 Logger.Info("Pushing the complete package to the server, as delta compression was explicitly disabled");
             }
-                
+
             contents.Seek(0, SeekOrigin.Begin);
 
             var link = repository.Link("PackageUpload");
             object pathParameters;
 
-            // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
+            // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter
             if (link.Contains(OverwriteModeLink.Link))
             {
                 pathParameters = new { overwriteMode = overwriteMode };
@@ -82,18 +88,43 @@ namespace Octopus.Client.Repositories
             {
                 pathParameters = new { replace = overwriteMode.ConvertToLegacyReplaceFlag(Logger) };
             }
-            
-            
+
+
             var result = repository.Client.Post<FileUpload, PackageFromBuiltInFeedResource>(
                 link,
                 new FileUpload() { Contents = contents, FileName = fileName },
                 pathParameters);
-            
+
             Logger.Info("Package transfer completed");
 
             return result;
         }
-        
+
+        private PackageFromBuiltInFeedResource VerifyTransfer(string fileName, Stream contents)
+        {
+            if (!PackageIdentityParser.TryParsePackageIdAndVersion(Path.GetFileNameWithoutExtension(fileName),
+                out var packageId, out var version))
+            {
+                Logger.Info("Can't check whether the delta transfer actually worked");
+                return null;
+            }
+
+            var package = repository.BuiltInPackageRepository.ListPackages($"{packageId}.{version}").Items
+                .SingleOrDefault();
+
+            if (package == null)
+            {
+                Logger.Info("Packaged hasn't been uploaded");
+                return null;
+            }
+
+            contents.Seek(0, SeekOrigin.Begin);
+
+            var localFileHash = HashCalculator.Hash(contents);
+
+            return localFileHash == package.Hash ? package : null;
+        }
+
         private PackageFromBuiltInFeedResource AttemptDeltaPush(string fileName, Stream contents, OverwriteMode overwriteMode)
         {
             if (!repository.HasLink("PackageDeltaSignature"))
@@ -107,7 +138,7 @@ namespace Octopus.Client.Repositories
                 Logger.Info("Could not determine the package ID and/or version based on the supplied filename");
                 return null;
             }
-            
+
             PackageSignatureResource signatureResult;
             try
             {
@@ -119,19 +150,19 @@ namespace Octopus.Client.Repositories
                 Logger.Info("No package with the same ID exists on the server");
                 return null;
             }
-                
+
             using(var deltaTempFile = new TemporaryFile())
             {
                 var shouldUpload = DeltaCompression.CreateDelta(contents, signatureResult, deltaTempFile.FileName);
                 if (!shouldUpload)
                     return null;
-                
+
                 using (var delta = File.OpenRead(deltaTempFile.FileName))
                 {
                     var link = repository.Link("PackageDeltaUpload");
                     object pathParameters;
-                    
-                    // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter  
+
+                    // if the link contains overwriteMode then we're connected to a new server, if not use the old `replace` parameter
                     if (link.Contains(OverwriteModeLink.Link))
                     {
                         pathParameters = new { overwriteMode = overwriteMode, packageId, signatureResult.BaseVersion };

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -21,7 +21,7 @@ namespace Octopus.Client.Repositories
         ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(int skip = 0, int take = 30);
         void DeletePackage(PackageResource package);
         void DeletePackages(IReadOnlyList<PackageResource> packages);
-        PackageFromBuiltInFeedResource GetPackage(string packageId);
+        PackageFromBuiltInFeedResource GetPackage(string packageId, string version);
     }
 
     class BuiltInPackageRepositoryRepository : IBuiltInPackageRepositoryRepository
@@ -49,9 +49,9 @@ namespace Octopus.Client.Repositories
             return PushPackage(fileName, contents, replaceExisting ? OverwriteMode.OverwriteExisting : OverwriteMode.FailIfExists, useDeltaCompression);
         }
 
-        public PackageFromBuiltInFeedResource GetPackage(string packageId)
+        public PackageFromBuiltInFeedResource GetPackage(string packageId, string version)
         {
-            return repository.Client.Get<PackageFromBuiltInFeedResource>(repository.Link("Packages"), new { id = packageId });
+            return repository.Client.Get<PackageFromBuiltInFeedResource>(repository.Link("Packages"), new { id = $"{packageId}.{version}" });
         }
 
 
@@ -136,7 +136,7 @@ namespace Octopus.Client.Repositories
         {
             try
             {
-                return repository.BuiltInPackageRepository.GetPackage($"{packageId}.{version}");
+                return repository.BuiltInPackageRepository.GetPackage(packageId, version.ToString());
             }
             catch (OctopusResourceNotFoundException)
             {

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -65,14 +65,16 @@ namespace Octopus.Client.Repositories
                     if (deltaResult != null)
                         return deltaResult;
                 }
+                catch (TimeoutException ex)
+                {
+                    Logger.Info("Delta push timed out: " + ex.Message);
+
+                    var verificationResult = VerifyTransfer(fileName, contents);
+                    if (verificationResult != null) return verificationResult;
+                }
                 catch (Exception ex) when (!(ex is OctopusValidationException))
                 {
                     Logger.Info("Something went wrong while performing a delta transfer: " + ex.Message);
-                }
-                catch (TimeoutException)
-                {
-                    var verificationResult = VerifyTransfer(fileName, contents);
-                    if (verificationResult != null) return verificationResult;
                 }
 
                 Logger.Info("Falling back to pushing the complete package to the server");

--- a/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
+++ b/source/Octopus.Client/Repositories/BuiltInPackageRepositoryRepository.cs
@@ -127,28 +127,9 @@ namespace Octopus.Client.Repositories
                 return null;
             }
 
-            var package = TryFindPackage(packageId, version);
+            var uploadedPackage = TryFindPackage(packageId, version);
 
-            if (package == null)
-            {
-                Logger.Info("Package hasn't been uploaded");
-                return null;
-            }
-
-            contents.Seek(0, SeekOrigin.Begin);
-
-            var localFileHash = HashCalculator.Hash(contents);
-
-            if (localFileHash != package.Hash)
-            {
-                Logger.Info("The hash of the local package and the hash of the uploaded package don't match");
-                return null;
-
-            }
-
-            Logger.Info("Package has been successfully uploaded");
-
-            return package;
+            return PackageContentComparer.AreSame(uploadedPackage, contents, Logger) ? uploadedPackage : null;
         }
 
         private PackageFromBuiltInFeedResource TryFindPackage(string packageId, SemanticVersion version)

--- a/source/Octopus.Client/Util/HashCalculator.cs
+++ b/source/Octopus.Client/Util/HashCalculator.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Octopus.Client.Util
 {
-    public static class HashCalculator
+    static class HashCalculator
     {
         public static string Hash(Stream stream)
         {

--- a/source/Octopus.Client/Util/HashCalculator.cs
+++ b/source/Octopus.Client/Util/HashCalculator.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Octopus.Client.Util
+{
+    public static class HashCalculator
+    {
+        public static string Hash(Stream stream)
+        {
+            using (SHA1CryptoServiceProvider cryptoServiceProvider = new SHA1CryptoServiceProvider())
+                return HashCalculator.Sanitize(cryptoServiceProvider.ComputeHash(stream));
+        }
+
+        public static string Hash(byte[] bytes)
+        {
+            using (SHA1CryptoServiceProvider cryptoServiceProvider = new SHA1CryptoServiceProvider())
+                return HashCalculator.Sanitize(cryptoServiceProvider.ComputeHash(bytes));
+        }
+
+        public static string Hash(string input)
+        {
+            using (SHA1CryptoServiceProvider cryptoServiceProvider = new SHA1CryptoServiceProvider())
+                return HashCalculator.Sanitize(cryptoServiceProvider.ComputeHash(Encoding.UTF8.GetBytes(input)));
+        }
+
+        private static string Sanitize(byte[] hash)
+        {
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
+    }
+}

--- a/source/Octopus.Client/Util/HashCodeCombiner.cs
+++ b/source/Octopus.Client/Util/HashCodeCombiner.cs
@@ -1,8 +1,6 @@
 ﻿// Based on HashCodeCombiner from https://github.com/NuGet/NuGet.Client
 // NuGet is licensed under the Apache license: https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt
 
-using System;
-
 namespace Octopus.Client.Util
 {
 

--- a/source/Octopus.Client/Util/PackageContentComparer.cs
+++ b/source/Octopus.Client/Util/PackageContentComparer.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using Octopus.Client.Logging;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Util
+{
+    static class PackageContentComparer
+    {
+        public static bool AreSame(PackageFromBuiltInFeedResource uploadedPackage, Stream contents, ILog logger)
+        {
+            if (uploadedPackage == null)
+            {
+                logger.Info("Package hasn't been uploaded");
+                return false;
+            }
+
+            var localPackageHash = CalculateLocalPackageHash(contents);
+            if (localPackageHash == null)
+            {
+                logger.Info("Couldn't calculate the hash of the local package");
+                return false;
+            }
+
+            if (localPackageHash != uploadedPackage.Hash)
+            {
+                logger.Info("The hash of the local package and the hash of the uploaded package don't match");
+                return false;
+            }
+
+            logger.Info("Package has been successfully uploaded");
+
+            return true;
+        }
+
+        private static string CalculateLocalPackageHash(Stream contents)
+        {
+            if (contents.CanSeek && contents.CanRead)
+            {
+                contents.Seek(0, SeekOrigin.Begin);
+                return HashCalculator.Hash(contents);
+            }
+
+            if (!(contents is FileStream fileStream)) return null;
+
+            // When a full package upload times out we get a stream here that is already disposed so we need to open a new one
+            using (var newContents = File.OpenRead(fileStream.Name))
+            {
+                return HashCalculator.Hash(newContents);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes OctopusDeploy/Issues#6055

It takes a long time to upload a large (< 2GB) file to Hosted v1 and Hosted v2. The data gets persisted relatively quickly but the client, in this case, otcto.exe,  doesn't get notified about this and waits until the call times out. 

**Before**

Data uploaded successfully but the client throws `TimeoutException`.

**Now**

We still wait until the timeout exception but this time the overall command succeeds.

![image](https://user-images.githubusercontent.com/347637/70323700-3bb44200-1879-11ea-8a96-6ef0320e920e.png)


![image](https://user-images.githubusercontent.com/347637/70324522-70c19400-187b-11ea-989d-ad8d45ccab36.png)


When the client gets `TimeoutException` it checks whether the package has been uploaded successfully.  If it has, it doesn't return an error.

We still don't know what the causes the delay but this change at least helps our Cloud customers to work around the problem.  If you compare the time when the client finished and the time when the package was uploaded you will see a gap of 17 and 27 minutes.

This change also makes sense in isolation because we really don't know whether an operation was successful when it times out.
