### PR TITLE
combine 2 related git properties on release to 1 type

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4138,7 +4138,7 @@ Octopus.Client.Model
     List<SelectedPackage> SelectedPackages { get; set; }
     String SpaceId { get; set; }
     String Version { get; set; }
-    Octopus.Client.Model.VersionControl.VersionControlReference VersionControlReference { get; set; }
+    Octopus.Client.Model.VersionControl.VersionControlReferenceResource VersionControlReferenceResource { get; set; }
   }
   class ReleaseSummaryResource
     Octopus.Client.Extensibility.IResource
@@ -6338,7 +6338,7 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
 }
 Octopus.Client.Model.VersionControl
 {
-  class VersionControlReference
+  class VersionControlReferenceResource
   {
     .ctor()
     String GitCommit { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4129,8 +4129,6 @@ Octopus.Client.Model
     DateTimeOffset Assembled { get; set; }
     List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }
-    String GitCommit { get; set; }
-    String GitRef { get; set; }
     Boolean IgnoreChannelRules { get; set; }
     List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }
@@ -4140,6 +4138,7 @@ Octopus.Client.Model
     List<SelectedPackage> SelectedPackages { get; set; }
     String SpaceId { get; set; }
     String Version { get; set; }
+    Octopus.Client.Model.VersionControl.VersionControlReference VersionControlReference { get; set; }
   }
   class ReleaseSummaryResource
     Octopus.Client.Extensibility.IResource
@@ -6335,6 +6334,15 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.TriggerFilterResource
   {
     String Timezone { get; set; }
+  }
+}
+Octopus.Client.Model.VersionControl
+{
+  class VersionControlReference
+  {
+    .ctor()
+    String GitCommit { get; set; }
+    String GitRef { get; set; }
   }
 }
 Octopus.Client.Model.Versioning

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4157,7 +4157,7 @@ Octopus.Client.Model
     List<SelectedPackage> SelectedPackages { get; set; }
     String SpaceId { get; set; }
     String Version { get; set; }
-    Octopus.Client.Model.VersionControl.VersionControlReference VersionControlReference { get; set; }
+    Octopus.Client.Model.VersionControl.VersionControlReferenceResource VersionControlReferenceResource { get; set; }
   }
   class ReleaseSummaryResource
     Octopus.Client.Extensibility.IResource
@@ -6363,7 +6363,7 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
 }
 Octopus.Client.Model.VersionControl
 {
-  class VersionControlReference
+  class VersionControlReferenceResource
   {
     .ctor()
     String GitCommit { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4148,8 +4148,6 @@ Octopus.Client.Model
     DateTimeOffset Assembled { get; set; }
     List<ReleasePackageVersionBuildInformationResource> BuildInformation { get; set; }
     String ChannelId { get; set; }
-    String GitCommit { get; set; }
-    String GitRef { get; set; }
     Boolean IgnoreChannelRules { get; set; }
     List<String> LibraryVariableSetSnapshotIds { get; set; }
     String ProjectDeploymentProcessSnapshotId { get; set; }
@@ -4159,6 +4157,7 @@ Octopus.Client.Model
     List<SelectedPackage> SelectedPackages { get; set; }
     String SpaceId { get; set; }
     String Version { get; set; }
+    Octopus.Client.Model.VersionControl.VersionControlReference VersionControlReference { get; set; }
   }
   class ReleaseSummaryResource
     Octopus.Client.Extensibility.IResource
@@ -6360,6 +6359,15 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.TriggerFilterResource
   {
     String Timezone { get; set; }
+  }
+}
+Octopus.Client.Model.VersionControl
+{
+  class VersionControlReference
+  {
+    .ctor()
+    String GitCommit { get; set; }
+    String GitRef { get; set; }
   }
 }
 Octopus.Client.Model.Versioning

--- a/source/Octopus.Client/Model/ReleaseResource.cs
+++ b/source/Octopus.Client/Model/ReleaseResource.cs
@@ -5,6 +5,7 @@ using Octopus.Client.Extensibility.Attributes;
 using Newtonsoft.Json;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Model.BuildInformation;
+using Octopus.Client.Model.VersionControl;
 
 namespace Octopus.Client.Model
 {
@@ -72,10 +73,8 @@ namespace Octopus.Client.Model
 
         public List<SelectedPackage> SelectedPackages { get; set; }
 
-        public string GitRef { get; set; }
-
-        public string GitCommit { get; set; }
-
+        public VersionControlReferenceResource VersionControlReferenceResource { get; set; }
+        
         public string SpaceId { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/VersionControl/VersionControlReferenceResource.cs
+++ b/source/Octopus.Client/Model/VersionControl/VersionControlReferenceResource.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.VersionControl
+{
+    public class VersionControlReferenceResource
+    {
+        [WriteableOnCreate]
+        public string GitRef { get; set; }
+        public string GitCommit { get; set; }
+    }
+}


### PR DESCRIPTION
Combining the GitRef and GitCommit to 1 type, where the GitCommit is readonly and GitRef is only writeable on create.