### PR TITLE
Remove GitRefType on Release resource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2923,12 +2923,6 @@ Octopus.Client.Model
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Username { get; set; }
   }
-  GitRefType
-  {
-      Branch = 0
-      Tag = 1
-      Commit = 2
-  }
   GuidedFailureMode
   {
       EnvironmentDefault = 0
@@ -4137,7 +4131,6 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String GitCommit { get; set; }
     String GitRef { get; set; }
-    Octopus.Client.Model.GitRefType GitRefType { get; set; }
     Boolean IgnoreChannelRules { get; set; }
     List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2939,12 +2939,6 @@ Octopus.Client.Model
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Username { get; set; }
   }
-  GitRefType
-  {
-      Branch = 0
-      Tag = 1
-      Commit = 2
-  }
   GuidedFailureMode
   {
       EnvironmentDefault = 0
@@ -4156,7 +4150,6 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String GitCommit { get; set; }
     String GitRef { get; set; }
-    Octopus.Client.Model.GitRefType GitRefType { get; set; }
     Boolean IgnoreChannelRules { get; set; }
     List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }

--- a/source/Octopus.Client/Model/GitRefType.cs
+++ b/source/Octopus.Client/Model/GitRefType.cs
@@ -1,9 +1,0 @@
-namespace Octopus.Client.Model
-{
-    public enum GitRefType
-    {
-        Branch,
-        Tag,
-        Commit
-    }
-}

--- a/source/Octopus.Client/Model/ReleaseResource.cs
+++ b/source/Octopus.Client/Model/ReleaseResource.cs
@@ -72,11 +72,10 @@ namespace Octopus.Client.Model
 
         public List<SelectedPackage> SelectedPackages { get; set; }
 
-        public GitRefType GitRefType { get; set; }
-
         public string GitRef { get; set; }
 
         public string GitCommit { get; set; }
+
         public string SpaceId { get; set; }
     }
 }


### PR DESCRIPTION
Removing the GitRefType on the release resource. 

If the consumer wants to release from a tag called 1.0.0, but they also have a branch called 1.0.0, we expect a full name - refs/tags/1.0.0. Otherwise we use the branch 1.0.0

we will always assume a GitRef value is a branch, if a full ref hasn't been provided

main - branch
1.0.0 - branch
refs/heads/main - branch
refs/heads/1.0.0 - branch
refs/tags/main - tag
refs/tags/refs/heads/main - tag
refs/tags/1.0.0 - tag
