### PR TITLE
Bring ScopeField enum into sync with server

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4409,11 +4409,13 @@ Octopus.Client.Model
       TargetRole = 4
       Action = 5
       User = 6
-      Private = 7
-      Channel = 8
-      TenantTag = 9
-      Tenant = 10
-      ProcessOwner = 11
+      Trigger = 7
+      ParentDeployment = 8
+      Private = 9
+      Channel = 10
+      TenantTag = 11
+      Tenant = 12
+      ProcessOwner = 13
   }
   class ScopeSpecification
     IDictionary<ScopeField, ScopeValue>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4428,11 +4428,13 @@ Octopus.Client.Model
       TargetRole = 4
       Action = 5
       User = 6
-      Private = 7
-      Channel = 8
-      TenantTag = 9
-      Tenant = 10
-      ProcessOwner = 11
+      Trigger = 7
+      ParentDeployment = 8
+      Private = 9
+      Channel = 10
+      TenantTag = 11
+      Tenant = 12
+      ProcessOwner = 13
   }
   class ScopeSpecification
     IDictionary<ScopeField, ScopeValue>

--- a/source/Octopus.Client/Model/ScopeField.cs
+++ b/source/Octopus.Client/Model/ScopeField.cs
@@ -13,11 +13,12 @@ namespace Octopus.Client.Model
         TargetRole,
         Action,
         User,
+        Trigger, // Allows vars coming via triggers to override scoped values
+        ParentDeployment, // Allows vars coming via deploy release step to override scoped values
         Private, // Allows inbuilt vars to override user ones
         Channel,
         TenantTag,
-        Tenant, 
-        ProcessOwner,
-        ParentDeployment,
+        Tenant,
+        ProcessOwner
     }
 }


### PR DESCRIPTION
To fix customers who might hit deserialization errors if the enum is sent from the server