### PR TITLE
Upgrade teamcity libs to work with newer netcore sdk

### DIFF
--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -29,8 +29,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
         <PackageReference Include="NUnit" Version="3.8.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-        <PackageReference Include="TeamCity.ServiceMessages" Version="3.0.9" />
-        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.3" />
+        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.18" />
         <PackageReference Include="FluentAssertions" Version="4.15.0" />
     </ItemGroup>
 

--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -29,7 +29,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
         <PackageReference Include="NUnit" Version="3.8.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.18" />
+        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
         <PackageReference Include="FluentAssertions" Version="4.15.0" />
     </ItemGroup>
 

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -38,8 +38,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="TeamCity.ServiceMessages" Version="3.0.9" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.3" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.18" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Assent" Version="1.3.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.18" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Assent" Version="1.3.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />


### PR DESCRIPTION
We were getting:
```
15:31:34]	Starting: dotnet test source/Octopus.Client.Tests/Octopus.Client.Tests.csproj -c Release -f netcoreapp2.1
[15:31:34]	in directory: /opt/TeamCity/BuildAgent/work/d8818cc5a2905d1
[15:31:34]	Microsoft (R) Build Engine version 16.4.0+e901037fe for .NET Core
[15:31:34]	Copyright (C) Microsoft Corporation. All rights reserved.
[15:31:34]	
[15:31:35]	  Restore completed in 48.19 ms for /opt/TeamCity/BuildAgent/work/d8818cc5a2905d1/source/Octopus.Client/Octopus.Client.csproj.
[15:31:35]	/opt/TeamCity/BuildAgent/work/d8818cc5a2905d1/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj : warning NU1603: Castle.Core 4.0.0 depends on System.ComponentModel.TypeConverter (>= 4.0.1) but System.ComponentModel.TypeConverter 4.0.1 was not found. An approximate best match of System.ComponentModel.TypeConverter 4.1.0 was resolved.
[15:31:35]	  Restore completed in 54.57 ms for /opt/TeamCity/BuildAgent/work/d8818cc5a2905d1/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj.
[15:31:36]	/opt/TeamCity/BuildAgent/work/d8818cc5a2905d1/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj : warning NU1603: Castle.Core 4.0.0 depends on System.ComponentModel.TypeConverter (>= 4.0.1) but System.ComponentModel.TypeConverter 4.0.1 was not found. An approximate best match of System.ComponentModel.TypeConverter 4.1.0 was resolved.
[15:31:42]	Integration/HttpIntegrationTestBase.cs(94,24): warning PC001: X509Certificate2.X509Certificate2(byte[], string) isn't supported on macOS [/opt/TeamCity/BuildAgent/work/d8818cc5a2905d1/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj]
[15:31:42]	Test run for /opt/TeamCity/BuildAgent/work/d8818cc5a2905d1/source/Octopus.Client.Tests/bin/Release/netcoreapp2.1/Octopus.Client.Tests.dll(.NETCoreApp,Version=v2.1)
[15:31:42]	Microsoft (R) Test Execution Command Line Tool Version 16.3.0
[15:31:42]	Copyright (c) Microsoft Corporation.  All rights reserved.
[15:31:42]	
[15:31:42]	Starting test execution, please wait...
[15:31:42]	Could not find a test logger with AssemblyQualifiedName, URI or FriendlyName 'logger://teamcity/'.
[15:31:42]	Process exited with code 1
[15:31:42]	Process exited with code 1 (Step: dotnet test client (Command Line))
[15:31:42]	Step dotnet test client (Command Line) failed
```