### PR TITLE
Added `ParentDeployment` to ScopeField enum

### DIFF
--- a/source/Octopus.Client/Model/ScopeField.cs
+++ b/source/Octopus.Client/Model/ScopeField.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+using Octopus.Client.Serialization;
 using System;
 
 namespace Octopus.Client.Model
@@ -16,5 +18,6 @@ namespace Octopus.Client.Model
         TenantTag,
         Tenant, 
         ProcessOwner,
+        ParentDeployment,
     }
 }


### PR DESCRIPTION
This PR resolves an exception when loading `VariableSets`