### PR TITLE
Add xFrameOptions configure option and deprecate xFrameOptionAllowFrom

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5222,8 +5222,10 @@ Octopus.Client.Model
   class XOptionsResource
   {
     static System.String XFrameAllowFromDescription
+    static System.String XFrameOptionsDescription
     .ctor()
     String XFrameOptionAllowFrom { get; set; }
+    String XFrameOptions { get; set; }
   }
 }
 Octopus.Client.Model.Accounts

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5246,8 +5246,10 @@ Octopus.Client.Model
   class XOptionsResource
   {
     static System.String XFrameAllowFromDescription
+    static System.String XFrameOptionsDescription
     .ctor()
     String XFrameOptionAllowFrom { get; set; }
+    String XFrameOptions { get; set; }
   }
 }
 Octopus.Client.Model.Accounts

--- a/source/Octopus.Client/Model/WebPortalConfigurationResource.cs
+++ b/source/Octopus.Client/Model/WebPortalConfigurationResource.cs
@@ -45,9 +45,14 @@ namespace Octopus.Client.Model
 
     public class XOptionsResource
     {
-        public const string XFrameAllowFromDescription = "A uri to provide in the X-Frame-Option http header in conjunction with the ALLOW-FROM value.";
+        public const string XFrameAllowFromDescription = "(Deprecated) A uri to provide in the X-Frame-Option http header in conjunction with the ALLOW-FROM value.";
+        public const string XFrameOptionsDescription = "Provide in the X-Frame-Option http header a directive such as sameorigin or deny.";
+
 
         [Writeable]
         public string XFrameOptionAllowFrom { get; set; }
+        
+        [Writeable]
+        public string XFrameOptions { get; set; }
     }
 }


### PR DESCRIPTION
# Background
xFrameOptionAllowFrom has been marked as deprecated as allow-from has been deprecated: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

new option XFrameOptions added which allows customers to set x-frame-options header to sameorigin, deny etc.

https://trello.com/c/qMkihfxa/2944-x-frame-options
Fixes https://github.com/OctopusDeploy/Issues/issues/6196
