### PR TITLE
initialise sensitive value to avoid nullrefs

### DIFF
--- a/source/Octopus.Client/Model/VersionControlSettingsResource.cs
+++ b/source/Octopus.Client/Model/VersionControlSettingsResource.cs
@@ -9,7 +9,7 @@ namespace Octopus.Client.Model
         [Writeable]
         public string Username { get; set; }
         [Writeable]
-        public SensitiveValue Password { get; set; }
+        public SensitiveValue Password { get; set; } = new SensitiveValue();
         [Writeable]
         public string DefaultBranch { get; set; }
     }


### PR DESCRIPTION
just a one-liner to initialise `VersionControlSettingsResource.Password`