### PR TITLE
Make client version checks ignore pre-release tags

### DIFF
--- a/source/Octopus.Client.Tests/ServerVersionCheckFixture.cs
+++ b/source/Octopus.Client.Tests/ServerVersionCheckFixture.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Client.Model;
+using Octopus.Client.Validation;
+
+namespace Octopus.Client.Tests
+{
+    public class ServerVersionCheckFixture
+    {
+        [Test]
+        public void IsOlderThanClient_Development_False()
+        {
+            ServerVersionCheck.IsOlderThanClient("0.0.0-local", SemanticVersion.Parse("2019.11.0"))
+                .Should().BeFalse();
+        }
+
+        [TestCase("2019.11.0")]
+        [TestCase("2019.11.0-prerelease", Reason = "We should be ignoring the prerelease tag")]
+        [TestCase("2019.11.1")]
+        [TestCase("2019.12.0")]
+        [TestCase("2020.0.0")]
+        public void IsOlderThanClient_SameVersionOrAbove_False(string currentVersion)
+        {
+            var minimumVersion = "2019.11.0";
+            ServerVersionCheck.IsOlderThanClient(currentVersion, SemanticVersion.Parse(minimumVersion))
+                .Should().BeFalse();
+        }
+        
+        [TestCase("2019.10.9")]
+        [TestCase("2018.12.0")]
+        public void IsOlderThanClient_LowerVersion_True(string currentVersion)
+        {
+            var minimumVersion = "2019.11.0";
+            ServerVersionCheck.IsOlderThanClient(currentVersion, SemanticVersion.Parse(minimumVersion))
+                .Should().BeTrue();
+        }
+    }
+}

--- a/source/Octopus.Client/Validation/ServerVersionCheck.cs
+++ b/source/Octopus.Client/Validation/ServerVersionCheck.cs
@@ -9,9 +9,16 @@ namespace Octopus.Client.Validation
 
         public static bool IsOlderThanClient(string currentServerVersion, SemanticVersion minimumRequiredVersion)
         {
-            if (WhitelistOfServerVersionsSafeToIgnore.Contains(currentServerVersion)) return false;
-                
-            return SemanticVersion.Parse(currentServerVersion) < minimumRequiredVersion;
+            if (WhitelistOfServerVersionsSafeToIgnore.Contains(currentServerVersion)) 
+                return false;
+
+            var currentVersion = Normalize(SemanticVersion.Parse(currentServerVersion));
+            return currentVersion < Normalize(minimumRequiredVersion);
+        }
+
+        private static SemanticVersion Normalize(SemanticVersion version)
+        {
+            return new SemanticVersion(version.Major, version.Minor, version.Patch);
         }
     }
 }


### PR DESCRIPTION
Our build version usually have a pre-release tag, so the tests fail miserably 😢 