### PR TITLE
Bug in OctopusClients prevents it from being used with non-space supported servers

### DIFF
--- a/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
@@ -164,35 +164,15 @@ namespace Octopus.Client.Tests.Repositories.Async
             var resource = CreateSpaceResourceForSpace(null);
             Assert.DoesNotThrow(() => repoForSpaceScopedResource.Create(resource).Wait());
         }
-        
-                
+     
         [Test]
         public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionBeforeSpaces_Ok()
         {
             mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
-            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2018.1.0"});
             var resource = CreateSpaceResourceForSpace(null);
-            Assert.DoesNotThrowAsync(() => repoForSpaceScopedResource.Create(resource));
-        }
-              
-        [Test]
-        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionSpacesIntroduced_Throws()
-        {
-            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
-            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2019.1.0"});
-            var resource = CreateSpaceResourceForSpace(null);
-            Assert.ThrowsAsync<DefaultSpaceNotFoundException>(() => repoForSpaceScopedResource.Create(resource));
+            Assert.DoesNotThrow(() => repoForSpaceScopedResource.Create(resource).Wait());
         }
 
-        [Test]
-        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionIncludesSpaces_Throws()
-        {
-            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
-            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2019.1.6"});
-            var resource = CreateSpaceResourceForSpace(null);
-            Assert.ThrowsAsync<DefaultSpaceNotFoundException>(() => repoForSpaceScopedResource.Create(resource));
-        }
-        
         [Test]
         public void UnspecifiedRepo_MixedResourceWithSpaceId_Ok()
         {

--- a/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
@@ -165,6 +165,34 @@ namespace Octopus.Client.Tests.Repositories.Async
             Assert.DoesNotThrow(() => repoForSpaceScopedResource.Create(resource).Wait());
         }
         
+                
+        [Test]
+        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionBeforeSpaces_Ok()
+        {
+            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
+            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2018.1.0"});
+            var resource = CreateSpaceResourceForSpace(null);
+            Assert.DoesNotThrowAsync(() => repoForSpaceScopedResource.Create(resource));
+        }
+              
+        [Test]
+        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionSpacesIntroduced_Throws()
+        {
+            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
+            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2019.1.0"});
+            var resource = CreateSpaceResourceForSpace(null);
+            Assert.ThrowsAsync<DefaultSpaceNotFoundException>(() => repoForSpaceScopedResource.Create(resource));
+        }
+
+        [Test]
+        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionIncludesSpaces_Throws()
+        {
+            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
+            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2019.1.6"});
+            var resource = CreateSpaceResourceForSpace(null);
+            Assert.ThrowsAsync<DefaultSpaceNotFoundException>(() => repoForSpaceScopedResource.Create(resource));
+        }
+        
         [Test]
         public void UnspecifiedRepo_MixedResourceWithSpaceId_Ok()
         {

--- a/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
@@ -164,7 +164,7 @@ namespace Octopus.Client.Tests.Repositories.Async
             var resource = CreateSpaceResourceForSpace(null);
             Assert.DoesNotThrow(() => repoForSpaceScopedResource.Create(resource).Wait());
         }
-     
+        
         [Test]
         public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionBeforeSpaces_Ok()
         {

--- a/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
@@ -256,7 +256,7 @@ namespace Octopus.Client.Tests.Repositories
         {
             repo.Scope.Returns(RepositoryScope.Unspecified());
             repo.LoadSpaceRootDocument().Returns((SpaceRootResource)null);
-            repo.LoadRootDocument().Returns(new RootResource() {Version = "2019.1.0"});
+            repo.LoadRootDocument().Returns(new RootResource());
         }
     }
 }

--- a/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
@@ -148,6 +148,37 @@ namespace Octopus.Client.Tests.Repositories
             actionUnderTest.ShouldThrow<DefaultSpaceNotFoundException>();
         }
         
+        
+        [Test]
+        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionSpacesIntroduced_Throws()
+        {
+            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
+            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2019.1.0"});
+            var resource = CreateSpaceResourceForSpace(null);
+            Action actionUnderTest = () => repoForSpaceScopedResource.Create(resource);
+            actionUnderTest.ShouldThrow<DefaultSpaceNotFoundException>();
+        }
+        
+        [Test]
+        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionWithSpaces_Throws()
+        {
+            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
+            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2020.1.0"});
+            var resource = CreateSpaceResourceForSpace(null);
+            Action actionUnderTest = () => repoForSpaceScopedResource.Create(resource);
+            actionUnderTest.ShouldThrow<DefaultSpaceNotFoundException>();
+        }
+
+        [Test]
+        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionBeforeSpaces_Ok()
+        {
+            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
+            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2018.12.5"});
+            var resource = CreateSpaceResourceForSpace(null);
+            Assert.DoesNotThrow(() => repoForSpaceScopedResource.Create(resource));
+        }
+        
+        
         [Test]
         public void UnspecifiedRepo_MixedResourceWithSpaceId_Ok()
         {
@@ -245,6 +276,7 @@ namespace Octopus.Client.Tests.Repositories
         {
             repo.Scope.Returns(RepositoryScope.Unspecified());
             repo.LoadSpaceRootDocument().Returns((SpaceRootResource)null);
+            repo.LoadRootDocument().Returns(new RootResource() {Version = "2019.1.0"});
         }
     }
 }

--- a/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
@@ -143,27 +143,8 @@ namespace Octopus.Client.Tests.Repositories
         public void UnspecifiedRepo_SpaceResourceNoSpaceIdDefaultSpaceMissing_Throws()
         {
             mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
-            var resource = CreateSpaceResourceForSpace(null);
-            Action actionUnderTest = () => repoForSpaceScopedResource.Create(resource);
-            actionUnderTest.ShouldThrow<DefaultSpaceNotFoundException>();
-        }
-        
-        
-        [Test]
-        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionSpacesIntroduced_Throws()
-        {
-            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
-            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2019.1.0"});
-            var resource = CreateSpaceResourceForSpace(null);
-            Action actionUnderTest = () => repoForSpaceScopedResource.Create(resource);
-            actionUnderTest.ShouldThrow<DefaultSpaceNotFoundException>();
-        }
-        
-        [Test]
-        public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionWithSpaces_Throws()
-        {
-            mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
-            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2020.1.0"});
+            mockRepo.LoadRootDocument().Returns(new RootResource()
+                {Links = new LinkCollection() {{"Spaces", "api/spaces"}}});
             var resource = CreateSpaceResourceForSpace(null);
             Action actionUnderTest = () => repoForSpaceScopedResource.Create(resource);
             actionUnderTest.ShouldThrow<DefaultSpaceNotFoundException>();
@@ -173,7 +154,6 @@ namespace Octopus.Client.Tests.Repositories
         public void UnspecifiedRepo_SpaceResourceNoSpaceIdServerVersionBeforeSpaces_Ok()
         {
             mockRepo.SetupScopeAsUnspecifiedWithDefaultSpaceDisabled();
-            mockRepo.LoadRootDocument().Returns(new RootResource() {Version = "2018.12.5"});
             var resource = CreateSpaceResourceForSpace(null);
             Assert.DoesNotThrow(() => repoForSpaceScopedResource.Create(resource));
         }

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -51,7 +51,7 @@ namespace Octopus.Client.Repositories.Async
                     var spaceRoot = await Repository.LoadSpaceRootDocument().ConfigureAwait((false));
                     var isDefaultSpaceFound = spaceRoot != null;
 
-                    if (!isDefaultSpaceFound && await ServerSupportsSpaces())
+                    if (!isDefaultSpaceFound && await ServerSupportsSpaces().ConfigureAwait(false))
                     {
                         throw new DefaultSpaceNotFoundException(spaceResource);
                     }

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -50,17 +50,21 @@ namespace Octopus.Client.Repositories.Async
                 {
                     var spaceRoot = Repository.LoadSpaceRootDocument().Result;
                     var isDefaultSpaceFound = spaceRoot != null;
-
                     
-                    var versionOfServer = SemanticVersion.Parse(Repository.LoadRootDocument().Result.Version);
-                    var versionSpacesIntroduced = SemanticVersion.Parse("2018.12.2");
-                    var versionIncludesSpaces = versionOfServer >= versionSpacesIntroduced;
-                    
-                    if (!isDefaultSpaceFound && versionIncludesSpaces)
+                    if (!isDefaultSpaceFound && CheckVersionIncludesSpaces(Repository.LoadRootDocument().Result.Version))
                     {
-                        throw new DefaultSpaceNotFoundException(spaceResource);
+                            throw new DefaultSpaceNotFoundException(spaceResource);
                     }
                 });
+        }
+        
+        private bool CheckVersionIncludesSpaces(string version)
+        {
+            var versionOfServer = SemanticVersion.Parse(version);
+            var versionSpacesIntroduced = SemanticVersion.Parse("2019.1.0");
+            var versionIncludesSpaces = versionOfServer >= versionSpacesIntroduced;
+
+            return versionIncludesSpaces;
         }
 
         protected void MinimumCompatibleVersion(string version)

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -37,16 +37,16 @@ namespace Octopus.Client.Repositories.Async
         public IOctopusAsyncClient Client { get; }
         public IOctopusAsyncRepository Repository { get; }
 
-        protected virtual async Task CheckSpaceResource(IHaveSpaceResource spaceResource)
+        protected virtual Task CheckSpaceResource(IHaveSpaceResource spaceResource)
         {
-            await Repository.Scope.Apply(
+            return Repository.Scope.Apply(
                 whenSpaceScoped: space =>
                 {
                     if (spaceResource.SpaceId != null && spaceResource.SpaceId != space.Id)
                         throw new ResourceSpaceDoesNotMatchRepositorySpaceException(spaceResource, space);
-                    return Task.FromResult("");
+                    return Task.FromResult(0);
                 },
-                whenSystemScoped: () => Task.FromResult(""),
+                whenSystemScoped: () => Task.FromResult(0),
                 whenUnspecifiedScope: async () =>
                 {
                     var spaceRoot = await Repository.LoadSpaceRootDocument().ConfigureAwait((false));
@@ -56,7 +56,7 @@ namespace Octopus.Client.Repositories.Async
                     {
                         throw new DefaultSpaceNotFoundException(spaceResource);
                     }
-                }).ConfigureAwait(false);
+                });
         }
 
         private async Task<bool> ServerSupportsSpaces()

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -149,10 +149,10 @@ namespace Octopus.Client.Repositories.Async
 
             var resources = new List<TResource>();
             await Paginate(page =>
-                {
-                    resources.AddRange(page.Items.Where(search));
-                    return true;
-                }, path, pathParameters)
+            {
+                resources.AddRange(page.Items.Where(search));
+                return true; 
+            }, path, pathParameters)
                 .ConfigureAwait(false);
             return resources;
         }
@@ -169,7 +169,7 @@ namespace Octopus.Client.Repositories.Async
             await ThrowIfServerVersionIsNotCompatible();
 
             var link = await ResolveLink().ConfigureAwait(false);
-            var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new {id = IdValueConstant.IdAll});
+            var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new { id = IdValueConstant.IdAll });
             return await Client.Get<List<TResource>>(link, parameters).ConfigureAwait(false);
         }
 
@@ -214,7 +214,7 @@ namespace Octopus.Client.Repositories.Async
             var link = await ResolveLink().ConfigureAwait(false);
             var additionalQueryParameters = GetAdditionalQueryParameters();
             var parameters = ParameterHelper.CombineParameters(additionalQueryParameters, new { id = idOrHref });
-            var getTask = idOrHref.StartsWith("/", StringComparison.OrdinalIgnoreCase)
+            var  getTask = idOrHref.StartsWith("/", StringComparison.OrdinalIgnoreCase)
                 ? Client.Get<TResource>(idOrHref, additionalQueryParameters).ConfigureAwait(false)
                 : Client.Get<TResource>(link, parameters).ConfigureAwait(false);
             return await getTask;
@@ -242,7 +242,6 @@ namespace Octopus.Client.Repositories.Async
                 {
                     resources.AddRange(page.Items);
                     return true;
-                    
                 })
                 .ConfigureAwait(false);
 

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -21,8 +21,7 @@ namespace Octopus.Client.Repositories.Async
         private SemanticVersion minimumRequiredVersion;
         private bool hasMinimumRequiredVersion;
 
-        protected BasicRepository(IOctopusAsyncRepository repository, string collectionLinkName,
-            Func<IOctopusAsyncRepository, Task<string>> getCollectionLinkName = null)
+        protected BasicRepository(IOctopusAsyncRepository repository, string collectionLinkName, Func<IOctopusAsyncRepository, Task<string>> getCollectionLinkName = null)
         {
             Client = repository.Client;
             Repository = repository;
@@ -121,8 +120,7 @@ namespace Octopus.Client.Repositories.Async
             return Client.Delete(resource.Links["Self"]);
         }
 
-        public async Task Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path = null,
-            object pathParameters = null)
+        public async Task Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path = null, object pathParameters = null)
         {
             await ThrowIfServerVersionIsNotCompatible();
 
@@ -131,23 +129,21 @@ namespace Octopus.Client.Repositories.Async
             await Client.Paginate(path ?? link, parameters, getNextPage).ConfigureAwait(false);
         }
 
-        public async Task<TResource> FindOne(Func<TResource, bool> search, string path = null,
-            object pathParameters = null)
+        public async Task<TResource> FindOne(Func<TResource, bool> search, string path = null, object pathParameters = null)
         {
             await ThrowIfServerVersionIsNotCompatible();
 
             TResource resource = null;
-            await Paginate(page =>
-                {
-                    resource = page.Items.FirstOrDefault(search);
-                    return resource == null;
-                }, path, pathParameters)
+            await Paginate(page => 
+            {
+                resource = page.Items.FirstOrDefault(search);
+                return resource == null;
+            }, path, pathParameters)
                 .ConfigureAwait(false);
             return resource;
         }
 
-        public async Task<List<TResource>> FindMany(Func<TResource, bool> search, string path = null,
-            object pathParameters = null)
+        public async Task<List<TResource>> FindMany(Func<TResource, bool> search, string path = null, object pathParameters = null)
         {
             await ThrowIfServerVersionIsNotCompatible();
 
@@ -173,8 +169,7 @@ namespace Octopus.Client.Repositories.Async
             await ThrowIfServerVersionIsNotCompatible();
 
             var link = await ResolveLink().ConfigureAwait(false);
-            var parameters =
-                ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new {id = IdValueConstant.IdAll});
+            var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new {id = IdValueConstant.IdAll});
             return await Client.Get<List<TResource>>(link, parameters).ConfigureAwait(false);
         }
 
@@ -186,24 +181,21 @@ namespace Octopus.Client.Repositories.Async
 
             // Some endpoints allow a Name query param which greatly increases efficiency
             if (pathParameters == null)
-                pathParameters = new {name = name};
+                pathParameters = new { name = name };
 
             return FindOne(r =>
             {
                 var named = r as INamedResource;
-                if (named != null)
-                    return string.Equals((named.Name ?? string.Empty).Trim(), name, StringComparison.OrdinalIgnoreCase);
+                if (named != null) return string.Equals((named.Name ?? string.Empty).Trim(), name, StringComparison.OrdinalIgnoreCase);
                 return false;
             }, path, pathParameters);
         }
 
-        public Task<List<TResource>> FindByNames(IEnumerable<string> names, string path = null,
-            object pathParameters = null)
+        public Task<List<TResource>> FindByNames(IEnumerable<string> names, string path = null, object pathParameters = null)
         {
             ThrowIfServerVersionIsNotCompatible().ConfigureAwait(false);
 
-            var nameSet = new HashSet<string>((names ?? new string[0]).Select(n => (n ?? string.Empty).Trim()),
-                StringComparer.OrdinalIgnoreCase);
+            var nameSet = new HashSet<string>((names ?? new string[0]).Select(n => (n ?? string.Empty).Trim()), StringComparer.OrdinalIgnoreCase);
             return FindMany(r =>
             {
                 var named = r as INamedResource;
@@ -221,7 +213,7 @@ namespace Octopus.Client.Repositories.Async
 
             var link = await ResolveLink().ConfigureAwait(false);
             var additionalQueryParameters = GetAdditionalQueryParameters();
-            var parameters = ParameterHelper.CombineParameters(additionalQueryParameters, new {id = idOrHref});
+            var parameters = ParameterHelper.CombineParameters(additionalQueryParameters, new { id = idOrHref });
             var getTask = idOrHref.StartsWith("/", StringComparison.OrdinalIgnoreCase)
                 ? Client.Get<TResource>(idOrHref, additionalQueryParameters).ConfigureAwait(false)
                 : Client.Get<TResource>(link, parameters).ConfigureAwait(false);
@@ -242,15 +234,16 @@ namespace Octopus.Client.Repositories.Async
             if (!Regex.IsMatch(link, @"\{\?.*\Wids\W"))
                 link += "{?ids}";
 
-            var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new {ids = actualIds});
+            var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new { ids = actualIds });
             await Client.Paginate<TResource>(
-                    link,
-                    parameters,
-                    page =>
-                    {
-                        resources.AddRange(page.Items);
-                        return true;
-                    })
+                link,
+                parameters,
+                page =>
+                {
+                    resources.AddRange(page.Items);
+                    return true;
+                    
+                })
                 .ConfigureAwait(false);
 
             return resources;

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -51,14 +51,14 @@ namespace Octopus.Client.Repositories.Async
                     var spaceRoot = Repository.LoadSpaceRootDocument().Result;
                     var isDefaultSpaceFound = spaceRoot != null;
                     
-                    if (!isDefaultSpaceFound && CheckVersionIncludesSpaces(Repository.LoadRootDocument().Result.Version))
+                    if (!isDefaultSpaceFound && CheckServerVersionIncludesSpaces(Repository.LoadRootDocument().Result.Version))
                     {
                             throw new DefaultSpaceNotFoundException(spaceResource);
                     }
                 });
         }
         
-        private bool CheckVersionIncludesSpaces(string version)
+        private bool CheckServerVersionIncludesSpaces(string version)
         {
             var versionOfServer = SemanticVersion.Parse(version);
             var versionSpacesIntroduced = SemanticVersion.Parse("2019.1.0");

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -48,10 +48,15 @@ namespace Octopus.Client.Repositories.Async
                 whenSystemScoped: () => { },
                 whenUnspecifiedScope: () =>
                 {
-                    var spaceRoot = Repository.LoadSpaceRootDocument();
+                    var spaceRoot = Repository.LoadSpaceRootDocument().Result;
                     var isDefaultSpaceFound = spaceRoot != null;
 
-                    if (!isDefaultSpaceFound)
+                    
+                    var versionOfServer = SemanticVersion.Parse(Repository.LoadRootDocument().Result.Version);
+                    var versionSpacesIntroduced = SemanticVersion.Parse("2018.12.2");
+                    var versionIncludesSpaces = versionOfServer >= versionSpacesIntroduced;
+                    
+                    if (!isDefaultSpaceFound && versionIncludesSpaces)
                     {
                         throw new DefaultSpaceNotFoundException(spaceResource);
                     }

--- a/source/Octopus.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BasicRepository.cs
@@ -134,7 +134,7 @@ namespace Octopus.Client.Repositories.Async
             await ThrowIfServerVersionIsNotCompatible();
 
             TResource resource = null;
-            await Paginate(page => 
+            await Paginate(page =>
             {
                 resource = page.Items.FirstOrDefault(search);
                 return resource == null;
@@ -151,7 +151,7 @@ namespace Octopus.Client.Repositories.Async
             await Paginate(page =>
             {
                 resources.AddRange(page.Items.Where(search));
-                return true; 
+                return true;
             }, path, pathParameters)
                 .ConfigureAwait(false);
             return resources;

--- a/source/Octopus.Client/Repositories/Async/MixedScopeBaseRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MixedScopeBaseRepository.cs
@@ -42,18 +42,18 @@ namespace Octopus.Client.Repositories.Async
             }
         }
 
-        protected override async Task CheckSpaceResource(IHaveSpaceResource spaceResource)
+        protected override Task CheckSpaceResource(IHaveSpaceResource spaceResource)
         {
-            await Repository.Scope.Apply(
+            return Repository.Scope.Apply(
                 whenSpaceScoped: space =>
                 {
                     if (spaceResource.SpaceId != null && spaceResource.SpaceId != space.Id)
                         throw new ResourceSpaceDoesNotMatchRepositorySpaceException(spaceResource, space);
 
-                    return Task.FromResult("");
+                    return Task.FromResult(0);
                 },
-                whenSystemScoped: () => Task.FromResult(""),
-                whenUnspecifiedScope: () => Task.FromResult("")).ConfigureAwait(false);
+                whenSystemScoped: () => Task.FromResult(0),
+                whenUnspecifiedScope: () => Task.FromResult(0));
         }
 
         

--- a/source/Octopus.Client/Repositories/Async/MixedScopeBaseRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MixedScopeBaseRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Extensibility;
 
@@ -41,16 +42,18 @@ namespace Octopus.Client.Repositories.Async
             }
         }
 
-        protected override void CheckSpaceResource(IHaveSpaceResource spaceResource)
+        protected override async Task CheckSpaceResource(IHaveSpaceResource spaceResource)
         {
-            Repository.Scope.Apply(
+            await Repository.Scope.Apply(
                 whenSpaceScoped: space =>
                 {
                     if (spaceResource.SpaceId != null && spaceResource.SpaceId != space.Id)
                         throw new ResourceSpaceDoesNotMatchRepositorySpaceException(spaceResource, space);
+
+                    return Task.FromResult("");
                 },
-                whenSystemScoped: () => { },
-                whenUnspecifiedScope: () => { });
+                whenSystemScoped: () => Task.FromResult(""),
+                whenUnspecifiedScope: () => Task.FromResult("")).ConfigureAwait(false);
         }
 
         

--- a/source/Octopus.Client/Repositories/Async/MixedScopeBaseRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MixedScopeBaseRepository.cs
@@ -41,21 +41,19 @@ namespace Octopus.Client.Repositories.Async
                 throw new SpaceContextSwitchException();
             }
         }
-
         protected override Task CheckSpaceResource(IHaveSpaceResource spaceResource)
         {
-            return Repository.Scope.Apply(
+            Repository.Scope.Apply(
                 whenSpaceScoped: space =>
                 {
                     if (spaceResource.SpaceId != null && spaceResource.SpaceId != space.Id)
                         throw new ResourceSpaceDoesNotMatchRepositorySpaceException(spaceResource, space);
-
-                    return Task.FromResult(0);
                 },
-                whenSystemScoped: () => Task.FromResult(0),
-                whenUnspecifiedScope: () => Task.FromResult(0));
-        }
+                whenSystemScoped: () => { },
+                whenUnspecifiedScope: () => { });
 
+            return Task.FromResult(0);
+        }
         
         protected SpaceContext GetCurrentSpaceContext()
         {

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -47,17 +47,21 @@ namespace Octopus.Client.Repositories
                 {
                     var spaceRoot = Repository.LoadSpaceRootDocument();
                     var isDefaultSpaceFound = spaceRoot != null;
-
-                    
-                    var versionOfServer = SemanticVersion.Parse(Repository.LoadRootDocument().Version);
-                    var versionSpacesIntroduced = SemanticVersion.Parse("2018.12.2");
-                    var versionIncludesSpaces = versionOfServer.CompareTo(versionSpacesIntroduced) >= 0;
-
-                    if (!isDefaultSpaceFound && versionIncludesSpaces)
+                  
+                    if (!isDefaultSpaceFound && CheckVersionIncludesSpaces(Repository.LoadRootDocument().Version))
                     {
                         throw new DefaultSpaceNotFoundException(spaceResource);
                     }
                 });
+        }
+        
+        private bool CheckVersionIncludesSpaces(string version)
+        {
+            var versionOfServer = SemanticVersion.Parse(version);
+            var versionSpacesIntroduced = SemanticVersion.Parse("2019.1.0");
+            var versionIncludesSpaces = versionOfServer >= versionSpacesIntroduced;
+
+            return versionIncludesSpaces;
         }
 
         protected void MinimumCompatibleVersion(string version)

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -47,21 +47,21 @@ namespace Octopus.Client.Repositories
                 {
                     var spaceRoot = Repository.LoadSpaceRootDocument();
                     var isDefaultSpaceFound = spaceRoot != null;
-                  
-                    if (!isDefaultSpaceFound && CheckServerVersionIncludesSpaces(Repository.LoadRootDocument().Version))
+
+                    if (!isDefaultSpaceFound && ServerSupportsSpaces())
                     {
                         throw new DefaultSpaceNotFoundException(spaceResource);
                     }
                 });
         }
-        
-        private bool CheckServerVersionIncludesSpaces(string version)
-        {
-            var versionOfServer = SemanticVersion.Parse(version);
-            var versionSpacesIntroduced = SemanticVersion.Parse("2019.1.0");
-            var versionIncludesSpaces = versionOfServer >= versionSpacesIntroduced;
 
-            return versionIncludesSpaces;
+        private bool ServerSupportsSpaces()
+        {
+            var rootDocument = Repository.LoadRootDocument();
+
+            var spacesIsSupported = rootDocument.HasLink("Spaces");
+
+            return spacesIsSupported;
         }
 
         protected void MinimumCompatibleVersion(string version)

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -23,8 +23,7 @@ namespace Octopus.Client.Repositories
         private bool hasMinimumRequiredVersion;
         protected virtual Dictionary<string, object> AdditionalQueryParameters { get; }
 
-        protected BasicRepository(IOctopusRepository repository, string collectionLinkName,
-            Func<IOctopusRepository, string> getCollectionLinkName = null)
+        protected BasicRepository(IOctopusRepository repository, string collectionLinkName, Func<IOctopusRepository, string> getCollectionLinkName = null)
         {
             Repository = repository;
             client = repository.Client;
@@ -49,7 +48,7 @@ namespace Octopus.Client.Repositories
                     var spaceRoot = Repository.LoadSpaceRootDocument();
                     var isDefaultSpaceFound = spaceRoot != null;
 
-
+                    
                     var versionOfServer = SemanticVersion.Parse(Repository.LoadRootDocument().Version);
                     var versionSpacesIntroduced = SemanticVersion.Parse("2018.12.2");
                     var versionIncludesSpaces = versionOfServer.CompareTo(versionSpacesIntroduced) >= 0;
@@ -117,8 +116,7 @@ namespace Octopus.Client.Repositories
             client.Delete(resource.Links["Self"]);
         }
 
-        public void Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path = null,
-            object pathParameters = null)
+        public void Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path = null, object pathParameters = null)
         {
             ThrowIfServerVersionIsNotCompatible();
 
@@ -165,8 +163,7 @@ namespace Octopus.Client.Repositories
             ThrowIfServerVersionIsNotCompatible();
 
             var link = ResolveLink();
-            var parameters =
-                ParameterHelper.CombineParameters(AdditionalQueryParameters, new {id = IdValueConstant.IdAll});
+            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new { id = IdValueConstant.IdAll });
             return client.Get<List<TResource>>(link, parameters);
         }
 
@@ -182,8 +179,7 @@ namespace Octopus.Client.Repositories
             return FindOne(r =>
             {
                 var named = r as INamedResource;
-                if (named != null)
-                    return string.Equals((named.Name ?? string.Empty).Trim(), name, StringComparison.OrdinalIgnoreCase);
+                if (named != null) return string.Equals((named.Name ?? string.Empty).Trim(), name, StringComparison.OrdinalIgnoreCase);
                 return false;
             }, path, pathParameters);
         }
@@ -192,8 +188,7 @@ namespace Octopus.Client.Repositories
         {
             ThrowIfServerVersionIsNotCompatible();
 
-            var nameSet = new HashSet<string>((names ?? new string[0]).Select(n => (n ?? string.Empty).Trim()),
-                StringComparer.OrdinalIgnoreCase);
+            var nameSet = new HashSet<string>((names ?? new string[0]).Select(n => (n ?? string.Empty).Trim()), StringComparer.OrdinalIgnoreCase);
             return FindMany(r =>
             {
                 var named = r as INamedResource;
@@ -213,8 +208,7 @@ namespace Octopus.Client.Repositories
             {
                 return client.Get<TResource>(idOrHref, AdditionalQueryParameters);
             }
-
-            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new {id = idOrHref});
+            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new { id = idOrHref });
             return client.Get<TResource>(link, parameters);
         }
 
@@ -230,7 +224,7 @@ namespace Octopus.Client.Repositories
             var link = ResolveLink();
             if (!Regex.IsMatch(link, @"\{\?.*\Wids\W"))
                 link += "{?ids}";
-            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new {ids = actualIds});
+            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new { ids = actualIds });
             client.Paginate<TResource>(
                 link,
                 parameters,

--- a/source/Octopus.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Client/Repositories/BasicRepository.cs
@@ -48,14 +48,14 @@ namespace Octopus.Client.Repositories
                     var spaceRoot = Repository.LoadSpaceRootDocument();
                     var isDefaultSpaceFound = spaceRoot != null;
                   
-                    if (!isDefaultSpaceFound && CheckVersionIncludesSpaces(Repository.LoadRootDocument().Version))
+                    if (!isDefaultSpaceFound && CheckServerVersionIncludesSpaces(Repository.LoadRootDocument().Version))
                     {
                         throw new DefaultSpaceNotFoundException(spaceResource);
                     }
                 });
         }
         
-        private bool CheckVersionIncludesSpaces(string version)
+        private bool CheckServerVersionIncludesSpaces(string version)
         {
             var versionOfServer = SemanticVersion.Parse(version);
             var versionSpacesIntroduced = SemanticVersion.Parse("2019.1.0");


### PR DESCRIPTION
OctopusClient needs to be updated to handle connecting to a server that does not know about spaces

Internal links:
https://trello.com/c/W7Tj8qJI/2675-bug-in-octopusclients-prevents-it-from-being-used-with-non-space-supported-servers
