### PR TITLE
Add package reference when creating package action

### DIFF
--- a/source/Octopus.Client/Model/DeploymentStepResource.cs
+++ b/source/Octopus.Client/Model/DeploymentStepResource.cs
@@ -169,6 +169,13 @@ namespace Octopus.Client.Model
         public DeploymentActionResource AddOrUpdatePackageAction(string name, PackageResource package)
         {
             var action = AddOrUpdateAction(name);
+            var packageReference = new PackageReference
+            {
+                FeedId = package.FeedId,
+                PackageId = package.PackageId
+            };
+            action.Packages.Clear();
+            action.Packages.Add(packageReference);
 
             action.ActionType = "Octopus.TentaclePackage";
             action.Properties["Octopus.Action.Package.PackageId"] = package.PackageId;


### PR DESCRIPTION
There is a helper method in Octopus client to add a package action to a step. The action configuration in that method is outdated, relying on some poly filling on the Octopus Server to configure the step correctly. This PR adds a package reference to the action configuration, which will configure the action correctly without poly filling on the Octopus Server.