### PR TITLE
Ensures runbook run commands inspect for server version >= 2020.3.1

### DIFF
--- a/source/Octopus.Client/Repositories/Async/RunbookRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/RunbookRepository.cs
@@ -26,7 +26,7 @@ namespace Octopus.Client.Repositories.Async
             : base(repository, "Runbooks")
         {
             integrationTestVersion = SemanticVersion.Parse("0.0.0-local");
-            versionAfterWhichRunbookRunParametersAreAvailable = SemanticVersion.Parse("2020.2.99999");
+            versionAfterWhichRunbookRunParametersAreAvailable = SemanticVersion.Parse("2020.3.1");
         }
 
         public Task<RunbookResource> FindByName(ProjectResource project, string name)
@@ -58,7 +58,11 @@ namespace Octopus.Client.Repositories.Async
         {
             var serverVersion = SemanticVersion.Parse(version);
 
-            return serverVersion >= versionAfterWhichRunbookRunParametersAreAvailable ||
+            // Note: We want to ensure the server version is >= *any* 2020.3.1, including all pre-releases to consider what may be rolled out to Octopus Cloud.
+            var preReleaseAgnosticServerVersion =
+                new SemanticVersion(serverVersion.Major, serverVersion.Minor, serverVersion.Patch);
+
+            return preReleaseAgnosticServerVersion >= versionAfterWhichRunbookRunParametersAreAvailable ||
                    serverVersion == integrationTestVersion;
         }
 

--- a/source/Octopus.Client/Repositories/RunbookRepository.cs
+++ b/source/Octopus.Client/Repositories/RunbookRepository.cs
@@ -25,7 +25,7 @@ namespace Octopus.Client.Repositories
             : base(repository, "Runbooks")
         {
             integrationTestVersion = SemanticVersion.Parse("0.0.0-local");
-            versionAfterWhichRunbookRunParametersAreAvailable = SemanticVersion.Parse("2020.2.99999");
+            versionAfterWhichRunbookRunParametersAreAvailable = SemanticVersion.Parse("2020.3.1");
         }
 
         public RunbookResource FindByName(ProjectResource project, string name)
@@ -57,7 +57,11 @@ namespace Octopus.Client.Repositories
         {
             var serverVersion = SemanticVersion.Parse(version);
 
-            return serverVersion >= versionAfterWhichRunbookRunParametersAreAvailable ||
+            // Note: We want to ensure the server version is >= *any* 2020.3.1, including all pre-releases to consider what may be rolled out to Octopus Cloud.
+            var preReleaseAgnosticServerVersion =
+                new SemanticVersion(serverVersion.Major, serverVersion.Minor, serverVersion.Patch);
+
+            return preReleaseAgnosticServerVersion >= versionAfterWhichRunbookRunParametersAreAvailable ||
                    serverVersion == integrationTestVersion;
         }
 


### PR DESCRIPTION
We need to tighten the window for version tolerance for the runbook run command in the CLI.

The first step is having the client help us route to the right endpoint given the server version.