### PR TITLE
Add a deprecation notice when client is being used from server's folder

### DIFF
--- a/source/Octopus.Client/LocationChecker.cs
+++ b/source/Octopus.Client/LocationChecker.cs
@@ -24,10 +24,10 @@ namespace Octopus.Client
             var applicationRegNode = octopusRegNode.OpenSubKey(application);
             if (applicationRegNode != null)
             {
-                var serverInstallationFolder = (string) applicationRegNode.GetValue("InstallLocation");
+                var installationFolder = (string) applicationRegNode.GetValue("InstallLocation");
                 var currentAssemblyLocation = typeof(LocationChecker).Assembly.Location;
 
-                if (currentAssemblyLocation.Contains(serverInstallationFolder))
+                if (currentAssemblyLocation.Contains(installationFolder))
                 {
                     var warningMessage = $"Using Octopus.Client from the {application}'s installation folder has been deprecated. In future versions it may not be shipped with {application}.";
                     

--- a/source/Octopus.Client/LocationChecker.cs
+++ b/source/Octopus.Client/LocationChecker.cs
@@ -14,26 +14,31 @@ namespace Octopus.Client
 
         public static void CheckAssemblyLocation()
         {
-            var octopusRegNode = Registry.LocalMachine.OpenSubKey(@"Software\Octopus");
-            CheckBasedOnApplication(octopusRegNode, "Server");
-            CheckBasedOnApplication(octopusRegNode, "Tentacle");
+            using (var octopusRegNode = Registry.LocalMachine.OpenSubKey(@"Software\Octopus"))
+            {
+                CheckBasedOnApplication(octopusRegNode, "Server");
+                CheckBasedOnApplication(octopusRegNode, "Tentacle");
+            }
         }
 
         private static void CheckBasedOnApplication(RegistryKey octopusRegNode, string application)
         {
-            var applicationRegNode = octopusRegNode.OpenSubKey(application);
-            if (applicationRegNode != null)
+            using (var applicationRegNode = octopusRegNode.OpenSubKey(application))
             {
-                var installationFolder = (string) applicationRegNode.GetValue("InstallLocation");
-                var currentAssemblyLocation = typeof(LocationChecker).Assembly.Location;
-
-                if (currentAssemblyLocation.Contains(installationFolder))
+                if (applicationRegNode != null)
                 {
-                    var warningMessage = $"Using Octopus.Client from the {application}'s installation folder has been deprecated. In future versions it may not be shipped with {application}. Please see https://g.octopushq.com/usingoctopusclientfrominstallationfolder.";
-                    
-                    // Write this to the log, if one is configured. Also write it to the console in case no log has been configured
-                    Logger.Warn(warningMessage);
-                    Console.WriteLine(warningMessage);
+                    var installationFolder = (string) applicationRegNode.GetValue("InstallLocation");
+                    var currentAssemblyLocation = typeof(LocationChecker).Assembly.Location;
+
+                    if (currentAssemblyLocation.Contains(installationFolder))
+                    {
+                        var warningMessage =
+                            $"Using Octopus.Client from the {application}'s installation folder has been deprecated. In future versions it may not be shipped with {application}. Please see https://g.octopushq.com/usingoctopusclientfrominstallationfolder.";
+
+                        // Write this to the log, if one is configured. Also write it to the console in case no log has been configured
+                        Logger.Warn(warningMessage);
+                        Console.WriteLine(warningMessage);
+                    }
                 }
             }
         }

--- a/source/Octopus.Client/LocationChecker.cs
+++ b/source/Octopus.Client/LocationChecker.cs
@@ -15,15 +15,23 @@ namespace Octopus.Client
         public static void CheckAssemblyLocation()
         {
             var octopusRegNode = Registry.LocalMachine.OpenSubKey(@"Software\Octopus");
-            var serverRegNode = octopusRegNode.OpenSubKey("Server");
-            if (serverRegNode != null)
+            CheckBasedOnApplication(octopusRegNode, "Server");
+            CheckBasedOnApplication(octopusRegNode, "Tentacle");
+        }
+
+        private static void CheckBasedOnApplication(RegistryKey octopusRegNode, string application)
+        {
+            var applicationRegNode = octopusRegNode.OpenSubKey(application);
+            if (applicationRegNode != null)
             {
-                var serverInstallationFolder = (string)serverRegNode.GetValue("InstallLocation");
+                var serverInstallationFolder = (string) applicationRegNode.GetValue("InstallLocation");
                 var currentAssemblyLocation = typeof(LocationChecker).Assembly.Location;
 
                 if (currentAssemblyLocation.Contains(serverInstallationFolder))
                 {
-                    var warningMessage = $"Using Octopus.Client from the server's installation folder has been deprecated. In future versions it may not be shipped with server.";
+                    var warningMessage = $"Using Octopus.Client from the {application}'s installation folder has been deprecated. In future versions it may not be shipped with {application}.";
+                    
+                    // Write this to the log, if one is configured. Also write it to the console in case no log has been configured
                     Logger.Warn(warningMessage);
                     Console.WriteLine(warningMessage);
                 }

--- a/source/Octopus.Client/LocationChecker.cs
+++ b/source/Octopus.Client/LocationChecker.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Win32;
+using Octopus.Client.Logging;
+
+namespace Octopus.Client
+{
+#if FULL_FRAMEWORK
+    class LocationChecker
+    {
+        private static readonly ILog Logger = LogProvider.For<LocationChecker>();
+
+        public static void CheckAssemblyLocation()
+        {
+            var octopusRegNode = Registry.LocalMachine.OpenSubKey(@"Software\Octopus");
+            var serverRegNode = octopusRegNode.OpenSubKey("Server");
+            if (serverRegNode != null)
+            {
+                var serverInstallationFolder = (string)serverRegNode.GetValue("InstallLocation");
+                var currentAssemblyLocation = typeof(LocationChecker).Assembly.Location;
+
+                if (currentAssemblyLocation.Contains(serverInstallationFolder))
+                {
+                    var warningMessage = $"Using Octopus.Client from the server's installation folder has been deprecated. In future versions it may not be shipped with server.";
+                    Logger.Warn(warningMessage);
+                    Console.WriteLine(warningMessage);
+                }
+            }
+        }
+    }
+#endif
+}

--- a/source/Octopus.Client/Octopus.Client.csproj
+++ b/source/Octopus.Client/Octopus.Client.csproj
@@ -25,7 +25,7 @@ This package contains the client library for the HTTP API in Octopus.</Descripti
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DebugType>embedded</DebugType>
-    <DefineConstants>$(DefineConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants);FULL_FRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS;LIBLOG_PORTABLE</DefineConstants>

--- a/source/Octopus.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Client/OctopusAsyncRepository.cs
@@ -50,6 +50,9 @@ namespace Octopus.Client
 
         public OctopusAsyncRepository(IOctopusAsyncClient client, RepositoryScope repositoryScope = null)
         {
+#if FULL_FRAMEWORK
+            LocationChecker.CheckAssemblyLocation();
+#endif
             Client = client;
             Scope = repositoryScope ?? RepositoryScope.Unspecified();
             Accounts = new AccountRepository(this);

--- a/source/Octopus.Client/OctopusRepository.cs
+++ b/source/Octopus.Client/OctopusRepository.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using Octopus.Client.Exceptions;
+using Octopus.Client.Logging;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories;
 
@@ -48,6 +49,9 @@ namespace Octopus.Client
 
         public OctopusRepository(IOctopusClient client, RepositoryScope repositoryScope = null)
         {
+#if FULL_FRAMEWORK
+            LocationChecker.CheckAssemblyLocation();
+#endif
             Client = client;
             Scope = repositoryScope ?? RepositoryScope.Unspecified();
             Accounts = new AccountRepository(this);

--- a/source/Octopus.Client/OctopusRepository.cs
+++ b/source/Octopus.Client/OctopusRepository.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using Octopus.Client.Exceptions;
-using Octopus.Client.Logging;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories;
 


### PR DESCRIPTION
This causes trouble with NETFramework vs NETCore, especially in PowerShell 5.