### PR TITLE
Remove AgentlessEndpointResource, it's a weird abstraction

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5704,12 +5704,6 @@ Octopus.Client.Model.DeploymentProcess
 }
 Octopus.Client.Model.Endpoints
 {
-  abstract class AgentlessEndpointResource
-    Octopus.Client.Extensibility.IResource
-    Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.EndpointResource
-  {
-  }
   AzureServiceFabricCredentialType
   {
       ClientCredential = 0
@@ -5724,7 +5718,7 @@ Octopus.Client.Model.Endpoints
   class AzureWebAppEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String AccountId { get; set; }
@@ -5742,7 +5736,7 @@ Octopus.Client.Model.Endpoints
   class CloudRegionEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
@@ -5751,7 +5745,7 @@ Octopus.Client.Model.Endpoints
   class CloudServiceEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String AccountId { get; set; }
@@ -5801,7 +5795,7 @@ Octopus.Client.Model.Endpoints
   class KubernetesEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     Octopus.Client.Model.Endpoints.IEndpointWithMultipleAuthenticationResource Authentication { get; set; }
@@ -5845,7 +5839,7 @@ Octopus.Client.Model.Endpoints
   class OfflineDropEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String ApplicationsDirectory { get; set; }
@@ -5866,7 +5860,7 @@ Octopus.Client.Model.Endpoints
   class ServiceFabricEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String AadClientCredentialSecret { get; set; }
@@ -5885,7 +5879,7 @@ Octopus.Client.Model.Endpoints
   class SshEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String AccountId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5729,12 +5729,6 @@ Octopus.Client.Model.DeploymentProcess
 }
 Octopus.Client.Model.Endpoints
 {
-  abstract class AgentlessEndpointResource
-    Octopus.Client.Extensibility.IResource
-    Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.EndpointResource
-  {
-  }
   AzureServiceFabricCredentialType
   {
       ClientCredential = 0
@@ -5749,7 +5743,7 @@ Octopus.Client.Model.Endpoints
   class AzureWebAppEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String AccountId { get; set; }
@@ -5767,7 +5761,7 @@ Octopus.Client.Model.Endpoints
   class CloudRegionEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
@@ -5776,7 +5770,7 @@ Octopus.Client.Model.Endpoints
   class CloudServiceEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String AccountId { get; set; }
@@ -5826,7 +5820,7 @@ Octopus.Client.Model.Endpoints
   class KubernetesEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     Octopus.Client.Model.Endpoints.IEndpointWithMultipleAuthenticationResource Authentication { get; set; }
@@ -5870,7 +5864,7 @@ Octopus.Client.Model.Endpoints
   class OfflineDropEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String ApplicationsDirectory { get; set; }
@@ -5891,7 +5885,7 @@ Octopus.Client.Model.Endpoints
   class ServiceFabricEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String AadClientCredentialSecret { get; set; }
@@ -5910,7 +5904,7 @@ Octopus.Client.Model.Endpoints
   class SshEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
-    Octopus.Client.Model.Endpoints.AgentlessEndpointResource
+    Octopus.Client.Model.Endpoints.EndpointResource
   {
     .ctor()
     String AccountId { get; set; }

--- a/source/Octopus.Client/Model/Endpoints/AgentlessEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/AgentlessEndpointResource.cs
@@ -1,8 +1,0 @@
-using System;
-
-namespace Octopus.Client.Model.Endpoints
-{
-    public abstract class AgentlessEndpointResource : EndpointResource
-    {
-    }
-}

--- a/source/Octopus.Client/Model/Endpoints/AzureWebAppEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/AzureWebAppEndpointResource.cs
@@ -4,7 +4,7 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class AzureWebAppEndpointResource : AgentlessEndpointResource
+    public class AzureWebAppEndpointResource : EndpointResource
     {
         public override CommunicationStyle CommunicationStyle
         {

--- a/source/Octopus.Client/Model/Endpoints/CloudRegionEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/CloudRegionEndpointResource.cs
@@ -2,7 +2,7 @@
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class CloudRegionEndpointResource : AgentlessEndpointResource
+    public class CloudRegionEndpointResource : EndpointResource
     {
         public override CommunicationStyle CommunicationStyle => CommunicationStyle.None;
 

--- a/source/Octopus.Client/Model/Endpoints/CloudServiceEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/CloudServiceEndpointResource.cs
@@ -4,7 +4,7 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class CloudServiceEndpointResource : AgentlessEndpointResource
+    public class CloudServiceEndpointResource : EndpointResource
     {
         public override CommunicationStyle CommunicationStyle
         {

--- a/source/Octopus.Client/Model/Endpoints/KubernetesEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/KubernetesEndpointResource.cs
@@ -2,7 +2,7 @@
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class KubernetesEndpointResource : AgentlessEndpointResource
+    public class KubernetesEndpointResource : EndpointResource
     {
         public override CommunicationStyle CommunicationStyle => CommunicationStyle.Kubernetes;
 

--- a/source/Octopus.Client/Model/Endpoints/OfflineDropEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/OfflineDropEndpointResource.cs
@@ -7,7 +7,7 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class OfflineDropEndpointResource : AgentlessEndpointResource
+    public class OfflineDropEndpointResource : EndpointResource
     {
         public OfflineDropEndpointResource()
         {

--- a/source/Octopus.Client/Model/Endpoints/ServiceFabricEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/ServiceFabricEndpointResource.cs
@@ -2,7 +2,7 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class ServiceFabricEndpointResource : AgentlessEndpointResource
+    public class ServiceFabricEndpointResource : EndpointResource
     {
         public override CommunicationStyle CommunicationStyle => CommunicationStyle.AzureServiceFabricCluster;
 

--- a/source/Octopus.Client/Model/Endpoints/SshEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/SshEndpointResource.cs
@@ -3,7 +3,7 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class SshEndpointResource : AgentlessEndpointResource
+    public class SshEndpointResource : EndpointResource
     {
         public override CommunicationStyle CommunicationStyle
         {


### PR DESCRIPTION
We've removed this on the Server side, so it makes sense to remove it here too.
Can we safely remove this intermediate class without breaking people?