### PR TITLE
Adds beta config-as-code endpoints

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6659,7 +6659,7 @@ Octopus.Client.Repositories
   interface IDeploymentProcessRepositoryBeta
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.DeploymentProcessResource, String)
+    Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7362,6 +7362,7 @@ Octopus.Client.Repositories.Async
   interface IDeploymentProcessRepositoryBeta
   {
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5245,6 +5245,14 @@ Octopus.Client.Model
       AzureAccount = 4
       WorkerPool = 5
   }
+  class VersionControlBranchResource
+  {
+    .ctor(String)
+    Octopus.Client.Extensibility.LinkCollection Links { get; }
+    String Name { get; }
+    String Link(String)
+    void WithLinks(Octopus.Client.Extensibility.LinkCollection)
+  }
   class VersionControlSettingsResource
   {
     .ctor()
@@ -6639,7 +6647,13 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.IModify<DeploymentProcessResource>
   {
+    Octopus.Client.Repositories.IDeploymentProcessRepositoryBeta Beta(Boolean)
     Octopus.Client.Model.ReleaseTemplateResource GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
+  }
+  interface IDeploymentProcessRepositoryBeta
+  {
+    Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
+    void Modify(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ProjectResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>
@@ -6840,6 +6854,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<ProjectResource>
     Octopus.Client.Repositories.IGetAll<ProjectResource>
   {
+    Octopus.Client.Repositories.IProjectRepositoryBeta Beta(Boolean)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -6856,6 +6871,11 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> GetTriggers(Octopus.Client.Model.ProjectResource)
     void SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
+  }
+  interface IProjectRepositoryBeta
+  {
+    Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
+    Octopus.Client.Model.VersionControlBranchResource[] GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
   interface IProjectTriggerRepository
     Octopus.Client.Repositories.ICreate<ProjectTriggerResource>
@@ -7330,7 +7350,13 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.Async.IModify<DeploymentProcessResource>
   {
+    Octopus.Client.Repositories.Async.IDeploymentProcessRepositoryBeta Beta(Boolean)
     Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
+  }
+  interface IDeploymentProcessRepositoryBeta
+  {
+    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task Modify(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ProjectResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>
@@ -7530,6 +7556,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ProjectResource>
     Octopus.Client.Repositories.Async.IGetAll<ProjectResource>
   {
+    Octopus.Client.Repositories.Async.IProjectRepositoryBeta Beta(Boolean)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -7546,6 +7573,11 @@ Octopus.Client.Repositories.Async
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
     Task SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
+  }
+  interface IProjectRepositoryBeta
+  {
+    Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
+    Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
   interface IProjectTriggerRepository
     Octopus.Client.Repositories.Async.ICreate<ProjectTriggerResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6653,7 +6653,6 @@ Octopus.Client.Repositories
   interface IDeploymentProcessRepositoryBeta
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
-    void Modify(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ProjectResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>
@@ -7356,7 +7355,6 @@ Octopus.Client.Repositories.Async
   interface IDeploymentProcessRepositoryBeta
   {
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
-    Task Modify(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ProjectResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6647,7 +6647,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.IModify<DeploymentProcessResource>
   {
-    Octopus.Client.Repositories.IDeploymentProcessRepositoryBeta Beta(Boolean)
+    Octopus.Client.Repositories.IDeploymentProcessRepositoryBeta Beta()
     Octopus.Client.Model.ReleaseTemplateResource GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
   }
   interface IDeploymentProcessRepositoryBeta
@@ -6853,7 +6853,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<ProjectResource>
     Octopus.Client.Repositories.IGetAll<ProjectResource>
   {
-    Octopus.Client.Repositories.IProjectRepositoryBeta Beta(Boolean)
+    Octopus.Client.Repositories.IProjectRepositoryBeta Beta()
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -7349,7 +7349,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.Async.IModify<DeploymentProcessResource>
   {
-    Octopus.Client.Repositories.Async.IDeploymentProcessRepositoryBeta Beta(Boolean)
+    Octopus.Client.Repositories.Async.IDeploymentProcessRepositoryBeta Beta()
     Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
   }
   interface IDeploymentProcessRepositoryBeta
@@ -7554,7 +7554,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ProjectResource>
     Octopus.Client.Repositories.Async.IGetAll<ProjectResource>
   {
-    Octopus.Client.Repositories.Async.IProjectRepositoryBeta Beta(Boolean)
+    Octopus.Client.Repositories.Async.IProjectRepositoryBeta Beta()
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2199,6 +2199,12 @@ Octopus.Client.Model
     String Id { get; set; }
     String LinkUrl { get; set; }
   }
+  class CommitResource`1
+  {
+    .ctor()
+    String CommitMessage { get; set; }
+    Octopus.Client.Model.TResource Resource { get; set; }
+  }
   CommunicationStyle
   {
       None = 0
@@ -6653,6 +6659,7 @@ Octopus.Client.Repositories
   interface IDeploymentProcessRepositoryBeta
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
+    Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.DeploymentProcessResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2215,6 +2215,12 @@ Octopus.Client.Model
     String Id { get; set; }
     String LinkUrl { get; set; }
   }
+  class CommitResource`1
+  {
+    .ctor()
+    String CommitMessage { get; set; }
+    Octopus.Client.Model.TResource Resource { get; set; }
+  }
   CommunicationStyle
   {
       None = 0
@@ -6678,6 +6684,7 @@ Octopus.Client.Repositories
   interface IDeploymentProcessRepositoryBeta
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
+    Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.DeploymentProcessResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6672,7 +6672,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.IModify<DeploymentProcessResource>
   {
-    Octopus.Client.Repositories.IDeploymentProcessRepositoryBeta Beta(Boolean)
+    Octopus.Client.Repositories.IDeploymentProcessRepositoryBeta Beta()
     Octopus.Client.Model.ReleaseTemplateResource GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
   }
   interface IDeploymentProcessRepositoryBeta
@@ -6878,7 +6878,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<ProjectResource>
     Octopus.Client.Repositories.IGetAll<ProjectResource>
   {
-    Octopus.Client.Repositories.IProjectRepositoryBeta Beta(Boolean)
+    Octopus.Client.Repositories.IProjectRepositoryBeta Beta()
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -7374,7 +7374,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.Async.IModify<DeploymentProcessResource>
   {
-    Octopus.Client.Repositories.Async.IDeploymentProcessRepositoryBeta Beta(Boolean)
+    Octopus.Client.Repositories.Async.IDeploymentProcessRepositoryBeta Beta()
     Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
   }
   interface IDeploymentProcessRepositoryBeta
@@ -7579,7 +7579,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ProjectResource>
     Octopus.Client.Repositories.Async.IGetAll<ProjectResource>
   {
-    Octopus.Client.Repositories.Async.IProjectRepositoryBeta Beta(Boolean)
+    Octopus.Client.Repositories.Async.IProjectRepositoryBeta Beta()
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6678,7 +6678,6 @@ Octopus.Client.Repositories
   interface IDeploymentProcessRepositoryBeta
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
-    void Modify(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ProjectResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>
@@ -7381,7 +7380,6 @@ Octopus.Client.Repositories.Async
   interface IDeploymentProcessRepositoryBeta
   {
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
-    Task Modify(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ProjectResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6684,7 +6684,7 @@ Octopus.Client.Repositories
   interface IDeploymentProcessRepositoryBeta
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.DeploymentProcessResource, String)
+    Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5269,6 +5269,14 @@ Octopus.Client.Model
       AzureAccount = 4
       WorkerPool = 5
   }
+  class VersionControlBranchResource
+  {
+    .ctor(String)
+    Octopus.Client.Extensibility.LinkCollection Links { get; }
+    String Name { get; }
+    String Link(String)
+    void WithLinks(Octopus.Client.Extensibility.LinkCollection)
+  }
   class VersionControlSettingsResource
   {
     .ctor()
@@ -6664,7 +6672,13 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.IModify<DeploymentProcessResource>
   {
+    Octopus.Client.Repositories.IDeploymentProcessRepositoryBeta Beta(Boolean)
     Octopus.Client.Model.ReleaseTemplateResource GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
+  }
+  interface IDeploymentProcessRepositoryBeta
+  {
+    Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
+    void Modify(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ProjectResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>
@@ -6865,6 +6879,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<ProjectResource>
     Octopus.Client.Repositories.IGetAll<ProjectResource>
   {
+    Octopus.Client.Repositories.IProjectRepositoryBeta Beta(Boolean)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -6881,6 +6896,11 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> GetTriggers(Octopus.Client.Model.ProjectResource)
     void SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
+  }
+  interface IProjectRepositoryBeta
+  {
+    Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
+    Octopus.Client.Model.VersionControlBranchResource[] GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
   interface IProjectTriggerRepository
     Octopus.Client.Repositories.ICreate<ProjectTriggerResource>
@@ -7355,7 +7375,13 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.Async.IModify<DeploymentProcessResource>
   {
+    Octopus.Client.Repositories.Async.IDeploymentProcessRepositoryBeta Beta(Boolean)
     Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
+  }
+  interface IDeploymentProcessRepositoryBeta
+  {
+    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task Modify(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ProjectResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>
@@ -7555,6 +7581,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ProjectResource>
     Octopus.Client.Repositories.Async.IGetAll<ProjectResource>
   {
+    Octopus.Client.Repositories.Async.IProjectRepositoryBeta Beta(Boolean)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -7571,6 +7598,11 @@ Octopus.Client.Repositories.Async
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
     Task SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
+  }
+  interface IProjectRepositoryBeta
+  {
+    Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
+    Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
   interface IProjectTriggerRepository
     Octopus.Client.Repositories.Async.ICreate<ProjectTriggerResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7387,6 +7387,7 @@ Octopus.Client.Repositories.Async
   interface IDeploymentProcessRepositoryBeta
   {
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>

--- a/source/Octopus.Client/Model/CommitResource.cs
+++ b/source/Octopus.Client/Model/CommitResource.cs
@@ -1,0 +1,8 @@
+﻿namespace Octopus.Client.Model
+{
+    public class CommitResource<TResource> where TResource : Resource
+    {
+        public TResource Resource { get; set; }
+        public string CommitMessage { get; set; }
+    }
+}

--- a/source/Octopus.Client/Model/VersionControlBranchResource.cs
+++ b/source/Octopus.Client/Model/VersionControlBranchResource.cs
@@ -1,0 +1,29 @@
+﻿using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
+{
+    public class VersionControlBranchResource
+    {
+        public VersionControlBranchResource(string name)
+        {
+            Name = name;
+            Links = new LinkCollection();
+        }
+
+        public string Name { get; }
+
+        /// <remarks>
+        /// TODO: We may want to derive an IVcsControlledResource at some point that this will be a part of
+        /// </remarks>
+        public LinkCollection Links { get; }
+
+        public void WithLinks(LinkCollection links)
+        {
+            Links.Clear();
+            foreach (var link in links)
+            {
+                Links.Add(link.Key, link.Value);
+            }
+        }
+    }
+}

--- a/source/Octopus.Client/Model/VersionControlBranchResource.cs
+++ b/source/Octopus.Client/Model/VersionControlBranchResource.cs
@@ -1,4 +1,5 @@
-﻿using Octopus.Client.Extensibility;
+﻿using System;
+using Octopus.Client.Extensibility;
 
 namespace Octopus.Client.Model
 {
@@ -12,9 +13,6 @@ namespace Octopus.Client.Model
 
         public string Name { get; }
 
-        /// <remarks>
-        /// TODO: We may want to derive an IVcsControlledResource at some point that this will be a part of
-        /// </remarks>
         public LinkCollection Links { get; }
 
         public void WithLinks(LinkCollection links)
@@ -24,6 +22,16 @@ namespace Octopus.Client.Model
             {
                 Links.Add(link.Key, link.Value);
             }
+        }
+
+        public string Link(string name)
+        {
+            if (!(Links ?? new LinkCollection()).TryGetValue(name, out var value))
+            {
+                throw new Exception($"The document does not define a link for '{name}'");
+            }
+
+            return value;
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DeploymentProcessRepository.cs
@@ -35,8 +35,7 @@ namespace Octopus.Client.Repositories.Async
 
     public interface IDeploymentProcessRepositoryBeta
     {
-        Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitref);
-        Task Modify(DeploymentProcessResource deploymentProcessResource, ProjectResource projectResource, string gitref);
+        Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitref = null);
     }
 
     class DeploymentProcessRepositoryBeta : IDeploymentProcessRepositoryBeta
@@ -60,18 +59,6 @@ namespace Octopus.Client.Repositories.Async
             }
 
             return await client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
-        }
-
-        public async Task Modify(DeploymentProcessResource deploymentProcessResource, ProjectResource projectResource, string gitref = null)
-        {
-            if (!string.IsNullOrWhiteSpace(gitref))
-            {
-                var branchResource = await repository.Projects.Beta(true).GetVersionControlledBranch(projectResource, gitref);
-
-                await client.Put(branchResource.Link("DeploymentProcess"), deploymentProcessResource);
-            }
-
-            await client.Put(projectResource.Link("DeploymentProcess"), deploymentProcessResource);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DeploymentProcessRepository.cs
@@ -6,19 +6,72 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IDeploymentProcessRepository : IGet<DeploymentProcessResource>, IModify<DeploymentProcessResource>
     {
+        IDeploymentProcessRepositoryBeta Beta(bool useBeta);
         Task<ReleaseTemplateResource> GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel);
     }
 
     class DeploymentProcessRepository : BasicRepository<DeploymentProcessResource>, IDeploymentProcessRepository
     {
+        private readonly IDeploymentProcessRepositoryBeta beta;
+
         public DeploymentProcessRepository(IOctopusAsyncRepository repository)
             : base(repository, "DeploymentProcesses")
         {
+            beta = new DeploymentProcessRepositoryBeta(repository);
+        }
+
+        public IDeploymentProcessRepositoryBeta Beta(bool useBeta)
+        {
+            if (!useBeta) throw new Exception($"You must supply true for {nameof(useBeta)} to use Beta functionality.");
+
+            return beta;
         }
 
         public Task<ReleaseTemplateResource> GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel)
         {
             return Client.Get<ReleaseTemplateResource>(deploymentProcess.Link("Template"), new { channel = channel?.Id });
+        }
+    }
+
+    public interface IDeploymentProcessRepositoryBeta
+    {
+        Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitref);
+        Task Modify(DeploymentProcessResource deploymentProcessResource, ProjectResource projectResource, string gitref);
+    }
+
+    class DeploymentProcessRepositoryBeta : IDeploymentProcessRepositoryBeta
+    {
+        private readonly IOctopusAsyncRepository repository;
+        private readonly IOctopusAsyncClient client;
+
+        public DeploymentProcessRepositoryBeta(IOctopusAsyncRepository repository)
+        {
+            this.repository = repository;
+            this.client = repository.Client;
+        }
+
+        public async Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitref = null)
+        {
+            if (!string.IsNullOrWhiteSpace(gitref))
+            {
+                var branchResource = await repository.Projects.Beta(true).GetVersionControlledBranch(projectResource, gitref);
+
+                return await client.Get<DeploymentProcessResource>(branchResource.Link("DeploymentProcess"));
+            }
+
+            return await client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
+        }
+
+        public async Task Modify(DeploymentProcessResource deploymentProcessResource, ProjectResource projectResource, string gitref = null)
+        {
+            if (!string.IsNullOrWhiteSpace(gitref))
+            {
+                var branchResource = await repository.Projects.Beta(true).GetVersionControlledBranch(projectResource, gitref);
+
+                await client.Put(branchResource.Link("DeploymentProcess"), deploymentProcessResource);
+            }
+
+            await client.Put(projectResource.Link("DeploymentProcess"), deploymentProcessResource);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DeploymentProcessRepository.cs
@@ -6,7 +6,7 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IDeploymentProcessRepository : IGet<DeploymentProcessResource>, IModify<DeploymentProcessResource>
     {
-        IDeploymentProcessRepositoryBeta Beta(bool useBeta);
+        IDeploymentProcessRepositoryBeta Beta();
         Task<ReleaseTemplateResource> GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel);
     }
 
@@ -20,10 +20,8 @@ namespace Octopus.Client.Repositories.Async
             beta = new DeploymentProcessRepositoryBeta(repository);
         }
 
-        public IDeploymentProcessRepositoryBeta Beta(bool useBeta)
+        public IDeploymentProcessRepositoryBeta Beta()
         {
-            if (!useBeta) throw new Exception($"You must supply true for {nameof(useBeta)} to use Beta functionality.");
-
             return beta;
         }
 
@@ -53,7 +51,7 @@ namespace Octopus.Client.Repositories.Async
         {
             if (!string.IsNullOrWhiteSpace(gitref))
             {
-                var branchResource = await repository.Projects.Beta(true).GetVersionControlledBranch(projectResource, gitref);
+                var branchResource = await repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitref);
 
                 return await client.Get<DeploymentProcessResource>(branchResource.Link("DeploymentProcess"));
             }

--- a/source/Octopus.Client/Repositories/Async/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DeploymentProcessRepository.cs
@@ -34,6 +34,9 @@ namespace Octopus.Client.Repositories.Async
     public interface IDeploymentProcessRepositoryBeta
     {
         Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitref = null);
+
+        Task<DeploymentProcessResource> Modify(ProjectResource projectResource, DeploymentProcessResource resource,
+            string commitMessage = null);
     }
 
     class DeploymentProcessRepositoryBeta : IDeploymentProcessRepositoryBeta
@@ -57,6 +60,23 @@ namespace Octopus.Client.Repositories.Async
             }
 
             return await client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
+        }
+
+        public async Task<DeploymentProcessResource> Modify(ProjectResource projectResource,
+            DeploymentProcessResource resource, string commitMessage = null)
+        {
+            if (!projectResource.IsVersionControlled)
+            {
+                return await client.Update(projectResource.Link("DeploymentProcess"), resource);
+            }
+
+            var commitResource = new CommitResource<DeploymentProcessResource>
+            {
+                Resource = resource,
+                CommitMessage = commitMessage
+            };
+            await client.Update(resource.Link("Self"), commitResource);
+            return await client.Get<DeploymentProcessResource>(resource.Link("Self"));
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -9,7 +9,7 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IProjectRepository : IFindByName<ProjectResource>, IGet<ProjectResource>, ICreate<ProjectResource>, IModify<ProjectResource>, IDelete<ProjectResource>, IGetAll<ProjectResource>
     {
-        IProjectRepositoryBeta Beta(bool useBeta);
+        IProjectRepositoryBeta Beta();
         Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null);
         Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project);
         Task<ReleaseResource> GetReleaseByVersion(ProjectResource project, string version);
@@ -38,10 +38,8 @@ namespace Octopus.Client.Repositories.Async
             beta = new ProjectRepositoryBeta(repository);
         }
 
-        public IProjectRepositoryBeta Beta(bool useBeta = false)
+        public IProjectRepositoryBeta Beta()
         {
-            if (!useBeta) throw new Exception($"You must supply true for {nameof(useBeta)} to use Beta functionality.");
-
             return beta;
         }
 

--- a/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
@@ -34,8 +34,7 @@ namespace Octopus.Client.Repositories
 
     public interface IDeploymentProcessRepositoryBeta
     {
-        DeploymentProcessResource Get(ProjectResource projectResource, string gitref);
-        void Modify(DeploymentProcessResource deploymentProcessResource, ProjectResource projectResource, string gitref);
+        DeploymentProcessResource Get(ProjectResource projectResource, string gitref = null);
     }
 
     class DeploymentProcessRepositoryBeta : IDeploymentProcessRepositoryBeta
@@ -59,18 +58,6 @@ namespace Octopus.Client.Repositories
             }
 
             return client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
-        }
-
-        public void Modify(DeploymentProcessResource deploymentProcessResource, ProjectResource projectResource, string gitref = null)
-        {
-            if (!string.IsNullOrWhiteSpace(gitref))
-            {
-                var branchResource = repository.Projects.Beta(true).GetVersionControlledBranch(projectResource, gitref);
-
-                client.Put(branchResource.Link("DeploymentProcess"), deploymentProcessResource);
-            }
-
-            client.Put(projectResource.Link("DeploymentProcess"), deploymentProcessResource);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
@@ -5,7 +5,7 @@ namespace Octopus.Client.Repositories
 {
     public interface IDeploymentProcessRepository : IGet<DeploymentProcessResource>, IModify<DeploymentProcessResource>
     {
-        IDeploymentProcessRepositoryBeta Beta(bool useBeta);
+        IDeploymentProcessRepositoryBeta Beta();
         ReleaseTemplateResource GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel);
     }
 
@@ -19,10 +19,8 @@ namespace Octopus.Client.Repositories
             beta = new DeploymentProcessRepositoryBeta(repository);
         }
 
-        public IDeploymentProcessRepositoryBeta Beta(bool useBeta)
+        public IDeploymentProcessRepositoryBeta Beta()
         {
-            if (!useBeta) throw new Exception($"You must supply true for {nameof(useBeta)} to use Beta functionality.");
-
             return beta;
         }
 
@@ -52,7 +50,7 @@ namespace Octopus.Client.Repositories
         {
             if (!string.IsNullOrWhiteSpace(gitref))
             {
-                var branchResource = repository.Projects.Beta(true).GetVersionControlledBranch(projectResource, gitref);
+                var branchResource = repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitref);
 
                 return client.Get<DeploymentProcessResource>(branchResource.Link("DeploymentProcess"));
             }

--- a/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
@@ -33,7 +33,7 @@ namespace Octopus.Client.Repositories
     public interface IDeploymentProcessRepositoryBeta
     {
         DeploymentProcessResource Get(ProjectResource projectResource, string gitref = null);
-        DeploymentProcessResource Modify(DeploymentProcessResource resource, string commitMessage = null);
+        DeploymentProcessResource Modify(ProjectResource projectResource, DeploymentProcessResource resource, string commitMessage = null);
     }
 
     class DeploymentProcessRepositoryBeta : IDeploymentProcessRepositoryBeta
@@ -59,8 +59,13 @@ namespace Octopus.Client.Repositories
             return client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
         }
 
-        public DeploymentProcessResource Modify(DeploymentProcessResource resource, string commitMessage = null)
+        public DeploymentProcessResource Modify(ProjectResource projectResource, DeploymentProcessResource resource, string commitMessage = null)
         {
+            if (!projectResource.IsVersionControlled)
+            {
+                return client.Update(projectResource.Link("DeploymentProcess"), resource);
+            }
+
             var commitResource = new CommitResource<DeploymentProcessResource>
             {
                 Resource = resource,

--- a/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
@@ -33,6 +33,7 @@ namespace Octopus.Client.Repositories
     public interface IDeploymentProcessRepositoryBeta
     {
         DeploymentProcessResource Get(ProjectResource projectResource, string gitref = null);
+        DeploymentProcessResource Modify(DeploymentProcessResource resource, string commitMessage = null);
     }
 
     class DeploymentProcessRepositoryBeta : IDeploymentProcessRepositoryBeta
@@ -56,6 +57,17 @@ namespace Octopus.Client.Repositories
             }
 
             return client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
+        }
+
+        public DeploymentProcessResource Modify(DeploymentProcessResource resource, string commitMessage = null)
+        {
+            var commitResource = new CommitResource<DeploymentProcessResource>
+            {
+                Resource = resource,
+                CommitMessage = commitMessage
+            };
+            client.Put(resource.Link("Self"), commitResource);
+            return client.Get<DeploymentProcessResource>(resource.Link("Self"));
         }
     }
 }

--- a/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/DeploymentProcessRepository.cs
@@ -5,19 +5,72 @@ namespace Octopus.Client.Repositories
 {
     public interface IDeploymentProcessRepository : IGet<DeploymentProcessResource>, IModify<DeploymentProcessResource>
     {
+        IDeploymentProcessRepositoryBeta Beta(bool useBeta);
         ReleaseTemplateResource GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel);
     }
 
     class DeploymentProcessRepository : BasicRepository<DeploymentProcessResource>, IDeploymentProcessRepository
     {
+        private readonly DeploymentProcessRepositoryBeta beta;
+
         public DeploymentProcessRepository(IOctopusRepository repository)
             : base(repository, "DeploymentProcesses")
         {
+            beta = new DeploymentProcessRepositoryBeta(repository);
+        }
+
+        public IDeploymentProcessRepositoryBeta Beta(bool useBeta)
+        {
+            if (!useBeta) throw new Exception($"You must supply true for {nameof(useBeta)} to use Beta functionality.");
+
+            return beta;
         }
 
         public ReleaseTemplateResource GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel)
         {
             return Client.Get<ReleaseTemplateResource>(deploymentProcess.Link("Template"), new { channel = channel?.Id });
+        }
+    }
+
+    public interface IDeploymentProcessRepositoryBeta
+    {
+        DeploymentProcessResource Get(ProjectResource projectResource, string gitref);
+        void Modify(DeploymentProcessResource deploymentProcessResource, ProjectResource projectResource, string gitref);
+    }
+
+    class DeploymentProcessRepositoryBeta : IDeploymentProcessRepositoryBeta
+    {
+        private readonly IOctopusRepository repository;
+        private readonly IOctopusClient client;
+
+        public DeploymentProcessRepositoryBeta(IOctopusRepository repository)
+        {
+            this.repository = repository;
+            this.client = repository.Client;
+        }
+
+        public DeploymentProcessResource Get(ProjectResource projectResource, string gitref = null)
+        {
+            if (!string.IsNullOrWhiteSpace(gitref))
+            {
+                var branchResource = repository.Projects.Beta(true).GetVersionControlledBranch(projectResource, gitref);
+
+                return client.Get<DeploymentProcessResource>(branchResource.Link("DeploymentProcess"));
+            }
+
+            return client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
+        }
+
+        public void Modify(DeploymentProcessResource deploymentProcessResource, ProjectResource projectResource, string gitref = null)
+        {
+            if (!string.IsNullOrWhiteSpace(gitref))
+            {
+                var branchResource = repository.Projects.Beta(true).GetVersionControlledBranch(projectResource, gitref);
+
+                client.Put(branchResource.Link("DeploymentProcess"), deploymentProcessResource);
+            }
+
+            client.Put(projectResource.Link("DeploymentProcess"), deploymentProcessResource);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectRepository.cs
@@ -8,7 +8,7 @@ namespace Octopus.Client.Repositories
 {
     public interface IProjectRepository : IFindByName<ProjectResource>, IGet<ProjectResource>, ICreate<ProjectResource>, IModify<ProjectResource>, IDelete<ProjectResource>, IGetAll<ProjectResource>
     {
-        IProjectRepositoryBeta Beta(bool useBeta);
+        IProjectRepositoryBeta Beta();
         ResourceCollection<ReleaseResource> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null);
         IReadOnlyList<ReleaseResource> GetAllReleases(ProjectResource project);
         ReleaseResource GetReleaseByVersion(ProjectResource project, string version);
@@ -37,10 +37,8 @@ namespace Octopus.Client.Repositories
             beta = new ProjectRepositoryBeta(repository);
         }
 
-        public IProjectRepositoryBeta Beta(bool useBeta = false)
+        public IProjectRepositoryBeta Beta()
         {
-            if (!useBeta) throw new Exception($"You must supply true for {nameof(useBeta)} to use Beta functionality.");
-
             return beta;
         }
 


### PR DESCRIPTION
Background
===

As a part of the Configuration As Code: Multi Branch Round Trip pitch, we will be implementing the ability to select a branch within the Octopus user interface.

This PR adds client methods for endpoints created in https://github.com/OctopusDeploy/OctopusDeploy/pull/6444 and https://github.com/OctopusDeploy/OctopusDeploy/pull/6408

These methods will be used to create e2e tests for the server application.

**Do not merge** until https://github.com/OctopusDeploy/OctopusDeploy/pull/6444 is merged