### PR TITLE
Allow `Delete` calls to include a resource.

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -67,8 +67,7 @@ Octopus.Client
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
-    void Delete(String, Object)
-    void DeleteWithResource(String, Octopus.Client.TResource, Object)
+    void Delete(String, Object, Object)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
     Octopus.Client.TResource Get(String, Object)
@@ -380,8 +379,7 @@ Octopus.Client
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
-    void Delete(String, Object)
-    void DeleteWithResource(String, Octopus.Client.TResource, Object)
+    void Delete(String, Object, Object)
     void Dispose()
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -68,6 +68,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
+    void Delete(String, Octopus.Client.TResource, Object)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
     Octopus.Client.TResource Get(String, Object)
@@ -380,6 +381,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
+    void Delete(String, Octopus.Client.TResource, Object)
     void Dispose()
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -68,7 +68,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
-    void Delete(String, Octopus.Client.TResource, Object)
+    void DeleteWithResource(String, Octopus.Client.TResource, Object)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
     Octopus.Client.TResource Get(String, Object)
@@ -381,7 +381,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
-    void Delete(String, Octopus.Client.TResource, Object)
+    void DeleteWithResource(String, Octopus.Client.TResource, Object)
     void Dispose()
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -31,7 +31,7 @@ Octopus.Client
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
-    Task Delete(String, Object)
+    Task Delete(String, Object, Object)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
     Task<TResource> Get(String, Object)
@@ -268,7 +268,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
-    Task Delete(String, Object)
+    Task Delete(String, Object, Object)
     void Dispose()
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -67,8 +67,7 @@ Octopus.Client
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
-    void Delete(String, Object)
-    void DeleteWithResource(String, Octopus.Client.TResource, Object)
+    void Delete(String, Object, Object)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
     Octopus.Client.TResource Get(String, Object)
@@ -380,8 +379,7 @@ Octopus.Client
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
-    void Delete(String, Object)
-    void DeleteWithResource(String, Octopus.Client.TResource, Object)
+    void Delete(String, Object, Object)
     void Dispose()
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -68,6 +68,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
+    void Delete(String, Octopus.Client.TResource, Object)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
     Octopus.Client.TResource Get(String, Object)
@@ -380,6 +381,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
+    void Delete(String, Octopus.Client.TResource, Object)
     void Dispose()
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -68,7 +68,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
-    void Delete(String, Octopus.Client.TResource, Object)
+    void DeleteWithResource(String, Octopus.Client.TResource, Object)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
     Octopus.Client.TResource Get(String, Object)
@@ -381,7 +381,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
     void Delete(String, Object)
-    void Delete(String, Octopus.Client.TResource, Object)
+    void DeleteWithResource(String, Octopus.Client.TResource, Object)
     void Dispose()
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -31,7 +31,7 @@ Octopus.Client
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
-    Task Delete(String, Object)
+    Task Delete(String, Object, Object)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
     Task<TResource> Get(String, Object)
@@ -268,7 +268,7 @@ Octopus.Client
     Octopus.Client.Model.RootResource RootDocument { get; }
     static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Task<TResource> Create(String, Octopus.Client.TResource, Object)
-    Task Delete(String, Object)
+    Task Delete(String, Object, Object)
     void Dispose()
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()

--- a/source/Octopus.Client/IOctopusAsyncClient.cs
+++ b/source/Octopus.Client/IOctopusAsyncClient.cs
@@ -326,8 +326,9 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the resource to delete.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <param name="resource">An optional resource to pass as the body of the request.</param>
         /// <returns>A task resource that provides details about the background task that deletes the specified resource.</returns>
-        Task Delete(string path, object pathParameters = null);
+        Task Delete(string path, object pathParameters = null, object resource = null);
 
         /// <summary>
         /// Fetches raw content from the resource at the specified path, using the GET verb.

--- a/source/Octopus.Client/IOctopusClient.cs
+++ b/source/Octopus.Client/IOctopusClient.cs
@@ -328,7 +328,7 @@ namespace Octopus.Client
         /// <param name="resource">The body of the request.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <returns>A task resource that provides details about the background task that deletes the specified resource.</returns>
-        void Delete<TResource>(string path, TResource resource, object pathParameters = null);
+        void DeleteWithResource<TResource>(string path, TResource resource, object pathParameters = null);
 
         /// <summary>
         /// Fetches raw content from the resource at the specified path, using the GET verb.

--- a/source/Octopus.Client/IOctopusClient.cs
+++ b/source/Octopus.Client/IOctopusClient.cs
@@ -312,6 +312,25 @@ namespace Octopus.Client
         void Delete(string path, object pathParameters = null);
 
         /// <summary>
+        /// Deletes the resource at the given URI from the server using a the DELETE verb.
+        /// </summary>
+        /// <exception cref="OctopusSecurityException">
+        /// HTTP 401 or 403: Thrown when the current user's API key was not valid, their
+        /// account is disabled, or they don't have permission to perform the specified action.
+        /// </exception>
+        /// <exception cref="OctopusServerException">
+        /// If any other error is successfully returned from the server (e.g., a 500
+        /// server error).
+        /// </exception>
+        /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
+        /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
+        /// <param name="path">The path to the resource to delete.</param>
+        /// <param name="resource">The body of the request.</param>
+        /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <returns>A task resource that provides details about the background task that deletes the specified resource.</returns>
+        void Delete<TResource>(string path, TResource resource, object pathParameters = null);
+
+        /// <summary>
         /// Fetches raw content from the resource at the specified path, using the GET verb.
         /// </summary>
         /// <exception cref="OctopusSecurityException">

--- a/source/Octopus.Client/IOctopusClient.cs
+++ b/source/Octopus.Client/IOctopusClient.cs
@@ -308,27 +308,9 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the resource to delete.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <param name="resource">An optional resource to pass as the body of the request.</param>
         /// <returns>A task resource that provides details about the background task that deletes the specified resource.</returns>
-        void Delete(string path, object pathParameters = null);
-
-        /// <summary>
-        /// Deletes the resource at the given URI from the server using a the DELETE verb.
-        /// </summary>
-        /// <exception cref="OctopusSecurityException">
-        /// HTTP 401 or 403: Thrown when the current user's API key was not valid, their
-        /// account is disabled, or they don't have permission to perform the specified action.
-        /// </exception>
-        /// <exception cref="OctopusServerException">
-        /// If any other error is successfully returned from the server (e.g., a 500
-        /// server error).
-        /// </exception>
-        /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
-        /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
-        /// <param name="path">The path to the resource to delete.</param>
-        /// <param name="resource">The body of the request.</param>
-        /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
-        /// <returns>A task resource that provides details about the background task that deletes the specified resource.</returns>
-        void DeleteWithResource<TResource>(string path, TResource resource, object pathParameters = null);
+        void Delete(string path, object pathParameters = null, object resource = null);
 
         /// <summary>
         /// Fetches raw content from the resource at the specified path, using the GET verb.

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -430,11 +430,12 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// </summary>
         /// <param name="path">The path to the resource to delete.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
-        public Task Delete(string path, object pathParameters = null)
+        /// <param name="resource">An optional resource to pass as the body of the request.</param>
+        public Task Delete(string path, object pathParameters = null, object resource = null)
         {
             var uri = QualifyUri(path, pathParameters);
 
-            return DispatchRequest<string>(new OctopusRequest("DELETE", uri), true);
+            return DispatchRequest<string>(new OctopusRequest("DELETE", uri, resource), true);
         }
 
         /// <summary>

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -343,6 +343,19 @@ namespace Octopus.Client
         }
 
         /// <summary>
+        /// Deletes the resource at the given URI from the server using a the DELETE verb.
+        /// </summary>
+        /// <param name="path">The path to the resource to delete.</param>
+        /// <param name="resource">The body of the request.</param>
+        /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        public void Delete<TResource>(string path, TResource resource, object pathParameters = null)
+        {
+            var uri = QualifyUri(path, pathParameters);
+
+            DispatchRequest<string>(new OctopusRequest("DELETE", uri, resource), true);
+        }
+
+        /// <summary>
         /// Updates the resource at the given URI on the server using the PUT verb, then performs a fresh GET request to reload
         /// the data.
         /// </summary>

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -1,20 +1,14 @@
 using System;
-using System.Collections;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Text;
-using System.Threading;
 using Newtonsoft.Json;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
 using Octopus.Client.Serialization;
 using System.Collections.Generic;
 using System.Linq;
-using Octopus.Client.Extensibility;
-using Octopus.Client.Extensions;
 using Octopus.Client.Logging;
-using Octopus.Client.Repositories;
 
 namespace Octopus.Client
 {
@@ -348,7 +342,7 @@ namespace Octopus.Client
         /// <param name="path">The path to the resource to delete.</param>
         /// <param name="resource">The body of the request.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
-        public void Delete<TResource>(string path, TResource resource, object pathParameters = null)
+        public void DeleteWithResource<TResource>(string path, TResource resource = default, object pathParameters = null)
         {
             var uri = QualifyUri(path, pathParameters);
 

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -329,20 +329,8 @@ namespace Octopus.Client
         /// </summary>
         /// <param name="path">The path to the resource to delete.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
-        public void Delete(string path, object pathParameters = null)
-        {
-            var uri = QualifyUri(path, pathParameters);
-
-            DispatchRequest<string>(new OctopusRequest("DELETE", uri), true);
-        }
-
-        /// <summary>
-        /// Deletes the resource at the given URI from the server using a the DELETE verb.
-        /// </summary>
-        /// <param name="path">The path to the resource to delete.</param>
-        /// <param name="resource">The body of the request.</param>
-        /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
-        public void DeleteWithResource<TResource>(string path, TResource resource = default, object pathParameters = null)
+        /// <param name="resource">The resource to pass as the request body, if supplied.</param>
+        public void Delete(string path, object pathParameters = null, object resource = null)
         {
             var uri = QualifyUri(path, pathParameters);
 


### PR DESCRIPTION
This PR adds a way to call `Delete` with a resource as the body of the request. This is required for config-as-code runbooks, where we want to allow a user to supply a commit message (via the request body) when deleting a runbook.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE