### PR TITLE
Adding missing endpoints to variables repositories

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7003,8 +7003,10 @@ Octopus.Client.Repositories
   interface IVariableSetRepository
     Octopus.Client.Repositories.IGet<VariableSetResource>
     Octopus.Client.Repositories.IModify<VariableSetResource>
+    Octopus.Client.Repositories.IGetAll<VariableSetResource>
   {
     String[] GetVariableNames(String, String[])
+    Octopus.Client.Model.VariableSetResource GetVariablePreview(String, String, String, String, String, String, String, String)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
@@ -7687,8 +7689,10 @@ Octopus.Client.Repositories.Async
   interface IVariableSetRepository
     Octopus.Client.Repositories.Async.IGet<VariableSetResource>
     Octopus.Client.Repositories.Async.IModify<VariableSetResource>
+    Octopus.Client.Repositories.Async.IGetAll<VariableSetResource>
   {
     Task<String[]> GetVariableNames(String, String[])
+    Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerPoolResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7028,8 +7028,10 @@ Octopus.Client.Repositories
   interface IVariableSetRepository
     Octopus.Client.Repositories.IGet<VariableSetResource>
     Octopus.Client.Repositories.IModify<VariableSetResource>
+    Octopus.Client.Repositories.IGetAll<VariableSetResource>
   {
     String[] GetVariableNames(String, String[])
+    Octopus.Client.Model.VariableSetResource GetVariablePreview(String, String, String, String, String, String, String, String)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
@@ -7712,8 +7714,10 @@ Octopus.Client.Repositories.Async
   interface IVariableSetRepository
     Octopus.Client.Repositories.Async.IGet<VariableSetResource>
     Octopus.Client.Repositories.Async.IModify<VariableSetResource>
+    Octopus.Client.Repositories.Async.IGetAll<VariableSetResource>
   {
     Task<String[]> GetVariableNames(String, String[])
+    Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerPoolResource>

--- a/source/Octopus.Client/Repositories/Async/VariableSetRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/VariableSetRepository.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
-    public interface IVariableSetRepository : IGet<VariableSetResource>, IModify<VariableSetResource>
+    public interface IVariableSetRepository : IGet<VariableSetResource>, IModify<VariableSetResource>, IGetAll<VariableSetResource>
     {
         Task<string[]> GetVariableNames(string projects, string[] environments);
+        Task<VariableSetResource> GetVariablePreview(string project, string channel, string tenant, string runbook, string action, string environment, string machine, string role);
     }
 
     class VariableSetRepository : BasicRepository<VariableSetResource>, IVariableSetRepository
@@ -21,6 +21,11 @@ namespace Octopus.Client.Repositories.Async
         public async Task<string[]> GetVariableNames(string project, string[] environments)
         {
             return await Client.Get<string[]>(await Repository.Link("VariableNames").ConfigureAwait(false), new { project, projectEnvironmentsFilter = environments ?? new string[0] }).ConfigureAwait(false);
+        }
+
+        public async Task<VariableSetResource> GetVariablePreview(string project, string channel, string tenant, string runbook, string action, string environment, string machine, string role)
+        {
+            return await Client.Get<VariableSetResource>(await Repository.Link("VariablePreview").ConfigureAwait(false), new { project, channel, tenant, runbook, action, environment, machine, role }).ConfigureAwait(false);
         }
 
         public override Task<List<VariableSetResource>> Get(params string[] ids)

--- a/source/Octopus.Client/Repositories/VariableSetRepository.cs
+++ b/source/Octopus.Client/Repositories/VariableSetRepository.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
 {
-    public interface IVariableSetRepository : IGet<VariableSetResource>, IModify<VariableSetResource>
+    public interface IVariableSetRepository : IGet<VariableSetResource>, IModify<VariableSetResource>, IGetAll<VariableSetResource>
     {
         string[] GetVariableNames(string projects, string[] environments);
+        VariableSetResource GetVariablePreview(string project, string channel, string tenant, string runbook, string action, string environment, string machine, string role);
     }
     
     class VariableSetRepository : BasicRepository<VariableSetResource>, IVariableSetRepository
@@ -21,6 +20,11 @@ namespace Octopus.Client.Repositories
         public string[] GetVariableNames(string project, string[] environments)
         {
             return Client.Get<string[]>(Repository.Link("VariableNames"), new { project, projectEnvironmentsFilter = environments ?? new string[0] });
+        }
+
+        public VariableSetResource GetVariablePreview(string project, string channel, string tenant, string runbook, string action, string environment, string machine, string role)
+        {
+            return Client.Get<VariableSetResource>(Repository.Link("VariablePreview"), new { project, channel, tenant, runbook, action, environment, machine, role });
         }
 
         public override List<VariableSetResource> Get(params string[] ids)


### PR DESCRIPTION
We had the `/api/variables/all` endpoint exploding when we introduced runbooks, and nobody noticed because we don't have any tests around this endpoint 😢 and clients wasn't even exposing this particular endpoint. If our API supports it, we should be including it in clients, even if customers _should_ be using the other variable endpoints available in other repositories.

Also noticed the variables/preview endpoint was not included in clients too.