### PR TITLE
Add git reference properties to Release resource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4129,6 +4129,8 @@ Octopus.Client.Model
     DateTimeOffset Assembled { get; set; }
     List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }
+    String GitCommit { get; set; }
+    String GitRef { get; set; }
     Boolean IgnoreChannelRules { get; set; }
     List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2923,6 +2923,12 @@ Octopus.Client.Model
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Username { get; set; }
   }
+  GitRefType
+  {
+      Branch = 0
+      Tag = 1
+      Commit = 2
+  }
   GuidedFailureMode
   {
       EnvironmentDefault = 0
@@ -4131,6 +4137,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String GitCommit { get; set; }
     String GitRef { get; set; }
+    Octopus.Client.Model.GitRefType GitRefType { get; set; }
     Boolean IgnoreChannelRules { get; set; }
     List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4148,6 +4148,8 @@ Octopus.Client.Model
     DateTimeOffset Assembled { get; set; }
     List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }
+    String GitCommit { get; set; }
+    String GitRef { get; set; }
     Boolean IgnoreChannelRules { get; set; }
     List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2939,6 +2939,12 @@ Octopus.Client.Model
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Username { get; set; }
   }
+  GitRefType
+  {
+      Branch = 0
+      Tag = 1
+      Commit = 2
+  }
   GuidedFailureMode
   {
       EnvironmentDefault = 0
@@ -4150,6 +4156,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String GitCommit { get; set; }
     String GitRef { get; set; }
+    Octopus.Client.Model.GitRefType GitRefType { get; set; }
     Boolean IgnoreChannelRules { get; set; }
     List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }

--- a/source/Octopus.Client/Model/GitRefType.cs
+++ b/source/Octopus.Client/Model/GitRefType.cs
@@ -1,0 +1,9 @@
+namespace Octopus.Client.Model
+{
+    public enum GitRefType
+    {
+        Branch,
+        Tag,
+        Commit
+    }
+}

--- a/source/Octopus.Client/Model/ReleaseResource.cs
+++ b/source/Octopus.Client/Model/ReleaseResource.cs
@@ -72,9 +72,11 @@ namespace Octopus.Client.Model
 
         public List<SelectedPackage> SelectedPackages { get; set; }
 
-        public string GitCommit { get; set; }
+        public GitRefType GitRefType { get; set; }
 
         public string GitRef { get; set; }
+
+        public string GitCommit { get; set; }
         public string SpaceId { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/ReleaseResource.cs
+++ b/source/Octopus.Client/Model/ReleaseResource.cs
@@ -72,6 +72,9 @@ namespace Octopus.Client.Model
 
         public List<SelectedPackage> SelectedPackages { get; set; }
 
+        public string GitCommit { get; set; }
+
+        public string GitRef { get; set; }
         public string SpaceId { get; set; }
     }
 }


### PR DESCRIPTION
Adding VCS properties on Release resource

Related https://octopusdeploy.slack.com/archives/C01AJE4K3T2/p1600657024020300 - We should be adding `Experimental` or `EarlyAccessFeature` attributes to properties like this, however this can b done in a later PR