### PR TITLE
Bump assent v1.5.0

### DIFF
--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Assent" Version="1.3.0" />
+    <PackageReference Include="Assent" Version="1.5.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="FluentAssertions" Version="4.15.0" />
     <PackageReference Include="Nancy" Version="2.0.0" />


### PR DESCRIPTION
The version of Assent used in Clients did not support finding any reporters on linux so bumping to this version will at least support vscode as a reporter.