### PR TITLE
Support compression

### DIFF
--- a/source/Octopus.Client.Tests/Integration/OctopusClient/CompressionTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/CompressionTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nancy;
+using NUnit.Framework;
+
+namespace Octopus.Client.Tests.Integration.OctopusClient
+{
+    public class CompressionTests : HttpIntegrationTestBase
+    {
+        private static readonly string[] ExpectedValues = { "deflate", "gzip" };
+        
+        public CompressionTests()
+            : base(UrlPathPrefixBehaviour.UseClassNameAsUrlPathPrefix)
+        {
+            Get(TestRootPath, p =>
+            {
+                var acceptEncoding = Request.Headers.AcceptEncoding;
+
+                return Response.AsJson(new TestDto { AcceptEncoding = acceptEncoding })
+                    .WithStatusCode(HttpStatusCode.OK);
+            });
+        }
+
+        [Test]
+        public async Task AsyncClient_ShouldProvideAcceptEncoding()
+        {
+            var response = await AsyncClient.Get<TestDto>(TestRootPath);
+            response.AcceptEncoding.Should().Contain(ExpectedValues);
+        }
+
+        [Test]
+        public void SyncClient_ShouldProvideAcceptEncoding()
+        {
+            var client = new Client.OctopusClient(new OctopusServerEndpoint(HostBaseUri + TestRootPath));
+            var response = client.Get<TestDto>(TestRootPath);
+            response.AcceptEncoding.Should().Contain(ExpectedValues);
+        }
+
+        private class TestDto
+        {
+            public IEnumerable<string> AcceptEncoding { get; set; }
+        }
+    }
+}

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -46,6 +46,11 @@ namespace Octopus.Client
                 Credentials = serverEndpoint.Credentials ?? CredentialCache.DefaultNetworkCredentials,
             };
 
+            if (handler.SupportsAutomaticDecompression)
+            {
+                handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+            }
+
             if (clientOptions.Proxy != null)
             {
                 handler.UseProxy = true;

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -420,6 +420,7 @@ namespace Octopus.Client
             webRequest.Method = request.Method;
             webRequest.Headers[ApiConstants.ApiKeyHttpHeaderName] = serverEndpoint.ApiKey;
             webRequest.UserAgent = octopusCustomHeaders.UserAgent;
+            webRequest.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
 
             if (webRequest.Method == "PUT")
             {


### PR DESCRIPTION
# Background

The client library doesn't take advantage of compression features of HTTP by sending the `Accept-Encoding` header. This PR sets the `AutomaticDecompression` option, which will handle setting the appropriate header and performing the decompression of the result stream automatically.