### PR TITLE
Add cancellation token parameter to async methods

### DIFF
--- a/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -109,7 +110,7 @@ namespace Octopus.Client.Tests.Operations
             await client.Received().Create("/api/machines", Arg.Is<MachineResource>(m =>
                 m.Name == "Mymachine"
                 && ((ListeningTentacleEndpointResource)m.Endpoint).Uri == "https://mymachine.test.com:10930/"
-                && m.EnvironmentIds.First() == "environments-2"))
+                && m.EnvironmentIds.First() == "environments-2"), Arg.Any<object>(), Arg.Is(default(CancellationToken)))
                 .ConfigureAwait(false);
         }
 
@@ -153,7 +154,7 @@ namespace Octopus.Client.Tests.Operations
             await client.Received().Update("/machines/whatever/1", Arg.Is<MachineResource>(m =>
                 m.Id == "machines/84"
                 && m.Name == "Mymachine"
-                && m.EnvironmentIds.First() == "environments-2")).ConfigureAwait(false);
+                && m.EnvironmentIds.First() == "environments-2"), Arg.Any<object>(), Arg.Is(default(CancellationToken))).ConfigureAwait(false);
         }
 
         [Test]
@@ -177,7 +178,7 @@ namespace Octopus.Client.Tests.Operations
             await client.Received().Create("/api/machines", Arg.Is<MachineResource>(m =>
                 m.Name == "Mymachine"
                 && ((ListeningTentacleEndpointResource)m.Endpoint).Uri == "https://mymachine.test.com:10930/"
-                && m.EnvironmentIds.First() == "environments-2")).ConfigureAwait(false);
+                && m.EnvironmentIds.First() == "environments-2"), Arg.Any<object>(), Arg.Is(default(CancellationToken))).ConfigureAwait(false);
         }
 
         [Test]
@@ -202,7 +203,7 @@ namespace Octopus.Client.Tests.Operations
                 m.Id == "machines/84"
                 && m.Name == "Mymachine"
                 && m.EnvironmentIds.First() == "environments-2"
-                && m.MachinePolicyId == "MachinePolicies-1")).ConfigureAwait(false);
+                && m.MachinePolicyId == "MachinePolicies-1"), Arg.Any<object>(), Arg.Is(default(CancellationToken))).ConfigureAwait(false);
         }
 
         [Test]
@@ -228,7 +229,7 @@ namespace Octopus.Client.Tests.Operations
                 m.Id == "machines/84"
                 && m.Name == "Mymachine"
                 && m.EnvironmentIds.First() == "environments-2"
-                && m.MachinePolicyId == "MachinePolicies-2")).ConfigureAwait(false);
+                && m.MachinePolicyId == "MachinePolicies-2"), Arg.Any<object>(), Arg.Is(default(CancellationToken))).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -30,27 +30,26 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Task<TResource> Create(String, Octopus.Client.TResource, Object)
-    Task Delete(String, Object, Object)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task Delete(String, Object, Object, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object)
-    Task<Stream> GetContent(String, Object)
-    Task<ResourceCollection<TResource>> List(String, Object)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object)
-    Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
-    Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
-    Task Post(String, Octopus.Client.TResource, Object)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
-    Task Post(String)
-    Task Put(String, Octopus.Client.TResource)
-    Task Put(String)
-    Task Put(String, Octopus.Client.TResource, Object)
-    Task PutContent(String, Stream)
+    Task<TResource> Get(String, Object, CancellationToken)
+    Task<Stream> GetContent(String, Object, CancellationToken)
+    Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
+    Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task Post(String, CancellationToken)
+    Task Put(String, CancellationToken)
+    Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task PutContent(String, Stream, CancellationToken)
     Uri QualifyUri(String, Object)
-    Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignOut()
-    Task<TResource> Update(String, Octopus.Client.TResource, Object)
+    Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
+    Task SignOut(CancellationToken)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
   interface IOctopusAsyncRepository
     Octopus.Client.IOctopusSpaceAsyncRepository
@@ -269,28 +268,27 @@ Octopus.Client
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
     static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
-    Task<TResource> Create(String, Octopus.Client.TResource, Object)
-    Task Delete(String, Object, Object)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task Delete(String, Object, Object, CancellationToken)
     void Dispose()
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object)
-    Task<Stream> GetContent(String, Object)
-    Task<ResourceCollection<TResource>> List(String, Object)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object)
-    Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
-    Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
-    Task Post(String, Octopus.Client.TResource, Object)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
-    Task Post(String)
-    Task Put(String, Octopus.Client.TResource)
-    Task Put(String)
-    Task Put(String, Octopus.Client.TResource, Object)
-    Task PutContent(String, Stream)
+    Task<TResource> Get(String, Object, CancellationToken)
+    Task<Stream> GetContent(String, Object, CancellationToken)
+    Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
+    Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task Post(String, CancellationToken)
+    Task Put(String, CancellationToken)
+    Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task PutContent(String, Stream, CancellationToken)
     Uri QualifyUri(String, Object)
-    Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignOut()
-    Task<TResource> Update(String, Octopus.Client.TResource, Object)
+    Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
+    Task SignOut(CancellationToken)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
   class OctopusAsyncRepository
     Octopus.Client.IOctopusAsyncRepository
@@ -966,11 +964,11 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IAccountRepository)
     Octopus.Client.Editors.Async.TAccountResource Instance { get; }
-    Task<TAccountEditor> CreateOrModify(String)
+    Task<TAccountEditor> CreateOrModify(String, CancellationToken)
     Octopus.Client.Editors.Async.TAccountEditor Customize(Action<TAccountResource>)
-    Task<TAccountEditor> FindByName(String)
-    Task<TAccountEditor> Save()
-    Task<AccountUsageResource> Usages()
+    Task<TAccountEditor> FindByName(String, CancellationToken)
+    Task<TAccountEditor> Save(CancellationToken)
+    Task<AccountUsageResource> Usages(CancellationToken)
   }
   class AmazonWebServicesAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<AmazonWebServicesAccountResource, AmazonWebServicesAccountEditor>
@@ -985,10 +983,10 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.AccountEditor<AzureServicePrincipalAccountResource, AzureServicePrincipalAccountEditor>
   {
     .ctor(Octopus.Client.Repositories.Async.IAccountRepository)
-    Task<List<ResourceGroup>> ResourceGroups()
-    Task<List<AzureStorageAccount>> StorageAccounts()
-    Task<List<WebSite>> WebSites()
-    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.WebSite)
+    Task<List<ResourceGroup>> ResourceGroups(CancellationToken)
+    Task<List<AzureStorageAccount>> StorageAccounts(CancellationToken)
+    Task<List<WebSite>> WebSites(CancellationToken)
+    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.WebSite, CancellationToken)
   }
   class AzureSubscriptionAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<AzureSubscriptionAccountResource, AzureSubscriptionAccountEditor>
@@ -996,11 +994,11 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.AccountEditor<AzureSubscriptionAccountResource, AzureSubscriptionAccountEditor>
   {
     .ctor(Octopus.Client.Repositories.Async.IAccountRepository)
-    Task<List<AzureStorageAccount>> StorageAccounts(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource)
-    Task<List<WebSite>> WebSites(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource)
-    Task<List<WebSite>> WebSites()
-    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource, Octopus.Client.Model.Accounts.WebSite)
-    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.WebSite)
+    Task<List<AzureStorageAccount>> StorageAccounts(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource, CancellationToken)
+    Task<List<WebSite>> WebSites(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource, CancellationToken)
+    Task<List<WebSite>> WebSites(CancellationToken)
+    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource, Octopus.Client.Model.Accounts.WebSite, CancellationToken)
+    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.WebSite, CancellationToken)
   }
   class CertificateEditor
     Octopus.Client.Editors.Async.IResourceEditor<CertificateResource, CertificateEditor>
@@ -1008,11 +1006,11 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.ICertificateRepository)
     Octopus.Client.Model.CertificateResource Instance { get; }
-    Task<CertificateEditor> Create(String, String)
+    Task<CertificateEditor> Create(String, String, CancellationToken)
     Octopus.Client.Editors.Async.CertificateEditor Customize(Action<CertificateResource>)
-    Task<CertificateEditor> FindByName(String)
-    Task<CertificateEditor> Save()
-    Task<CertificateUsageResource> Usages()
+    Task<CertificateEditor> FindByName(String, CancellationToken)
+    Task<CertificateEditor> Save(CancellationToken)
+    Task<CertificateUsageResource> Usages(CancellationToken)
   }
   class ChannelEditor
     Octopus.Client.Editors.Async.IResourceEditor<ChannelResource, ChannelEditor>
@@ -1026,10 +1024,10 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.ChannelEditor AddRule(String, String, Octopus.Client.Model.DeploymentActionResource[])
     Octopus.Client.Editors.Async.ChannelEditor ClearRules()
     Octopus.Client.Editors.Async.ChannelEditor ClearTenantTags()
-    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String)
-    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
+    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.ChannelEditor Customize(Action<ChannelResource>)
-    Task<ChannelEditor> Save()
+    Task<ChannelEditor> Save(CancellationToken)
     Octopus.Client.Editors.Async.ChannelEditor SetAsDefaultChannel()
     Octopus.Client.Editors.Async.ChannelEditor UsingLifecycle(Octopus.Client.Model.LifecycleResource)
   }
@@ -1043,9 +1041,9 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.DeploymentProcessEditor ClearSteps()
     Octopus.Client.Editors.Async.DeploymentProcessEditor Customize(Action<DeploymentProcessResource>)
     Octopus.Client.Model.DeploymentStepResource FindStep(String)
-    Task<DeploymentProcessEditor> Load(String)
+    Task<DeploymentProcessEditor> Load(String, CancellationToken)
     Octopus.Client.Editors.Async.DeploymentProcessEditor RemoveStep(String)
-    Task<DeploymentProcessEditor> Save()
+    Task<DeploymentProcessEditor> Save(CancellationToken)
   }
   class EnvironmentEditor
     Octopus.Client.Editors.Async.IResourceEditor<EnvironmentResource, EnvironmentEditor>
@@ -1053,11 +1051,11 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IEnvironmentRepository)
     Octopus.Client.Model.EnvironmentResource Instance { get; }
-    Task<EnvironmentEditor> CreateOrModify(String)
-    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
-    Task<EnvironmentEditor> CreateOrModify(String, String)
+    Task<EnvironmentEditor> CreateOrModify(String, CancellationToken)
+    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean, CancellationToken)
+    Task<EnvironmentEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.EnvironmentEditor Customize(Action<EnvironmentResource>)
-    Task<EnvironmentEditor> Save()
+    Task<EnvironmentEditor> Save(CancellationToken)
   }
   interface IResourceBuilder
   {
@@ -1067,7 +1065,7 @@ Octopus.Client.Editors.Async
   {
     Octopus.Client.Editors.Async.TResource Instance { get; }
     Octopus.Client.Editors.Async.TResourceBuilder Customize(Action<TResource>)
-    Task<TResourceBuilder> Save()
+    Task<TResourceBuilder> Save(CancellationToken)
   }
   class LibraryVariableSetEditor
     Octopus.Client.Editors.Async.IResourceEditor<LibraryVariableSetResource, LibraryVariableSetEditor>
@@ -1077,10 +1075,10 @@ Octopus.Client.Editors.Async
     Octopus.Client.Model.LibraryVariableSetResource Instance { get; }
     Task<VariableSetEditor> Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<LibraryVariableSetResource> VariableTemplates { get; }
-    Task<LibraryVariableSetEditor> CreateOrModify(String)
-    Task<LibraryVariableSetEditor> CreateOrModify(String, String)
+    Task<LibraryVariableSetEditor> CreateOrModify(String, CancellationToken)
+    Task<LibraryVariableSetEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.LibraryVariableSetEditor Customize(Action<LibraryVariableSetResource>)
-    Task<LibraryVariableSetEditor> Save()
+    Task<LibraryVariableSetEditor> Save(CancellationToken)
   }
   class LifecycleEditor
     Octopus.Client.Editors.Async.IResourceEditor<LifecycleResource, LifecycleEditor>
@@ -1091,10 +1089,10 @@ Octopus.Client.Editors.Async
     Octopus.Client.Model.PhaseResource AddOrUpdatePhase(String)
     Octopus.Client.Editors.Async.LifecycleEditor AsSimplePromotionLifecycle(IEnumerable<EnvironmentResource>)
     Octopus.Client.Editors.Async.LifecycleEditor Clear()
-    Task<LifecycleEditor> CreateOrModify(String)
-    Task<LifecycleEditor> CreateOrModify(String, String)
+    Task<LifecycleEditor> CreateOrModify(String, CancellationToken)
+    Task<LifecycleEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.LifecycleEditor Customize(Action<LifecycleResource>)
-    Task<LifecycleEditor> Save()
+    Task<LifecycleEditor> Save(CancellationToken)
   }
   class MachineEditor
     Octopus.Client.Editors.Async.IResourceEditor<MachineResource, MachineEditor>
@@ -1102,18 +1100,18 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], CancellationToken)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>, CancellationToken)
     Octopus.Client.Editors.Async.MachineEditor Customize(Action<MachineResource>)
-    Task<MachineEditor> Save()
+    Task<MachineEditor> Save(CancellationToken)
   }
   class ProjectChannelsEditor
   {
     .ctor(Octopus.Client.Repositories.Async.IChannelRepository, Octopus.Client.Model.ProjectResource)
-    Task<ChannelEditor> CreateOrModify(String)
-    Task<ChannelEditor> CreateOrModify(String, String)
-    Task<ProjectChannelsEditor> Delete(String)
-    Task<ProjectChannelsEditor> SaveAll()
+    Task<ChannelEditor> CreateOrModify(String, CancellationToken)
+    Task<ChannelEditor> CreateOrModify(String, String, CancellationToken)
+    Task<ProjectChannelsEditor> Delete(String, CancellationToken)
+    Task<ProjectChannelsEditor> SaveAll(CancellationToken)
   }
   class ProjectEditor
     Octopus.Client.Editors.Async.IResourceEditor<ProjectResource, ProjectEditor>
@@ -1126,12 +1124,12 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.ProjectTriggersEditor Triggers { get; }
     Task<VariableSetEditor> Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, CancellationToken)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.ProjectEditor Customize(Action<ProjectResource>)
     Octopus.Client.Editors.Async.ProjectEditor IncludingLibraryVariableSets(Octopus.Client.Model.LibraryVariableSetResource[])
-    Task<ProjectEditor> Save()
-    Task<ProjectEditor> SetLogo(String)
+    Task<ProjectEditor> Save(CancellationToken)
+    Task<ProjectEditor> SetLogo(String, CancellationToken)
   }
   class ProjectGroupEditor
     Octopus.Client.Editors.Async.IResourceEditor<ProjectGroupResource, ProjectGroupEditor>
@@ -1139,10 +1137,10 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IProjectGroupRepository)
     Octopus.Client.Model.ProjectGroupResource Instance { get; }
-    Task<ProjectGroupEditor> CreateOrModify(String)
-    Task<ProjectGroupEditor> CreateOrModify(String, String)
+    Task<ProjectGroupEditor> CreateOrModify(String, CancellationToken)
+    Task<ProjectGroupEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.ProjectGroupEditor Customize(Action<ProjectGroupResource>)
-    Task<ProjectGroupEditor> Save()
+    Task<ProjectGroupEditor> Save(CancellationToken)
   }
   class ProjectTriggerEditor
     Octopus.Client.Editors.Async.IResourceEditor<ProjectTriggerResource, ProjectTriggerEditor>
@@ -1150,16 +1148,16 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IProjectTriggerRepository)
     Octopus.Client.Model.ProjectTriggerResource Instance { get; }
-    Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
+    Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource, CancellationToken)
     Octopus.Client.Editors.Async.ProjectTriggerEditor Customize(Action<ProjectTriggerResource>)
-    Task<ProjectTriggerEditor> Save()
+    Task<ProjectTriggerEditor> Save(CancellationToken)
   }
   class ProjectTriggersEditor
   {
     .ctor(Octopus.Client.Repositories.Async.IProjectTriggerRepository, Octopus.Client.Model.ProjectResource)
-    Task<ProjectTriggerEditor> CreateOrModify(String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
-    Task<ProjectTriggersEditor> Delete(String)
-    Task<ProjectTriggersEditor> SaveAll()
+    Task<ProjectTriggerEditor> CreateOrModify(String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource, CancellationToken)
+    Task<ProjectTriggersEditor> Delete(String, CancellationToken)
+    Task<ProjectTriggersEditor> SaveAll(CancellationToken)
   }
   class RunbookEditor
     Octopus.Client.Editors.Async.IResourceEditor<RunbookResource, RunbookEditor>
@@ -1168,10 +1166,10 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IRunbookRepository, Octopus.Client.Repositories.Async.IRunbookProcessRepository)
     Octopus.Client.Model.RunbookResource Instance { get; }
     Task<RunbookProcessEditor> RunbookProcess { get; }
-    Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
+    Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.RunbookEditor Customize(Action<RunbookResource>)
-    Task<RunbookEditor> Load(String)
-    Task<RunbookEditor> Save()
+    Task<RunbookEditor> Load(String, CancellationToken)
+    Task<RunbookEditor> Save(CancellationToken)
   }
   class RunbookProcessEditor
     Octopus.Client.Editors.Async.IResourceEditor<RunbookProcessResource, RunbookProcessEditor>
@@ -1183,9 +1181,9 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.RunbookProcessEditor ClearSteps()
     Octopus.Client.Editors.Async.RunbookProcessEditor Customize(Action<RunbookProcessResource>)
     Octopus.Client.Model.DeploymentStepResource FindStep(String)
-    Task<RunbookProcessEditor> Load(String)
+    Task<RunbookProcessEditor> Load(String, CancellationToken)
     Octopus.Client.Editors.Async.RunbookProcessEditor RemoveStep(String)
-    Task<RunbookProcessEditor> Save()
+    Task<RunbookProcessEditor> Save(CancellationToken)
   }
   class SshKeyPairAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<SshKeyPairAccountResource, SshKeyPairAccountEditor>
@@ -1200,9 +1198,9 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.ISubscriptionRepository)
     Octopus.Client.Model.SubscriptionResource Instance { get; }
-    Task<SubscriptionEditor> CreateOrModify(String, Octopus.Client.Model.EventNotificationSubscription, Boolean)
+    Task<SubscriptionEditor> CreateOrModify(String, Octopus.Client.Model.EventNotificationSubscription, Boolean, CancellationToken)
     Octopus.Client.Editors.Async.SubscriptionEditor Customize(Action<SubscriptionResource>)
-    Task<SubscriptionEditor> Save()
+    Task<SubscriptionEditor> Save(CancellationToken)
   }
   class TagSetEditor
     Octopus.Client.Editors.Async.IResourceEditor<TagSetResource, TagSetEditor>
@@ -1212,11 +1210,11 @@ Octopus.Client.Editors.Async
     Octopus.Client.Model.TagSetResource Instance { get; }
     Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String, String)
     Octopus.Client.Editors.Async.TagSetEditor ClearTags()
-    Task<TagSetEditor> CreateOrModify(String)
-    Task<TagSetEditor> CreateOrModify(String, String)
+    Task<TagSetEditor> CreateOrModify(String, CancellationToken)
+    Task<TagSetEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.TagSetEditor Customize(Action<TagSetResource>)
     Octopus.Client.Editors.Async.TagSetEditor RemoveTag(String)
-    Task<TagSetEditor> Save()
+    Task<TagSetEditor> Save(CancellationToken)
   }
   class TenantEditor
     Octopus.Client.Editors.Async.IResourceEditor<TenantResource, TenantEditor>
@@ -1228,11 +1226,11 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.TenantEditor ClearProjects()
     Octopus.Client.Editors.Async.TenantEditor ClearTags()
     Octopus.Client.Editors.Async.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
-    Task<TenantEditor> CreateOrModify(String)
-    Task<TenantEditor> CreateOrModify(String, String, String)
+    Task<TenantEditor> CreateOrModify(String, CancellationToken)
+    Task<TenantEditor> CreateOrModify(String, String, String, CancellationToken)
     Octopus.Client.Editors.Async.TenantEditor Customize(Action<TenantResource>)
-    Task<TenantEditor> Save()
-    Task<TenantEditor> SetLogo(String)
+    Task<TenantEditor> Save(CancellationToken)
+    Task<TenantEditor> SetLogo(String, CancellationToken)
     Octopus.Client.Editors.Async.TenantEditor WithTag(Octopus.Client.Model.TagResource)
   }
   class TenantVariablesEditor
@@ -1242,8 +1240,8 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.ITenantRepository, Octopus.Client.Model.TenantResource)
     Octopus.Client.Model.TenantVariableResource Instance { get; }
     Octopus.Client.Editors.Async.TenantVariablesEditor Customize(Action<TenantVariableResource>)
-    Task<TenantVariablesEditor> Load()
-    Task<TenantVariablesEditor> Save()
+    Task<TenantVariablesEditor> Load(CancellationToken)
+    Task<TenantVariablesEditor> Save(CancellationToken)
   }
   class UsernamePasswordAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<UsernamePasswordAccountResource, UsernamePasswordAccountEditor>
@@ -1264,8 +1262,8 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.VariableSetEditor AddOrUpdateVariableValue(String, String)
     Octopus.Client.Editors.Async.VariableSetEditor AddOrUpdateVariableValue(String, String, String)
     Octopus.Client.Editors.Async.VariableSetEditor Customize(Action<VariableSetResource>)
-    Task<VariableSetEditor> Load(String)
-    Task<VariableSetEditor> Save()
+    Task<VariableSetEditor> Load(String, CancellationToken)
+    Task<VariableSetEditor> Save(CancellationToken)
   }
   class VariableTemplateContainerEditor`1
   {
@@ -1287,9 +1285,9 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IWorkerRepository)
     Octopus.Client.Model.WorkerResource Instance { get; }
-    Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
+    Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[], CancellationToken)
     Octopus.Client.Editors.Async.WorkerEditor Customize(Action<WorkerResource>)
-    Task<WorkerEditor> Save()
+    Task<WorkerEditor> Save(CancellationToken)
   }
   class WorkerPoolEditor
     Octopus.Client.Editors.Async.IResourceEditor<WorkerPoolResource, WorkerPoolEditor>
@@ -1297,10 +1295,10 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IWorkerPoolRepository)
     Octopus.Client.Model.WorkerPoolResource Instance { get; }
-    Task<WorkerPoolEditor> CreateOrModify(String)
-    Task<WorkerPoolEditor> CreateOrModify(String, String)
+    Task<WorkerPoolEditor> CreateOrModify(String, CancellationToken)
+    Task<WorkerPoolEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.WorkerPoolEditor Customize(Action<WorkerPoolResource>)
-    Task<WorkerPoolEditor> Save()
+    Task<WorkerPoolEditor> Save(CancellationToken)
   }
 }
 Octopus.Client.Exceptions
@@ -6465,9 +6463,9 @@ Octopus.Client.Operations
     void Execute(Octopus.Client.OctopusServerEndpoint)
     void Execute(Octopus.Client.OctopusRepository)
     void Execute(Octopus.Client.IOctopusSpaceRepository)
-    Task ExecuteAsync(Octopus.Client.OctopusServerEndpoint)
-    Task ExecuteAsync(Octopus.Client.OctopusAsyncRepository)
-    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
+    Task ExecuteAsync(Octopus.Client.OctopusServerEndpoint, CancellationToken)
+    Task ExecuteAsync(Octopus.Client.OctopusAsyncRepository, CancellationToken)
+    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository, CancellationToken)
   }
   interface IRegisterWorkerOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -6487,7 +6485,7 @@ Octopus.Client.Operations
     String[] Tenants { get; set; }
     String[] TenantTags { get; set; }
     void Execute(Octopus.Client.IOctopusSpaceRepository)
-    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
+    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository, CancellationToken)
   }
   abstract class RegisterMachineOperationBase
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -6505,9 +6503,9 @@ Octopus.Client.Operations
     void Execute(Octopus.Client.OctopusServerEndpoint)
     void Execute(Octopus.Client.OctopusRepository)
     void Execute(Octopus.Client.IOctopusSpaceRepository)
-    Task ExecuteAsync(Octopus.Client.OctopusServerEndpoint)
-    Task ExecuteAsync(Octopus.Client.OctopusAsyncRepository)
-    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
+    Task ExecuteAsync(Octopus.Client.OctopusServerEndpoint, CancellationToken)
+    Task ExecuteAsync(Octopus.Client.OctopusAsyncRepository, CancellationToken)
+    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository, CancellationToken)
   }
   class RegisterWorkerOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -6518,7 +6516,7 @@ Octopus.Client.Operations
     .ctor(Octopus.Client.IOctopusClientFactory)
     String[] WorkerPoolNames { get; set; }
     void Execute(Octopus.Client.IOctopusSpaceRepository)
-    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
+    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository, CancellationToken)
   }
 }
 Octopus.Client.Repositories
@@ -7289,16 +7287,16 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    Task<List<TAccount>> FindAllOfType(Object)
-    Task<TAccount> FindByNameOfType(String)
-    Task<List<TAccount>> FindByNamesOfType(IEnumerable<String>)
-    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object)
-    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object)
-    Task<AccountUsageResource> GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
-    Task<TAccount> GetOfType(String)
-    Task<List<TAccount>> GetOfType(String[])
-    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
-    Task<TAccount> RefreshOfType(Octopus.Client.Repositories.Async.TAccount)
+    Task<List<TAccount>> FindAllOfType(Object, CancellationToken)
+    Task<TAccount> FindByNameOfType(String, CancellationToken)
+    Task<List<TAccount>> FindByNamesOfType(IEnumerable<String>, CancellationToken)
+    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object, CancellationToken)
+    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object, CancellationToken)
+    Task<AccountUsageResource> GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource, CancellationToken)
+    Task<TAccount> GetOfType(String, CancellationToken)
+    Task<List<TAccount>> GetOfType(CancellationToken, String[])
+    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object, CancellationToken)
+    Task<TAccount> RefreshOfType(Octopus.Client.Repositories.Async.TAccount, CancellationToken)
   }
   interface IActionTemplateRepository
     Octopus.Client.Repositories.Async.ICreate<ActionTemplateResource>
@@ -7309,10 +7307,10 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<ActionTemplateResource>
     Octopus.Client.Repositories.Async.IGetAll<ActionTemplateResource>
   {
-    Task<ActionTemplateResource> GetVersion(Octopus.Client.Model.ActionTemplateResource, Int32)
-    Task<List<ActionTemplateSearchResource>> Search()
-    Task SetLogo(Octopus.Client.Model.ActionTemplateResource, String, Stream)
-    Task<ActionUpdateResultResource[]> UpdateActions(Octopus.Client.Model.ActionTemplateResource, Octopus.Client.Model.ActionsUpdateResource)
+    Task<ActionTemplateResource> GetVersion(Octopus.Client.Model.ActionTemplateResource, Int32, CancellationToken)
+    Task<List<ActionTemplateSearchResource>> Search(CancellationToken)
+    Task SetLogo(Octopus.Client.Model.ActionTemplateResource, String, Stream, CancellationToken)
+    Task<ActionUpdateResultResource[]> UpdateActions(Octopus.Client.Model.ActionTemplateResource, Octopus.Client.Model.ActionsUpdateResource, CancellationToken)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.Async.IPaginate<ArtifactResource>
@@ -7321,14 +7319,14 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<ArtifactResource>
     Octopus.Client.Repositories.Async.IDelete<ArtifactResource>
   {
-    Task<ResourceCollection<ArtifactResource>> FindRegarding(Octopus.Client.Extensibility.IResource)
-    Task<Stream> GetContent(Octopus.Client.Model.ArtifactResource)
-    Task PutContent(Octopus.Client.Model.ArtifactResource, Stream)
+    Task<ResourceCollection<ArtifactResource>> FindRegarding(Octopus.Client.Extensibility.IResource, CancellationToken)
+    Task<Stream> GetContent(Octopus.Client.Model.ArtifactResource, CancellationToken)
+    Task PutContent(Octopus.Client.Model.ArtifactResource, Stream, CancellationToken)
   }
   interface IBackupRepository
   {
-    Task<BackupConfigurationResource> GetConfiguration()
-    Task<BackupConfigurationResource> ModifyConfiguration(Octopus.Client.Model.BackupConfigurationResource)
+    Task<BackupConfigurationResource> GetConfiguration(CancellationToken)
+    Task<BackupConfigurationResource> ModifyConfiguration(Octopus.Client.Model.BackupConfigurationResource, CancellationToken)
   }
   interface IBranchScopedRepository
   {
@@ -7336,25 +7334,25 @@ Octopus.Client.Repositories.Async
   }
   interface IBuildInformationRepository
   {
-    Task Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
-    Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
-    Task<OctopusPackageVersionBuildInformationMappedResource> Get(String)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32, Int32)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32, Int32)
-    Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
-    Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Boolean)
+    Task Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource, CancellationToken)
+    Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>, CancellationToken)
+    Task<OctopusPackageVersionBuildInformationMappedResource> Get(String, CancellationToken)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32, Int32, CancellationToken)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32, Int32, CancellationToken)
+    Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode, CancellationToken)
+    Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Boolean, CancellationToken)
   }
   interface IBuiltInPackageRepositoryRepository
   {
-    Task DeletePackage(Octopus.Client.Model.PackageResource)
-    Task DeletePackages(IReadOnlyList<PackageResource>)
-    Task<PackageFromBuiltInFeedResource> GetPackage(String, String)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
+    Task DeletePackage(Octopus.Client.Model.PackageResource, CancellationToken)
+    Task DeletePackages(IReadOnlyList<PackageResource>, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> GetPackage(String, String, CancellationToken)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32, CancellationToken)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean, CancellationToken)
   }
   interface ICanExtendSpaceContext`1
   {
@@ -7365,8 +7363,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<CertificateConfigurationResource>
     Octopus.Client.Repositories.Async.IPaginate<CertificateConfigurationResource>
   {
-    Task<CertificateConfigurationResource> GetOctopusCertificate()
-    Task<Stream> GetPublicCertificate(Octopus.Client.Model.CertificateConfigurationResource)
+    Task<CertificateConfigurationResource> GetOctopusCertificate(CancellationToken)
+    Task<Stream> GetPublicCertificate(Octopus.Client.Model.CertificateConfigurationResource, CancellationToken)
   }
   interface ICertificateRepository
     Octopus.Client.Repositories.Async.IResourceRepository
@@ -7377,12 +7375,12 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<CertificateResource>
     Octopus.Client.Repositories.Async.IDelete<CertificateResource>
   {
-    Task Archive(Octopus.Client.Model.CertificateResource)
-    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
-    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
-    Task<CertificateConfigurationResource> GetOctopusCertificate()
-    Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String)
-    Task UnArchive(Octopus.Client.Model.CertificateResource)
+    Task Archive(Octopus.Client.Model.CertificateResource, CancellationToken)
+    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean, CancellationToken)
+    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions, CancellationToken)
+    Task<CertificateConfigurationResource> GetOctopusCertificate(CancellationToken)
+    Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String, CancellationToken)
+    Task UnArchive(Octopus.Client.Model.CertificateResource, CancellationToken)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.Async.ICreate<ChannelResource>
@@ -7391,60 +7389,60 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ChannelResource>
     Octopus.Client.Repositories.Async.IPaginate<ChannelResource>
   {
-    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String)
-    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
-    Task<ChannelResource> FindByName(Octopus.Client.Model.ProjectResource, String)
-    Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ChannelResource)
-    Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ChannelResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32, Nullable<Int32>, String)
+    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
+    Task<ChannelResource> FindByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ChannelResource, CancellationToken)
+    Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ChannelResource, String, CancellationToken)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32, Nullable<Int32>, String, CancellationToken)
   }
   interface ICommunityActionTemplateRepository
     Octopus.Client.Repositories.Async.IGet<CommunityActionTemplateResource>
   {
-    Task<ActionTemplateResource> GetInstalledTemplate(Octopus.Client.Model.CommunityActionTemplateResource)
-    Task Install(Octopus.Client.Model.CommunityActionTemplateResource)
-    Task UpdateInstallation(Octopus.Client.Model.CommunityActionTemplateResource)
+    Task<ActionTemplateResource> GetInstalledTemplate(Octopus.Client.Model.CommunityActionTemplateResource, CancellationToken)
+    Task Install(Octopus.Client.Model.CommunityActionTemplateResource, CancellationToken)
+    Task UpdateInstallation(Octopus.Client.Model.CommunityActionTemplateResource, CancellationToken)
   }
   interface IConfigurationRepository
   {
-    Task<T> Get()
-    Task<T> Modify(Octopus.Client.Repositories.Async.T)
+    Task<T> Get(CancellationToken)
+    Task<T> Modify(Octopus.Client.Repositories.Async.T, CancellationToken)
   }
   interface ICreate`1
   {
-    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object)
+    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object, CancellationToken)
   }
   interface IDashboardConfigurationRepository
   {
-    Task<DashboardConfigurationResource> GetDashboardConfiguration()
-    Task<DashboardConfigurationResource> ModifyDashboardConfiguration(Octopus.Client.Model.DashboardConfigurationResource)
+    Task<DashboardConfigurationResource> GetDashboardConfiguration(CancellationToken)
+    Task<DashboardConfigurationResource> ModifyDashboardConfiguration(Octopus.Client.Model.DashboardConfigurationResource, CancellationToken)
   }
   interface IDashboardRepository
   {
-    Task<DashboardResource> GetDashboard()
-    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
+    Task<DashboardResource> GetDashboard(CancellationToken)
+    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions, CancellationToken)
   }
   interface IDefectsRepository
   {
-    Task<ResourceCollection<DefectResource>> GetDefects(Octopus.Client.Model.ReleaseResource)
-    Task RaiseDefect(Octopus.Client.Model.ReleaseResource, String)
-    Task ResolveDefect(Octopus.Client.Model.ReleaseResource)
+    Task<ResourceCollection<DefectResource>> GetDefects(Octopus.Client.Model.ReleaseResource, CancellationToken)
+    Task RaiseDefect(Octopus.Client.Model.ReleaseResource, String, CancellationToken)
+    Task ResolveDefect(Octopus.Client.Model.ReleaseResource, CancellationToken)
   }
   interface IDelete`1
   {
-    Task Delete(Octopus.Client.Repositories.Async.TResource)
+    Task Delete(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IDeploymentProcessBetaRepository
   {
-    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
-    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
+    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String, CancellationToken)
   }
   interface IDeploymentProcessRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.Async.IModify<DeploymentProcessResource>
   {
     Octopus.Client.Repositories.Async.IDeploymentProcessBetaRepository Beta()
-    Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
+    Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource, CancellationToken)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>
@@ -7452,11 +7450,11 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.Async.IDelete<DeploymentResource>
   {
-    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32, Nullable<Int32>)
-    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32, Nullable<Int32>)
-    Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource)
-    Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
-    Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
+    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32, Nullable<Int32>, CancellationToken)
+    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32, Nullable<Int32>, CancellationToken)
+    Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource, CancellationToken)
+    Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>, CancellationToken)
+    Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>, CancellationToken)
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>
@@ -7467,28 +7465,28 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<EnvironmentResource>
     Octopus.Client.Repositories.Async.IGetAll<EnvironmentResource>
   {
-    Task<EnvironmentEditor> CreateOrModify(String)
-    Task<EnvironmentEditor> CreateOrModify(String, String)
-    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
-    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
-    Task Sort(String[])
-    Task<EnvironmentsSummaryResource> Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
+    Task<EnvironmentEditor> CreateOrModify(String, CancellationToken)
+    Task<EnvironmentEditor> CreateOrModify(String, String, CancellationToken)
+    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean, CancellationToken)
+    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String, CancellationToken)
+    Task Sort(String[], CancellationToken)
+    Task<EnvironmentsSummaryResource> Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>, CancellationToken)
   }
   interface IEventRepository
     Octopus.Client.Repositories.Async.IGet<EventResource>
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<IEventRepository>
   {
-    Task<IReadOnlyList<EventAgentResource>> GetAgents()
-    Task<IReadOnlyList<EventCategoryResource>> GetCategories()
-    Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes()
-    Task<IReadOnlyList<EventGroupResource>> GetGroups()
-    Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean)
-    Task<ResourceCollection<EventResource>> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
+    Task<IReadOnlyList<EventAgentResource>> GetAgents(CancellationToken)
+    Task<IReadOnlyList<EventCategoryResource>> GetCategories(CancellationToken)
+    Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes(CancellationToken)
+    Task<IReadOnlyList<EventGroupResource>> GetGroups(CancellationToken)
+    Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean, CancellationToken)
+    Task<ResourceCollection<EventResource>> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String, CancellationToken)
   }
   interface IFeaturesConfigurationRepository
   {
-    Task<FeaturesConfigurationResource> GetFeaturesConfiguration()
-    Task<FeaturesConfigurationResource> ModifyFeaturesConfiguration(Octopus.Client.Model.FeaturesConfigurationResource)
+    Task<FeaturesConfigurationResource> GetFeaturesConfiguration(CancellationToken)
+    Task<FeaturesConfigurationResource> ModifyFeaturesConfiguration(Octopus.Client.Model.FeaturesConfigurationResource, CancellationToken)
   }
   interface IFeedRepository
     Octopus.Client.Repositories.Async.ICreate<FeedResource>
@@ -7498,31 +7496,31 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<FeedResource>
     Octopus.Client.Repositories.Async.IPaginate<FeedResource>
   {
-    Task<List<PackageResource>> GetVersions(Octopus.Client.Model.FeedResource, String[])
+    Task<List<PackageResource>> GetVersions(Octopus.Client.Model.FeedResource, String[], CancellationToken)
   }
   interface IFindByName`1
     Octopus.Client.Repositories.Async.IPaginate<TResource>
   {
-    Task<TResource> FindByName(String, String, Object)
-    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object)
+    Task<TResource> FindByName(String, String, Object, CancellationToken)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
   interface IGetAll`1
   {
-    Task<List<TResource>> GetAll()
+    Task<List<TResource>> GetAll(CancellationToken)
   }
   interface IGet`1
   {
-    Task<TResource> Get(String)
-    Task<List<TResource>> Get(String[])
-    Task<TResource> Refresh(Octopus.Client.Repositories.Async.TResource)
+    Task<TResource> Get(String, CancellationToken)
+    Task<List<TResource>> Get(CancellationToken, String[])
+    Task<TResource> Refresh(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IInterruptionRepository
     Octopus.Client.Repositories.Async.IGet<InterruptionResource>
   {
-    Task<UserResource> GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Task<ResourceCollection<InterruptionResource>> List(Int32, Nullable<Int32>, Boolean, String)
-    Task Submit(Octopus.Client.Model.InterruptionResource)
-    Task TakeResponsibility(Octopus.Client.Model.InterruptionResource)
+    Task<UserResource> GetResponsibleUser(Octopus.Client.Model.InterruptionResource, CancellationToken)
+    Task<ResourceCollection<InterruptionResource>> List(Int32, Nullable<Int32>, Boolean, String, CancellationToken)
+    Task Submit(Octopus.Client.Model.InterruptionResource, CancellationToken)
+    Task TakeResponsibility(Octopus.Client.Model.InterruptionResource, CancellationToken)
   }
   interface ILibraryVariableSetRepository
     Octopus.Client.Repositories.Async.ICreate<LibraryVariableSetResource>
@@ -7532,14 +7530,14 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<LibraryVariableSetResource>
     Octopus.Client.Repositories.Async.IPaginate<LibraryVariableSetResource>
   {
-    Task<LibraryVariableSetEditor> CreateOrModify(String)
-    Task<LibraryVariableSetEditor> CreateOrModify(String, String)
+    Task<LibraryVariableSetEditor> CreateOrModify(String, CancellationToken)
+    Task<LibraryVariableSetEditor> CreateOrModify(String, String, CancellationToken)
   }
   interface ILicensesRepository
   {
-    Task<LicenseResource> GetCurrent()
-    Task<LicenseStatusResource> GetStatus()
-    Task<LicenseResource> UpdateCurrent(Octopus.Client.Model.LicenseResource)
+    Task<LicenseResource> GetCurrent(CancellationToken)
+    Task<LicenseStatusResource> GetStatus(CancellationToken)
+    Task<LicenseResource> UpdateCurrent(Octopus.Client.Model.LicenseResource, CancellationToken)
   }
   interface ILifecyclesRepository
     Octopus.Client.Repositories.Async.IGet<LifecycleResource>
@@ -7549,8 +7547,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<LifecycleResource>
     Octopus.Client.Repositories.Async.IPaginate<LifecycleResource>
   {
-    Task<LifecycleEditor> CreateOrModify(String)
-    Task<LifecycleEditor> CreateOrModify(String, String)
+    Task<LifecycleEditor> CreateOrModify(String, CancellationToken)
+    Task<LifecycleEditor> CreateOrModify(String, String, CancellationToken)
   }
   interface IMachinePolicyRepository
     Octopus.Client.Repositories.Async.IFindByName<MachinePolicyResource>
@@ -7560,8 +7558,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<MachinePolicyResource>
     Octopus.Client.Repositories.Async.IDelete<MachinePolicyResource>
   {
-    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.MachinePolicyResource)
-    Task<MachinePolicyResource> GetTemplate()
+    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.MachinePolicyResource, CancellationToken)
+    Task<MachinePolicyResource> GetTemplate(CancellationToken)
   }
   interface IMachineRepository
     Octopus.Client.Repositories.Async.IFindByName<MachineResource>
@@ -7571,28 +7569,28 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<MachineResource>
     Octopus.Client.Repositories.Async.IDelete<MachineResource>
   {
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
-    Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions)
-    Task<List<MachineResource>> FindByThumbprint(String)
-    Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource)
-    Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource)
-    Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Task<ResourceCollection<MachineResource>> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>, CancellationToken)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], CancellationToken)
+    Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>, CancellationToken)
+    Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions, CancellationToken)
+    Task<List<MachineResource>> FindByThumbprint(String, CancellationToken)
+    Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource, CancellationToken)
+    Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, CancellationToken)
+    Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, Object, CancellationToken)
+    Task<ResourceCollection<MachineResource>> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String, CancellationToken)
   }
   interface IMachineRoleRepository
   {
-    Task<List<String>> GetAllRoleNames()
+    Task<List<String>> GetAllRoleNames(CancellationToken)
   }
   interface IMigrationRepository
   {
-    Task<MigrationImportResource> Import(Octopus.Client.Model.Migrations.MigrationImportResource)
-    Task<MigrationPartialExportResource> PartialExport(Octopus.Client.Model.Migrations.MigrationPartialExportResource)
+    Task<MigrationImportResource> Import(Octopus.Client.Model.Migrations.MigrationImportResource, CancellationToken)
+    Task<MigrationPartialExportResource> PartialExport(Octopus.Client.Model.Migrations.MigrationPartialExportResource, CancellationToken)
   }
   interface IModify`1
   {
-    Task<TResource> Modify(Octopus.Client.Repositories.Async.TResource)
+    Task<TResource> Modify(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IOctopusServerNodeRepository
     Octopus.Client.Repositories.Async.IModify<OctopusServerNodeResource>
@@ -7601,8 +7599,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<OctopusServerNodeResource>
     Octopus.Client.Repositories.Async.IPaginate<OctopusServerNodeResource>
   {
-    Task<OctopusServerNodeDetailsResource> Details(Octopus.Client.Model.OctopusServerNodeResource)
-    Task<OctopusServerClusterSummaryResource> Summary()
+    Task<OctopusServerNodeDetailsResource> Details(Octopus.Client.Model.OctopusServerNodeResource, CancellationToken)
+    Task<OctopusServerClusterSummaryResource> Summary(CancellationToken)
   }
   interface IOctopusSpaceAsyncBetaRepository
   {
@@ -7610,26 +7608,26 @@ Octopus.Client.Repositories.Async
   }
   interface IPackageMetadataRepository
   {
-    Task<OctopusPackageMetadataMappedResource> Get(String)
-    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
-    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Boolean)
+    Task<OctopusPackageMetadataMappedResource> Get(String, CancellationToken)
+    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode, CancellationToken)
+    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Boolean, CancellationToken)
   }
   interface IPaginate`1
   {
-    Task<List<TResource>> FindAll(String, Object)
-    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object)
-    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object)
-    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
+    Task<List<TResource>> FindAll(String, Object, CancellationToken)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object, CancellationToken)
+    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object, CancellationToken)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object, CancellationToken)
   }
   interface IPerformanceConfigurationRepository
   {
-    Task<PerformanceConfigurationResource> Get()
-    Task<PerformanceConfigurationResource> Modify(Octopus.Client.Model.PerformanceConfigurationResource)
+    Task<PerformanceConfigurationResource> Get(CancellationToken)
+    Task<PerformanceConfigurationResource> Modify(Octopus.Client.Model.PerformanceConfigurationResource, CancellationToken)
   }
   interface IProjectBetaRepository
   {
-    Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
-    Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
+    Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource, CancellationToken)
   }
   interface IProjectGroupRepository
     Octopus.Client.Repositories.Async.IFindByName<ProjectGroupResource>
@@ -7640,9 +7638,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ProjectGroupResource>
     Octopus.Client.Repositories.Async.IGetAll<ProjectGroupResource>
   {
-    Task<ProjectGroupEditor> CreateOrModify(String)
-    Task<ProjectGroupEditor> CreateOrModify(String, String)
-    Task<List<ProjectResource>> GetProjects(Octopus.Client.Model.ProjectGroupResource)
+    Task<ProjectGroupEditor> CreateOrModify(String, CancellationToken)
+    Task<ProjectGroupEditor> CreateOrModify(String, String, CancellationToken)
+    Task<List<ProjectResource>> GetProjects(Octopus.Client.Model.ProjectGroupResource, CancellationToken)
   }
   interface IProjectRepository
     Octopus.Client.Repositories.Async.IFindByName<ProjectResource>
@@ -7654,22 +7652,22 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGetAll<ProjectResource>
   {
     Octopus.Client.Repositories.Async.IProjectBetaRepository Beta()
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
-    Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)
-    Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ProjectResource)
-    Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(Octopus.Client.Model.ProjectResource)
-    Task<IReadOnlyList<RunbookSnapshotResource>> GetAllRunbookSnapshots(Octopus.Client.Model.ProjectResource)
-    Task<IReadOnlyList<ProjectTriggerResource>> GetAllTriggers(Octopus.Client.Model.ProjectResource)
-    Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource)
-    Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
-    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
-    Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
-    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
-    Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
-    Task SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, CancellationToken)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
+    Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<IReadOnlyList<RunbookSnapshotResource>> GetAllRunbookSnapshots(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<IReadOnlyList<ProjectTriggerResource>> GetAllTriggers(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
+    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
+    Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
+    Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task SetLogo(Octopus.Client.Model.ProjectResource, String, Stream, CancellationToken)
   }
   interface IProjectTriggerRepository
     Octopus.Client.Repositories.Async.ICreate<ProjectTriggerResource>
@@ -7677,9 +7675,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<ProjectTriggerResource>
     Octopus.Client.Repositories.Async.IDelete<ProjectTriggerResource>
   {
-    Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
-    Task<ProjectTriggerResource> FindByName(Octopus.Client.Model.ProjectResource, String)
-    Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(String[])
+    Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource, CancellationToken)
+    Task<ProjectTriggerResource> FindByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(CancellationToken, String[])
   }
   interface IProxyRepository
     Octopus.Client.Repositories.Async.IGet<ProxyResource>
@@ -7697,13 +7695,13 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<ReleaseResource>
     Octopus.Client.Repositories.Async.IDelete<ReleaseResource>
   {
-    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
-    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
-    Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<LifecycleProgressionResource> GetProgression(Octopus.Client.Model.ReleaseResource)
-    Task<DeploymentTemplateResource> GetTemplate(Octopus.Client.Model.ReleaseResource)
-    Task<ReleaseResource> SnapshotVariables(Octopus.Client.Model.ReleaseResource)
+    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean, CancellationToken)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
+    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
+    Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget, CancellationToken)
+    Task<LifecycleProgressionResource> GetProgression(Octopus.Client.Model.ReleaseResource, CancellationToken)
+    Task<DeploymentTemplateResource> GetTemplate(Octopus.Client.Model.ReleaseResource, CancellationToken)
+    Task<ReleaseResource> SnapshotVariables(Octopus.Client.Model.ReleaseResource, CancellationToken)
   }
   interface IResourceRepository
   {
@@ -7711,13 +7709,13 @@ Octopus.Client.Repositories.Async
   }
   interface IRetentionPolicyRepository
   {
-    Task<TaskResource> ApplyNow(String)
+    Task<TaskResource> ApplyNow(String, CancellationToken)
   }
   interface IRunbookProcessRepository
     Octopus.Client.Repositories.Async.IGet<RunbookProcessResource>
     Octopus.Client.Repositories.Async.IModify<RunbookProcessResource>
   {
-    Task<RunbookSnapshotTemplateResource> GetTemplate(Octopus.Client.Model.RunbookProcessResource)
+    Task<RunbookSnapshotTemplateResource> GetTemplate(Octopus.Client.Model.RunbookProcessResource, CancellationToken)
   }
   interface IRunbookRepository
     Octopus.Client.Repositories.Async.IFindByName<RunbookResource>
@@ -7727,13 +7725,13 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<RunbookResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookResource>
   {
-    Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
-    Task<RunbookResource> FindByName(Octopus.Client.Model.ProjectResource, String)
-    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.RunbookResource)
-    Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.RunbookResource)
-    Task<RunbookRunResource> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunResource)
-    Task<RunbookRunResource[]> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunParameters)
+    Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
+    Task<RunbookResource> FindByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget, CancellationToken)
+    Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.RunbookResource, CancellationToken)
+    Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.RunbookResource, CancellationToken)
+    Task<RunbookRunResource> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunResource, CancellationToken)
+    Task<RunbookRunResource[]> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunParameters, CancellationToken)
   }
   interface IRunbookRunRepository
     Octopus.Client.Repositories.Async.IGet<RunbookRunResource>
@@ -7741,10 +7739,10 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookRunResource>
   {
-    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
-    Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource)
-    Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
-    Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
+    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32, Nullable<Int32>, CancellationToken)
+    Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource, CancellationToken)
+    Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>, CancellationToken)
+    Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>, CancellationToken)
   }
   interface IRunbookSnapshotRepository
     Octopus.Client.Repositories.Async.IGet<RunbookSnapshotResource>
@@ -7753,23 +7751,23 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<RunbookSnapshotResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookSnapshotResource>
   {
-    Task<RunbookSnapshotResource> Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
-    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
-    Task<RunbookRunTemplateResource> GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
-    Task<RunbookSnapshotResource> SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
+    Task<RunbookSnapshotResource> Create(Octopus.Client.Model.RunbookSnapshotResource, CancellationToken)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>, CancellationToken)
+    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget, CancellationToken)
+    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>, CancellationToken)
+    Task<RunbookRunTemplateResource> GetTemplate(Octopus.Client.Model.RunbookSnapshotResource, CancellationToken)
+    Task<RunbookSnapshotResource> SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource, CancellationToken)
   }
   interface ISchedulerRepository
   {
-    Task<ScheduledTaskDetailsResource> GetLogs(String)
-    Task<Stream> GetRawLogs(String)
-    Task Start()
-    Task Start(String)
-    Task<SchedulerStatusResource> Status()
-    Task Stop()
-    Task Stop(String)
-    Task Trigger(String)
+    Task<ScheduledTaskDetailsResource> GetLogs(String, CancellationToken)
+    Task<Stream> GetRawLogs(String, CancellationToken)
+    Task Start(CancellationToken)
+    Task Start(String, CancellationToken)
+    Task<SchedulerStatusResource> Status(CancellationToken)
+    Task Stop(CancellationToken)
+    Task Stop(String, CancellationToken)
+    Task Trigger(String, CancellationToken)
   }
   interface IScopedUserRoleRepository
     Octopus.Client.Repositories.Async.ICreate<ScopedUserRoleResource>
@@ -7781,9 +7779,9 @@ Octopus.Client.Repositories.Async
   }
   interface IServerStatusRepository
   {
-    Task<ServerStatusHealthResource> GetServerHealth()
-    Task<ServerStatusResource> GetServerStatus()
-    Task<SystemInfoResource> GetSystemInfo(Octopus.Client.Model.ServerStatusResource)
+    Task<ServerStatusHealthResource> GetServerHealth(CancellationToken)
+    Task<ServerStatusResource> GetServerStatus(CancellationToken)
+    Task<SystemInfoResource> GetSystemInfo(Octopus.Client.Model.ServerStatusResource, CancellationToken)
   }
   interface ISpaceRepository
     Octopus.Client.Repositories.Async.ICreate<SpaceResource>
@@ -7793,7 +7791,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<SpaceResource>
     Octopus.Client.Repositories.Async.IGet<SpaceResource>
   {
-    Task SetLogo(Octopus.Client.Model.SpaceResource, String, Stream)
+    Task SetLogo(Octopus.Client.Model.SpaceResource, String, Stream, CancellationToken)
   }
   interface ISubscriptionRepository
     Octopus.Client.Repositories.Async.IFindByName<SubscriptionResource>
@@ -7803,7 +7801,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<SubscriptionResource>
     Octopus.Client.Repositories.Async.IDelete<SubscriptionResource>
   {
-    Task<SubscriptionEditor> CreateOrModify(String, Octopus.Client.Model.EventNotificationSubscription, Boolean)
+    Task<SubscriptionEditor> CreateOrModify(String, Octopus.Client.Model.EventNotificationSubscription, Boolean, CancellationToken)
   }
   interface ITagSetRepository
     Octopus.Client.Repositories.Async.ICreate<TagSetResource>
@@ -7814,9 +7812,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<TagSetResource>
     Octopus.Client.Repositories.Async.IGetAll<TagSetResource>
   {
-    Task<TagSetEditor> CreateOrModify(String)
-    Task<TagSetEditor> CreateOrModify(String, String)
-    Task Sort(String[])
+    Task<TagSetEditor> CreateOrModify(String, CancellationToken)
+    Task<TagSetEditor> CreateOrModify(String, String, CancellationToken)
+    Task Sort(String[], CancellationToken)
   }
   interface ITaskRepository
     Octopus.Client.Repositories.Async.IPaginate<TaskResource>
@@ -7824,27 +7822,27 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.ICreate<TaskResource>
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<ITaskRepository>
   {
-    Task Cancel(Octopus.Client.Model.TaskResource)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteBackup(String)
-    Task<TaskResource> ExecuteCalamariUpdate(String, String[])
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String)
-    Task<TaskResource> ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
-    Task<TaskResource> ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
-    Task<TaskResourceCollection> GetActiveWithSummary(Int32, Int32)
-    Task<List<TaskResource>> GetAllActive(Int32)
-    Task<TaskResourceCollection> GetAllWithSummary(Int32, Int32)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
-    Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
-    Task<String> GetRawOutputLog(Octopus.Client.Model.TaskResource)
-    Task<TaskTypeResource[]> GetTaskTypes()
-    Task ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String)
-    Task Rerun(Octopus.Client.Model.TaskResource)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Func<TaskResource[], Task>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Func<TaskResource[], Task>)
+    Task Cancel(Octopus.Client.Model.TaskResource, CancellationToken)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>, CancellationToken)
+    Task<TaskResource> ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>, CancellationToken)
+    Task<TaskResource> ExecuteBackup(String, CancellationToken)
+    Task<TaskResource> ExecuteCalamariUpdate(String, String[], CancellationToken)
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String, CancellationToken)
+    Task<TaskResource> ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[], CancellationToken)
+    Task<TaskResource> ExecuteTentacleUpgrade(String, String, String[], String, String, String[], CancellationToken)
+    Task<TaskResourceCollection> GetActiveWithSummary(Int32, Int32, CancellationToken)
+    Task<List<TaskResource>> GetAllActive(Int32, CancellationToken)
+    Task<TaskResourceCollection> GetAllWithSummary(Int32, Int32, CancellationToken)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>, CancellationToken)
+    Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource, CancellationToken)
+    Task<String> GetRawOutputLog(Octopus.Client.Model.TaskResource, CancellationToken)
+    Task<TaskTypeResource[]> GetTaskTypes(CancellationToken)
+    Task ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String, CancellationToken)
+    Task Rerun(Octopus.Client.Model.TaskResource, CancellationToken)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>, CancellationToken)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>, CancellationToken)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Func<TaskResource[], Task>, CancellationToken)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Func<TaskResource[], Task>, CancellationToken)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.Async.ICreate<TeamResource>
@@ -7855,7 +7853,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<TeamResource>
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<ITeamsRepository>
   {
-    Task<List<ScopedUserRoleResource>> GetScopedUserRoles(Octopus.Client.Model.TeamResource)
+    Task<List<ScopedUserRoleResource>> GetScopedUserRoles(Octopus.Client.Model.TeamResource, CancellationToken)
   }
   interface ITenantRepository
     Octopus.Client.Repositories.Async.ICreate<TenantResource>
@@ -7866,38 +7864,38 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<TenantResource>
     Octopus.Client.Repositories.Async.IGetAll<TenantResource>
   {
-    Task<TenantEditor> CreateOrModify(String)
-    Task<TenantEditor> CreateOrModify(String, String)
-    Task<TenantEditor> CreateOrModify(String, String, String)
-    Task<List<TenantResource>> FindAll(String, String[], Int32)
-    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String, String, String)
-    Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource)
-    Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
-    Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
-    Task<MultiTenancyStatusResource> Status()
+    Task<TenantEditor> CreateOrModify(String, CancellationToken)
+    Task<TenantEditor> CreateOrModify(String, String, CancellationToken)
+    Task<TenantEditor> CreateOrModify(String, String, String, CancellationToken)
+    Task<List<TenantResource>> FindAll(String, String[], Int32, CancellationToken)
+    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String, String, String, CancellationToken)
+    Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource, CancellationToken)
+    Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource, CancellationToken)
+    Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream, CancellationToken)
+    Task<MultiTenancyStatusResource> Status(CancellationToken)
   }
   interface ITenantVariablesRepository
     Octopus.Client.Repositories.Async.IGetAll<TenantVariableResource>
   {
-    Task<List<TenantVariableResource>> GetAll(Octopus.Client.Model.ProjectResource)
+    Task<List<TenantVariableResource>> GetAll(Octopus.Client.Model.ProjectResource, CancellationToken)
   }
   interface IUpgradeConfigurationRepository
     Octopus.Client.Repositories.Async.IGet<UpgradeConfigurationResource>
     Octopus.Client.Repositories.Async.IModify<UpgradeConfigurationResource>
   {
-    Task<UpgradeConfigurationResource> Get()
+    Task<UpgradeConfigurationResource> Get(CancellationToken)
   }
   interface IUserInvitesRepository
   {
-    Task<InvitationResource> Invite(String)
-    Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection)
+    Task<InvitationResource> Invite(String, CancellationToken)
+    Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection, CancellationToken)
   }
   interface IUserPermissionsRepository
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<IUserPermissionsRepository>
   {
-    Task<Stream> Export(Octopus.Client.Model.UserPermissionSetResource)
-    Task<UserPermissionSetResource> Get(Octopus.Client.Model.UserResource)
-    Task<UserPermissionSetResource> GetConfiguration(Octopus.Client.Model.UserResource)
+    Task<Stream> Export(Octopus.Client.Model.UserPermissionSetResource, CancellationToken)
+    Task<UserPermissionSetResource> Get(Octopus.Client.Model.UserResource, CancellationToken)
+    Task<UserPermissionSetResource> GetConfiguration(Octopus.Client.Model.UserResource, CancellationToken)
   }
   interface IUserRepository
     Octopus.Client.Repositories.Async.IPaginate<UserResource>
@@ -7906,20 +7904,20 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<UserResource>
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
-    Task<UserResource> Create(String, String, String, String)
-    Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
-    Task<UserResource> CreateServiceAccount(String, String)
-    Task<UserResource> FindByUsername(String)
-    Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
-    Task<UserResource> GetCurrent()
-    Task<SpaceResource[]> GetSpaces(Octopus.Client.Model.UserResource)
-    Task<InvitationResource> Invite(String)
-    Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection)
-    Task<UserResource> Register(Octopus.Client.Model.RegisterCommand)
-    Task RevokeApiKey(Octopus.Client.Model.ApiKeyResource)
-    Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignIn(String, String, Boolean)
-    Task SignOut()
+    Task<UserResource> Create(String, String, String, String, CancellationToken)
+    Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String, CancellationToken)
+    Task<UserResource> CreateServiceAccount(String, String, CancellationToken)
+    Task<UserResource> FindByUsername(String, CancellationToken)
+    Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource, CancellationToken)
+    Task<UserResource> GetCurrent(CancellationToken)
+    Task<SpaceResource[]> GetSpaces(Octopus.Client.Model.UserResource, CancellationToken)
+    Task<InvitationResource> Invite(String, CancellationToken)
+    Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection, CancellationToken)
+    Task<UserResource> Register(Octopus.Client.Model.RegisterCommand, CancellationToken)
+    Task RevokeApiKey(Octopus.Client.Model.ApiKeyResource, CancellationToken)
+    Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
+    Task SignIn(String, String, Boolean, CancellationToken)
+    Task SignOut(CancellationToken)
   }
   interface IUserRolesRepository
     Octopus.Client.Repositories.Async.IFindByName<UserRoleResource>
@@ -7933,23 +7931,23 @@ Octopus.Client.Repositories.Async
   interface IUserTeamsRepository
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<IUserTeamsRepository>
   {
-    Task<TeamNameResource[]> Get(Octopus.Client.Model.UserResource)
+    Task<TeamNameResource[]> Get(Octopus.Client.Model.UserResource, CancellationToken)
   }
   interface IVariableSetRepository
     Octopus.Client.Repositories.Async.IGet<VariableSetResource>
     Octopus.Client.Repositories.Async.IModify<VariableSetResource>
     Octopus.Client.Repositories.Async.IGetAll<VariableSetResource>
   {
-    Task<String[]> GetVariableNames(String, String[])
-    Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String)
+    Task<String[]> GetVariableNames(String, String[], CancellationToken)
+    Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String, CancellationToken)
   }
   interface IVcsRunbookRepository
   {
-    Task<VcsRunbookResource> Create(Octopus.Client.Model.VcsRunbookResource, String)
-    Task Delete(Octopus.Client.Model.VcsRunbookResource, String)
-    Task<VcsRunbookResource> Get(String)
-    Task<ResourceCollection<VcsRunbookResource>> List(String, Int32, Nullable<Int32>)
-    Task<VcsRunbookResource> Modify(Octopus.Client.Model.VcsRunbookResource, String)
+    Task<VcsRunbookResource> Create(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
+    Task Delete(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
+    Task<VcsRunbookResource> Get(String, CancellationToken)
+    Task<ResourceCollection<VcsRunbookResource>> List(String, Int32, Nullable<Int32>, CancellationToken)
+    Task<VcsRunbookResource> Modify(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerPoolResource>
@@ -7960,11 +7958,11 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<WorkerPoolResource>
     Octopus.Client.Repositories.Async.IGetAll<WorkerPoolResource>
   {
-    Task<WorkerPoolEditor> CreateOrModify(String)
-    Task<WorkerPoolEditor> CreateOrModify(String, String)
-    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
-    Task Sort(String[])
-    Task<WorkerPoolsSummaryResource> Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
+    Task<WorkerPoolEditor> CreateOrModify(String, CancellationToken)
+    Task<WorkerPoolEditor> CreateOrModify(String, String, CancellationToken)
+    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String, CancellationToken)
+    Task Sort(String[], CancellationToken)
+    Task<WorkerPoolsSummaryResource> Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>, CancellationToken)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerResource>
@@ -7974,11 +7972,11 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<WorkerResource>
     Octopus.Client.Repositories.Async.IDelete<WorkerResource>
   {
-    Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Task<WorkerResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
-    Task<List<WorkerResource>> FindByThumbprint(String)
-    Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+    Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[], CancellationToken)
+    Task<WorkerResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>, CancellationToken)
+    Task<List<WorkerResource>> FindByThumbprint(String, CancellationToken)
+    Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource, CancellationToken)
+    Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String, CancellationToken)
   }
   class OctopusSpaceAsyncBetaRepository
     Octopus.Client.Repositories.Async.IOctopusSpaceAsyncBetaRepository
@@ -7996,11 +7994,11 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IVcsRunbookRepository
   {
     .ctor(Octopus.Client.IOctopusAsyncRepository, Octopus.Client.Model.VersionControlBranchResource)
-    Task<VcsRunbookResource> Create(Octopus.Client.Model.VcsRunbookResource, String)
-    Task Delete(Octopus.Client.Model.VcsRunbookResource, String)
-    Task<VcsRunbookResource> Get(String)
-    Task<ResourceCollection<VcsRunbookResource>> List(String, Int32, Nullable<Int32>)
-    Task<VcsRunbookResource> Modify(Octopus.Client.Model.VcsRunbookResource, String)
+    Task<VcsRunbookResource> Create(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
+    Task Delete(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
+    Task<VcsRunbookResource> Get(String, CancellationToken)
+    Task<ResourceCollection<VcsRunbookResource>> List(String, Int32, Nullable<Int32>, CancellationToken)
+    Task<VcsRunbookResource> Modify(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
   }
 }
 Octopus.Client.Serialization

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -30,27 +30,26 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Task<TResource> Create(String, Octopus.Client.TResource, Object)
-    Task Delete(String, Object, Object)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task Delete(String, Object, Object, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object)
-    Task<Stream> GetContent(String, Object)
-    Task<ResourceCollection<TResource>> List(String, Object)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object)
-    Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
-    Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
-    Task Post(String, Octopus.Client.TResource, Object)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
-    Task Post(String)
-    Task Put(String, Octopus.Client.TResource)
-    Task Put(String)
-    Task Put(String, Octopus.Client.TResource, Object)
-    Task PutContent(String, Stream)
+    Task<TResource> Get(String, Object, CancellationToken)
+    Task<Stream> GetContent(String, Object, CancellationToken)
+    Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
+    Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task Post(String, CancellationToken)
+    Task Put(String, CancellationToken)
+    Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task PutContent(String, Stream, CancellationToken)
     Uri QualifyUri(String, Object)
-    Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignOut()
-    Task<TResource> Update(String, Octopus.Client.TResource, Object)
+    Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
+    Task SignOut(CancellationToken)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
   interface IOctopusAsyncRepository
     Octopus.Client.IOctopusSpaceAsyncRepository
@@ -269,28 +268,27 @@ Octopus.Client
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
     static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
-    Task<TResource> Create(String, Octopus.Client.TResource, Object)
-    Task Delete(String, Object, Object)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task Delete(String, Object, Object, CancellationToken)
     void Dispose()
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object)
-    Task<Stream> GetContent(String, Object)
-    Task<ResourceCollection<TResource>> List(String, Object)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object)
-    Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
-    Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
-    Task Post(String, Octopus.Client.TResource, Object)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
-    Task Post(String)
-    Task Put(String, Octopus.Client.TResource)
-    Task Put(String)
-    Task Put(String, Octopus.Client.TResource, Object)
-    Task PutContent(String, Stream)
+    Task<TResource> Get(String, Object, CancellationToken)
+    Task<Stream> GetContent(String, Object, CancellationToken)
+    Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
+    Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task Post(String, CancellationToken)
+    Task Put(String, CancellationToken)
+    Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
+    Task PutContent(String, Stream, CancellationToken)
     Uri QualifyUri(String, Object)
-    Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignOut()
-    Task<TResource> Update(String, Octopus.Client.TResource, Object)
+    Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
+    Task SignOut(CancellationToken)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
   class OctopusAsyncRepository
     Octopus.Client.IOctopusAsyncRepository
@@ -967,11 +965,11 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IAccountRepository)
     Octopus.Client.Editors.Async.TAccountResource Instance { get; }
-    Task<TAccountEditor> CreateOrModify(String)
+    Task<TAccountEditor> CreateOrModify(String, CancellationToken)
     Octopus.Client.Editors.Async.TAccountEditor Customize(Action<TAccountResource>)
-    Task<TAccountEditor> FindByName(String)
-    Task<TAccountEditor> Save()
-    Task<AccountUsageResource> Usages()
+    Task<TAccountEditor> FindByName(String, CancellationToken)
+    Task<TAccountEditor> Save(CancellationToken)
+    Task<AccountUsageResource> Usages(CancellationToken)
   }
   class AmazonWebServicesAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<AmazonWebServicesAccountResource, AmazonWebServicesAccountEditor>
@@ -986,10 +984,10 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.AccountEditor<AzureServicePrincipalAccountResource, AzureServicePrincipalAccountEditor>
   {
     .ctor(Octopus.Client.Repositories.Async.IAccountRepository)
-    Task<List<ResourceGroup>> ResourceGroups()
-    Task<List<AzureStorageAccount>> StorageAccounts()
-    Task<List<WebSite>> WebSites()
-    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.WebSite)
+    Task<List<ResourceGroup>> ResourceGroups(CancellationToken)
+    Task<List<AzureStorageAccount>> StorageAccounts(CancellationToken)
+    Task<List<WebSite>> WebSites(CancellationToken)
+    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.WebSite, CancellationToken)
   }
   class AzureSubscriptionAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<AzureSubscriptionAccountResource, AzureSubscriptionAccountEditor>
@@ -997,11 +995,11 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.AccountEditor<AzureSubscriptionAccountResource, AzureSubscriptionAccountEditor>
   {
     .ctor(Octopus.Client.Repositories.Async.IAccountRepository)
-    Task<List<AzureStorageAccount>> StorageAccounts(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource)
-    Task<List<WebSite>> WebSites(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource)
-    Task<List<WebSite>> WebSites()
-    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource, Octopus.Client.Model.Accounts.WebSite)
-    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.WebSite)
+    Task<List<AzureStorageAccount>> StorageAccounts(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource, CancellationToken)
+    Task<List<WebSite>> WebSites(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource, CancellationToken)
+    Task<List<WebSite>> WebSites(CancellationToken)
+    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.AzureSubscriptionAccountResource, Octopus.Client.Model.Accounts.WebSite, CancellationToken)
+    Task<List<WebSlot>> WebSlots(Octopus.Client.Model.Accounts.WebSite, CancellationToken)
   }
   class CertificateEditor
     Octopus.Client.Editors.Async.IResourceEditor<CertificateResource, CertificateEditor>
@@ -1009,11 +1007,11 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.ICertificateRepository)
     Octopus.Client.Model.CertificateResource Instance { get; }
-    Task<CertificateEditor> Create(String, String)
+    Task<CertificateEditor> Create(String, String, CancellationToken)
     Octopus.Client.Editors.Async.CertificateEditor Customize(Action<CertificateResource>)
-    Task<CertificateEditor> FindByName(String)
-    Task<CertificateEditor> Save()
-    Task<CertificateUsageResource> Usages()
+    Task<CertificateEditor> FindByName(String, CancellationToken)
+    Task<CertificateEditor> Save(CancellationToken)
+    Task<CertificateUsageResource> Usages(CancellationToken)
   }
   class ChannelEditor
     Octopus.Client.Editors.Async.IResourceEditor<ChannelResource, ChannelEditor>
@@ -1027,10 +1025,10 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.ChannelEditor AddRule(String, String, Octopus.Client.Model.DeploymentActionResource[])
     Octopus.Client.Editors.Async.ChannelEditor ClearRules()
     Octopus.Client.Editors.Async.ChannelEditor ClearTenantTags()
-    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String)
-    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
+    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.ChannelEditor Customize(Action<ChannelResource>)
-    Task<ChannelEditor> Save()
+    Task<ChannelEditor> Save(CancellationToken)
     Octopus.Client.Editors.Async.ChannelEditor SetAsDefaultChannel()
     Octopus.Client.Editors.Async.ChannelEditor UsingLifecycle(Octopus.Client.Model.LifecycleResource)
   }
@@ -1044,9 +1042,9 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.DeploymentProcessEditor ClearSteps()
     Octopus.Client.Editors.Async.DeploymentProcessEditor Customize(Action<DeploymentProcessResource>)
     Octopus.Client.Model.DeploymentStepResource FindStep(String)
-    Task<DeploymentProcessEditor> Load(String)
+    Task<DeploymentProcessEditor> Load(String, CancellationToken)
     Octopus.Client.Editors.Async.DeploymentProcessEditor RemoveStep(String)
-    Task<DeploymentProcessEditor> Save()
+    Task<DeploymentProcessEditor> Save(CancellationToken)
   }
   class EnvironmentEditor
     Octopus.Client.Editors.Async.IResourceEditor<EnvironmentResource, EnvironmentEditor>
@@ -1054,11 +1052,11 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IEnvironmentRepository)
     Octopus.Client.Model.EnvironmentResource Instance { get; }
-    Task<EnvironmentEditor> CreateOrModify(String)
-    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
-    Task<EnvironmentEditor> CreateOrModify(String, String)
+    Task<EnvironmentEditor> CreateOrModify(String, CancellationToken)
+    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean, CancellationToken)
+    Task<EnvironmentEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.EnvironmentEditor Customize(Action<EnvironmentResource>)
-    Task<EnvironmentEditor> Save()
+    Task<EnvironmentEditor> Save(CancellationToken)
   }
   interface IResourceBuilder
   {
@@ -1068,7 +1066,7 @@ Octopus.Client.Editors.Async
   {
     Octopus.Client.Editors.Async.TResource Instance { get; }
     Octopus.Client.Editors.Async.TResourceBuilder Customize(Action<TResource>)
-    Task<TResourceBuilder> Save()
+    Task<TResourceBuilder> Save(CancellationToken)
   }
   class LibraryVariableSetEditor
     Octopus.Client.Editors.Async.IResourceEditor<LibraryVariableSetResource, LibraryVariableSetEditor>
@@ -1078,10 +1076,10 @@ Octopus.Client.Editors.Async
     Octopus.Client.Model.LibraryVariableSetResource Instance { get; }
     Task<VariableSetEditor> Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<LibraryVariableSetResource> VariableTemplates { get; }
-    Task<LibraryVariableSetEditor> CreateOrModify(String)
-    Task<LibraryVariableSetEditor> CreateOrModify(String, String)
+    Task<LibraryVariableSetEditor> CreateOrModify(String, CancellationToken)
+    Task<LibraryVariableSetEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.LibraryVariableSetEditor Customize(Action<LibraryVariableSetResource>)
-    Task<LibraryVariableSetEditor> Save()
+    Task<LibraryVariableSetEditor> Save(CancellationToken)
   }
   class LifecycleEditor
     Octopus.Client.Editors.Async.IResourceEditor<LifecycleResource, LifecycleEditor>
@@ -1092,10 +1090,10 @@ Octopus.Client.Editors.Async
     Octopus.Client.Model.PhaseResource AddOrUpdatePhase(String)
     Octopus.Client.Editors.Async.LifecycleEditor AsSimplePromotionLifecycle(IEnumerable<EnvironmentResource>)
     Octopus.Client.Editors.Async.LifecycleEditor Clear()
-    Task<LifecycleEditor> CreateOrModify(String)
-    Task<LifecycleEditor> CreateOrModify(String, String)
+    Task<LifecycleEditor> CreateOrModify(String, CancellationToken)
+    Task<LifecycleEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.LifecycleEditor Customize(Action<LifecycleResource>)
-    Task<LifecycleEditor> Save()
+    Task<LifecycleEditor> Save(CancellationToken)
   }
   class MachineEditor
     Octopus.Client.Editors.Async.IResourceEditor<MachineResource, MachineEditor>
@@ -1103,18 +1101,18 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], CancellationToken)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>, CancellationToken)
     Octopus.Client.Editors.Async.MachineEditor Customize(Action<MachineResource>)
-    Task<MachineEditor> Save()
+    Task<MachineEditor> Save(CancellationToken)
   }
   class ProjectChannelsEditor
   {
     .ctor(Octopus.Client.Repositories.Async.IChannelRepository, Octopus.Client.Model.ProjectResource)
-    Task<ChannelEditor> CreateOrModify(String)
-    Task<ChannelEditor> CreateOrModify(String, String)
-    Task<ProjectChannelsEditor> Delete(String)
-    Task<ProjectChannelsEditor> SaveAll()
+    Task<ChannelEditor> CreateOrModify(String, CancellationToken)
+    Task<ChannelEditor> CreateOrModify(String, String, CancellationToken)
+    Task<ProjectChannelsEditor> Delete(String, CancellationToken)
+    Task<ProjectChannelsEditor> SaveAll(CancellationToken)
   }
   class ProjectEditor
     Octopus.Client.Editors.Async.IResourceEditor<ProjectResource, ProjectEditor>
@@ -1127,12 +1125,12 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.ProjectTriggersEditor Triggers { get; }
     Task<VariableSetEditor> Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, CancellationToken)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.ProjectEditor Customize(Action<ProjectResource>)
     Octopus.Client.Editors.Async.ProjectEditor IncludingLibraryVariableSets(Octopus.Client.Model.LibraryVariableSetResource[])
-    Task<ProjectEditor> Save()
-    Task<ProjectEditor> SetLogo(String)
+    Task<ProjectEditor> Save(CancellationToken)
+    Task<ProjectEditor> SetLogo(String, CancellationToken)
   }
   class ProjectGroupEditor
     Octopus.Client.Editors.Async.IResourceEditor<ProjectGroupResource, ProjectGroupEditor>
@@ -1140,10 +1138,10 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IProjectGroupRepository)
     Octopus.Client.Model.ProjectGroupResource Instance { get; }
-    Task<ProjectGroupEditor> CreateOrModify(String)
-    Task<ProjectGroupEditor> CreateOrModify(String, String)
+    Task<ProjectGroupEditor> CreateOrModify(String, CancellationToken)
+    Task<ProjectGroupEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.ProjectGroupEditor Customize(Action<ProjectGroupResource>)
-    Task<ProjectGroupEditor> Save()
+    Task<ProjectGroupEditor> Save(CancellationToken)
   }
   class ProjectTriggerEditor
     Octopus.Client.Editors.Async.IResourceEditor<ProjectTriggerResource, ProjectTriggerEditor>
@@ -1151,16 +1149,16 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IProjectTriggerRepository)
     Octopus.Client.Model.ProjectTriggerResource Instance { get; }
-    Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
+    Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource, CancellationToken)
     Octopus.Client.Editors.Async.ProjectTriggerEditor Customize(Action<ProjectTriggerResource>)
-    Task<ProjectTriggerEditor> Save()
+    Task<ProjectTriggerEditor> Save(CancellationToken)
   }
   class ProjectTriggersEditor
   {
     .ctor(Octopus.Client.Repositories.Async.IProjectTriggerRepository, Octopus.Client.Model.ProjectResource)
-    Task<ProjectTriggerEditor> CreateOrModify(String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
-    Task<ProjectTriggersEditor> Delete(String)
-    Task<ProjectTriggersEditor> SaveAll()
+    Task<ProjectTriggerEditor> CreateOrModify(String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource, CancellationToken)
+    Task<ProjectTriggersEditor> Delete(String, CancellationToken)
+    Task<ProjectTriggersEditor> SaveAll(CancellationToken)
   }
   class RunbookEditor
     Octopus.Client.Editors.Async.IResourceEditor<RunbookResource, RunbookEditor>
@@ -1169,10 +1167,10 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IRunbookRepository, Octopus.Client.Repositories.Async.IRunbookProcessRepository)
     Octopus.Client.Model.RunbookResource Instance { get; }
     Task<RunbookProcessEditor> RunbookProcess { get; }
-    Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
+    Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.RunbookEditor Customize(Action<RunbookResource>)
-    Task<RunbookEditor> Load(String)
-    Task<RunbookEditor> Save()
+    Task<RunbookEditor> Load(String, CancellationToken)
+    Task<RunbookEditor> Save(CancellationToken)
   }
   class RunbookProcessEditor
     Octopus.Client.Editors.Async.IResourceEditor<RunbookProcessResource, RunbookProcessEditor>
@@ -1184,9 +1182,9 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.RunbookProcessEditor ClearSteps()
     Octopus.Client.Editors.Async.RunbookProcessEditor Customize(Action<RunbookProcessResource>)
     Octopus.Client.Model.DeploymentStepResource FindStep(String)
-    Task<RunbookProcessEditor> Load(String)
+    Task<RunbookProcessEditor> Load(String, CancellationToken)
     Octopus.Client.Editors.Async.RunbookProcessEditor RemoveStep(String)
-    Task<RunbookProcessEditor> Save()
+    Task<RunbookProcessEditor> Save(CancellationToken)
   }
   class SshKeyPairAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<SshKeyPairAccountResource, SshKeyPairAccountEditor>
@@ -1201,9 +1199,9 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.ISubscriptionRepository)
     Octopus.Client.Model.SubscriptionResource Instance { get; }
-    Task<SubscriptionEditor> CreateOrModify(String, Octopus.Client.Model.EventNotificationSubscription, Boolean)
+    Task<SubscriptionEditor> CreateOrModify(String, Octopus.Client.Model.EventNotificationSubscription, Boolean, CancellationToken)
     Octopus.Client.Editors.Async.SubscriptionEditor Customize(Action<SubscriptionResource>)
-    Task<SubscriptionEditor> Save()
+    Task<SubscriptionEditor> Save(CancellationToken)
   }
   class TagSetEditor
     Octopus.Client.Editors.Async.IResourceEditor<TagSetResource, TagSetEditor>
@@ -1213,11 +1211,11 @@ Octopus.Client.Editors.Async
     Octopus.Client.Model.TagSetResource Instance { get; }
     Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String, String)
     Octopus.Client.Editors.Async.TagSetEditor ClearTags()
-    Task<TagSetEditor> CreateOrModify(String)
-    Task<TagSetEditor> CreateOrModify(String, String)
+    Task<TagSetEditor> CreateOrModify(String, CancellationToken)
+    Task<TagSetEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.TagSetEditor Customize(Action<TagSetResource>)
     Octopus.Client.Editors.Async.TagSetEditor RemoveTag(String)
-    Task<TagSetEditor> Save()
+    Task<TagSetEditor> Save(CancellationToken)
   }
   class TenantEditor
     Octopus.Client.Editors.Async.IResourceEditor<TenantResource, TenantEditor>
@@ -1229,11 +1227,11 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.TenantEditor ClearProjects()
     Octopus.Client.Editors.Async.TenantEditor ClearTags()
     Octopus.Client.Editors.Async.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
-    Task<TenantEditor> CreateOrModify(String)
-    Task<TenantEditor> CreateOrModify(String, String, String)
+    Task<TenantEditor> CreateOrModify(String, CancellationToken)
+    Task<TenantEditor> CreateOrModify(String, String, String, CancellationToken)
     Octopus.Client.Editors.Async.TenantEditor Customize(Action<TenantResource>)
-    Task<TenantEditor> Save()
-    Task<TenantEditor> SetLogo(String)
+    Task<TenantEditor> Save(CancellationToken)
+    Task<TenantEditor> SetLogo(String, CancellationToken)
     Octopus.Client.Editors.Async.TenantEditor WithTag(Octopus.Client.Model.TagResource)
   }
   class TenantVariablesEditor
@@ -1243,8 +1241,8 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.ITenantRepository, Octopus.Client.Model.TenantResource)
     Octopus.Client.Model.TenantVariableResource Instance { get; }
     Octopus.Client.Editors.Async.TenantVariablesEditor Customize(Action<TenantVariableResource>)
-    Task<TenantVariablesEditor> Load()
-    Task<TenantVariablesEditor> Save()
+    Task<TenantVariablesEditor> Load(CancellationToken)
+    Task<TenantVariablesEditor> Save(CancellationToken)
   }
   class UsernamePasswordAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<UsernamePasswordAccountResource, UsernamePasswordAccountEditor>
@@ -1265,8 +1263,8 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.VariableSetEditor AddOrUpdateVariableValue(String, String)
     Octopus.Client.Editors.Async.VariableSetEditor AddOrUpdateVariableValue(String, String, String)
     Octopus.Client.Editors.Async.VariableSetEditor Customize(Action<VariableSetResource>)
-    Task<VariableSetEditor> Load(String)
-    Task<VariableSetEditor> Save()
+    Task<VariableSetEditor> Load(String, CancellationToken)
+    Task<VariableSetEditor> Save(CancellationToken)
   }
   class VariableTemplateContainerEditor`1
   {
@@ -1288,9 +1286,9 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IWorkerRepository)
     Octopus.Client.Model.WorkerResource Instance { get; }
-    Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
+    Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[], CancellationToken)
     Octopus.Client.Editors.Async.WorkerEditor Customize(Action<WorkerResource>)
-    Task<WorkerEditor> Save()
+    Task<WorkerEditor> Save(CancellationToken)
   }
   class WorkerPoolEditor
     Octopus.Client.Editors.Async.IResourceEditor<WorkerPoolResource, WorkerPoolEditor>
@@ -1298,10 +1296,10 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.IWorkerPoolRepository)
     Octopus.Client.Model.WorkerPoolResource Instance { get; }
-    Task<WorkerPoolEditor> CreateOrModify(String)
-    Task<WorkerPoolEditor> CreateOrModify(String, String)
+    Task<WorkerPoolEditor> CreateOrModify(String, CancellationToken)
+    Task<WorkerPoolEditor> CreateOrModify(String, String, CancellationToken)
     Octopus.Client.Editors.Async.WorkerPoolEditor Customize(Action<WorkerPoolResource>)
-    Task<WorkerPoolEditor> Save()
+    Task<WorkerPoolEditor> Save(CancellationToken)
   }
 }
 Octopus.Client.Exceptions
@@ -6490,9 +6488,9 @@ Octopus.Client.Operations
     void Execute(Octopus.Client.OctopusServerEndpoint)
     void Execute(Octopus.Client.OctopusRepository)
     void Execute(Octopus.Client.IOctopusSpaceRepository)
-    Task ExecuteAsync(Octopus.Client.OctopusServerEndpoint)
-    Task ExecuteAsync(Octopus.Client.OctopusAsyncRepository)
-    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
+    Task ExecuteAsync(Octopus.Client.OctopusServerEndpoint, CancellationToken)
+    Task ExecuteAsync(Octopus.Client.OctopusAsyncRepository, CancellationToken)
+    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository, CancellationToken)
   }
   interface IRegisterWorkerOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -6512,7 +6510,7 @@ Octopus.Client.Operations
     String[] Tenants { get; set; }
     String[] TenantTags { get; set; }
     void Execute(Octopus.Client.IOctopusSpaceRepository)
-    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
+    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository, CancellationToken)
   }
   abstract class RegisterMachineOperationBase
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -6530,9 +6528,9 @@ Octopus.Client.Operations
     void Execute(Octopus.Client.OctopusServerEndpoint)
     void Execute(Octopus.Client.OctopusRepository)
     void Execute(Octopus.Client.IOctopusSpaceRepository)
-    Task ExecuteAsync(Octopus.Client.OctopusServerEndpoint)
-    Task ExecuteAsync(Octopus.Client.OctopusAsyncRepository)
-    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
+    Task ExecuteAsync(Octopus.Client.OctopusServerEndpoint, CancellationToken)
+    Task ExecuteAsync(Octopus.Client.OctopusAsyncRepository, CancellationToken)
+    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository, CancellationToken)
   }
   class RegisterWorkerOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -6543,7 +6541,7 @@ Octopus.Client.Operations
     .ctor(Octopus.Client.IOctopusClientFactory)
     String[] WorkerPoolNames { get; set; }
     void Execute(Octopus.Client.IOctopusSpaceRepository)
-    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
+    Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository, CancellationToken)
   }
 }
 Octopus.Client.Repositories
@@ -7314,16 +7312,16 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    Task<List<TAccount>> FindAllOfType(Object)
-    Task<TAccount> FindByNameOfType(String)
-    Task<List<TAccount>> FindByNamesOfType(IEnumerable<String>)
-    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object)
-    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object)
-    Task<AccountUsageResource> GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
-    Task<TAccount> GetOfType(String)
-    Task<List<TAccount>> GetOfType(String[])
-    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
-    Task<TAccount> RefreshOfType(Octopus.Client.Repositories.Async.TAccount)
+    Task<List<TAccount>> FindAllOfType(Object, CancellationToken)
+    Task<TAccount> FindByNameOfType(String, CancellationToken)
+    Task<List<TAccount>> FindByNamesOfType(IEnumerable<String>, CancellationToken)
+    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object, CancellationToken)
+    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object, CancellationToken)
+    Task<AccountUsageResource> GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource, CancellationToken)
+    Task<TAccount> GetOfType(String, CancellationToken)
+    Task<List<TAccount>> GetOfType(CancellationToken, String[])
+    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object, CancellationToken)
+    Task<TAccount> RefreshOfType(Octopus.Client.Repositories.Async.TAccount, CancellationToken)
   }
   interface IActionTemplateRepository
     Octopus.Client.Repositories.Async.ICreate<ActionTemplateResource>
@@ -7334,10 +7332,10 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<ActionTemplateResource>
     Octopus.Client.Repositories.Async.IGetAll<ActionTemplateResource>
   {
-    Task<ActionTemplateResource> GetVersion(Octopus.Client.Model.ActionTemplateResource, Int32)
-    Task<List<ActionTemplateSearchResource>> Search()
-    Task SetLogo(Octopus.Client.Model.ActionTemplateResource, String, Stream)
-    Task<ActionUpdateResultResource[]> UpdateActions(Octopus.Client.Model.ActionTemplateResource, Octopus.Client.Model.ActionsUpdateResource)
+    Task<ActionTemplateResource> GetVersion(Octopus.Client.Model.ActionTemplateResource, Int32, CancellationToken)
+    Task<List<ActionTemplateSearchResource>> Search(CancellationToken)
+    Task SetLogo(Octopus.Client.Model.ActionTemplateResource, String, Stream, CancellationToken)
+    Task<ActionUpdateResultResource[]> UpdateActions(Octopus.Client.Model.ActionTemplateResource, Octopus.Client.Model.ActionsUpdateResource, CancellationToken)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.Async.IPaginate<ArtifactResource>
@@ -7346,14 +7344,14 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<ArtifactResource>
     Octopus.Client.Repositories.Async.IDelete<ArtifactResource>
   {
-    Task<ResourceCollection<ArtifactResource>> FindRegarding(Octopus.Client.Extensibility.IResource)
-    Task<Stream> GetContent(Octopus.Client.Model.ArtifactResource)
-    Task PutContent(Octopus.Client.Model.ArtifactResource, Stream)
+    Task<ResourceCollection<ArtifactResource>> FindRegarding(Octopus.Client.Extensibility.IResource, CancellationToken)
+    Task<Stream> GetContent(Octopus.Client.Model.ArtifactResource, CancellationToken)
+    Task PutContent(Octopus.Client.Model.ArtifactResource, Stream, CancellationToken)
   }
   interface IBackupRepository
   {
-    Task<BackupConfigurationResource> GetConfiguration()
-    Task<BackupConfigurationResource> ModifyConfiguration(Octopus.Client.Model.BackupConfigurationResource)
+    Task<BackupConfigurationResource> GetConfiguration(CancellationToken)
+    Task<BackupConfigurationResource> ModifyConfiguration(Octopus.Client.Model.BackupConfigurationResource, CancellationToken)
   }
   interface IBranchScopedRepository
   {
@@ -7361,25 +7359,25 @@ Octopus.Client.Repositories.Async
   }
   interface IBuildInformationRepository
   {
-    Task Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
-    Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
-    Task<OctopusPackageVersionBuildInformationMappedResource> Get(String)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32, Int32)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32, Int32)
-    Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
-    Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Boolean)
+    Task Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource, CancellationToken)
+    Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>, CancellationToken)
+    Task<OctopusPackageVersionBuildInformationMappedResource> Get(String, CancellationToken)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32, Int32, CancellationToken)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32, Int32, CancellationToken)
+    Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode, CancellationToken)
+    Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Boolean, CancellationToken)
   }
   interface IBuiltInPackageRepositoryRepository
   {
-    Task DeletePackage(Octopus.Client.Model.PackageResource)
-    Task DeletePackages(IReadOnlyList<PackageResource>)
-    Task<PackageFromBuiltInFeedResource> GetPackage(String, String)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
+    Task DeletePackage(Octopus.Client.Model.PackageResource, CancellationToken)
+    Task DeletePackages(IReadOnlyList<PackageResource>, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> GetPackage(String, String, CancellationToken)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32, CancellationToken)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, CancellationToken)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean, CancellationToken)
   }
   interface ICanExtendSpaceContext`1
   {
@@ -7390,8 +7388,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<CertificateConfigurationResource>
     Octopus.Client.Repositories.Async.IPaginate<CertificateConfigurationResource>
   {
-    Task<CertificateConfigurationResource> GetOctopusCertificate()
-    Task<Stream> GetPublicCertificate(Octopus.Client.Model.CertificateConfigurationResource)
+    Task<CertificateConfigurationResource> GetOctopusCertificate(CancellationToken)
+    Task<Stream> GetPublicCertificate(Octopus.Client.Model.CertificateConfigurationResource, CancellationToken)
   }
   interface ICertificateRepository
     Octopus.Client.Repositories.Async.IResourceRepository
@@ -7402,12 +7400,12 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<CertificateResource>
     Octopus.Client.Repositories.Async.IDelete<CertificateResource>
   {
-    Task Archive(Octopus.Client.Model.CertificateResource)
-    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
-    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
-    Task<CertificateConfigurationResource> GetOctopusCertificate()
-    Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String)
-    Task UnArchive(Octopus.Client.Model.CertificateResource)
+    Task Archive(Octopus.Client.Model.CertificateResource, CancellationToken)
+    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean, CancellationToken)
+    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions, CancellationToken)
+    Task<CertificateConfigurationResource> GetOctopusCertificate(CancellationToken)
+    Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String, CancellationToken)
+    Task UnArchive(Octopus.Client.Model.CertificateResource, CancellationToken)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.Async.ICreate<ChannelResource>
@@ -7416,60 +7414,60 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ChannelResource>
     Octopus.Client.Repositories.Async.IPaginate<ChannelResource>
   {
-    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String)
-    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
-    Task<ChannelResource> FindByName(Octopus.Client.Model.ProjectResource, String)
-    Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ChannelResource)
-    Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ChannelResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32, Nullable<Int32>, String)
+    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ChannelEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
+    Task<ChannelResource> FindByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ChannelResource, CancellationToken)
+    Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ChannelResource, String, CancellationToken)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32, Nullable<Int32>, String, CancellationToken)
   }
   interface ICommunityActionTemplateRepository
     Octopus.Client.Repositories.Async.IGet<CommunityActionTemplateResource>
   {
-    Task<ActionTemplateResource> GetInstalledTemplate(Octopus.Client.Model.CommunityActionTemplateResource)
-    Task Install(Octopus.Client.Model.CommunityActionTemplateResource)
-    Task UpdateInstallation(Octopus.Client.Model.CommunityActionTemplateResource)
+    Task<ActionTemplateResource> GetInstalledTemplate(Octopus.Client.Model.CommunityActionTemplateResource, CancellationToken)
+    Task Install(Octopus.Client.Model.CommunityActionTemplateResource, CancellationToken)
+    Task UpdateInstallation(Octopus.Client.Model.CommunityActionTemplateResource, CancellationToken)
   }
   interface IConfigurationRepository
   {
-    Task<T> Get()
-    Task<T> Modify(Octopus.Client.Repositories.Async.T)
+    Task<T> Get(CancellationToken)
+    Task<T> Modify(Octopus.Client.Repositories.Async.T, CancellationToken)
   }
   interface ICreate`1
   {
-    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object)
+    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object, CancellationToken)
   }
   interface IDashboardConfigurationRepository
   {
-    Task<DashboardConfigurationResource> GetDashboardConfiguration()
-    Task<DashboardConfigurationResource> ModifyDashboardConfiguration(Octopus.Client.Model.DashboardConfigurationResource)
+    Task<DashboardConfigurationResource> GetDashboardConfiguration(CancellationToken)
+    Task<DashboardConfigurationResource> ModifyDashboardConfiguration(Octopus.Client.Model.DashboardConfigurationResource, CancellationToken)
   }
   interface IDashboardRepository
   {
-    Task<DashboardResource> GetDashboard()
-    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
+    Task<DashboardResource> GetDashboard(CancellationToken)
+    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions, CancellationToken)
   }
   interface IDefectsRepository
   {
-    Task<ResourceCollection<DefectResource>> GetDefects(Octopus.Client.Model.ReleaseResource)
-    Task RaiseDefect(Octopus.Client.Model.ReleaseResource, String)
-    Task ResolveDefect(Octopus.Client.Model.ReleaseResource)
+    Task<ResourceCollection<DefectResource>> GetDefects(Octopus.Client.Model.ReleaseResource, CancellationToken)
+    Task RaiseDefect(Octopus.Client.Model.ReleaseResource, String, CancellationToken)
+    Task ResolveDefect(Octopus.Client.Model.ReleaseResource, CancellationToken)
   }
   interface IDelete`1
   {
-    Task Delete(Octopus.Client.Repositories.Async.TResource)
+    Task Delete(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IDeploymentProcessBetaRepository
   {
-    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
-    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
+    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String, CancellationToken)
   }
   interface IDeploymentProcessRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
     Octopus.Client.Repositories.Async.IModify<DeploymentProcessResource>
   {
     Octopus.Client.Repositories.Async.IDeploymentProcessBetaRepository Beta()
-    Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
+    Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource, CancellationToken)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>
@@ -7477,11 +7475,11 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.Async.IDelete<DeploymentResource>
   {
-    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32, Nullable<Int32>)
-    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32, Nullable<Int32>)
-    Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource)
-    Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
-    Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
+    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32, Nullable<Int32>, CancellationToken)
+    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32, Nullable<Int32>, CancellationToken)
+    Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource, CancellationToken)
+    Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>, CancellationToken)
+    Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>, CancellationToken)
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>
@@ -7492,28 +7490,28 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<EnvironmentResource>
     Octopus.Client.Repositories.Async.IGetAll<EnvironmentResource>
   {
-    Task<EnvironmentEditor> CreateOrModify(String)
-    Task<EnvironmentEditor> CreateOrModify(String, String)
-    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
-    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
-    Task Sort(String[])
-    Task<EnvironmentsSummaryResource> Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
+    Task<EnvironmentEditor> CreateOrModify(String, CancellationToken)
+    Task<EnvironmentEditor> CreateOrModify(String, String, CancellationToken)
+    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean, CancellationToken)
+    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String, CancellationToken)
+    Task Sort(String[], CancellationToken)
+    Task<EnvironmentsSummaryResource> Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>, CancellationToken)
   }
   interface IEventRepository
     Octopus.Client.Repositories.Async.IGet<EventResource>
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<IEventRepository>
   {
-    Task<IReadOnlyList<EventAgentResource>> GetAgents()
-    Task<IReadOnlyList<EventCategoryResource>> GetCategories()
-    Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes()
-    Task<IReadOnlyList<EventGroupResource>> GetGroups()
-    Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean)
-    Task<ResourceCollection<EventResource>> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
+    Task<IReadOnlyList<EventAgentResource>> GetAgents(CancellationToken)
+    Task<IReadOnlyList<EventCategoryResource>> GetCategories(CancellationToken)
+    Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes(CancellationToken)
+    Task<IReadOnlyList<EventGroupResource>> GetGroups(CancellationToken)
+    Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean, CancellationToken)
+    Task<ResourceCollection<EventResource>> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String, CancellationToken)
   }
   interface IFeaturesConfigurationRepository
   {
-    Task<FeaturesConfigurationResource> GetFeaturesConfiguration()
-    Task<FeaturesConfigurationResource> ModifyFeaturesConfiguration(Octopus.Client.Model.FeaturesConfigurationResource)
+    Task<FeaturesConfigurationResource> GetFeaturesConfiguration(CancellationToken)
+    Task<FeaturesConfigurationResource> ModifyFeaturesConfiguration(Octopus.Client.Model.FeaturesConfigurationResource, CancellationToken)
   }
   interface IFeedRepository
     Octopus.Client.Repositories.Async.ICreate<FeedResource>
@@ -7523,31 +7521,31 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<FeedResource>
     Octopus.Client.Repositories.Async.IPaginate<FeedResource>
   {
-    Task<List<PackageResource>> GetVersions(Octopus.Client.Model.FeedResource, String[])
+    Task<List<PackageResource>> GetVersions(Octopus.Client.Model.FeedResource, String[], CancellationToken)
   }
   interface IFindByName`1
     Octopus.Client.Repositories.Async.IPaginate<TResource>
   {
-    Task<TResource> FindByName(String, String, Object)
-    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object)
+    Task<TResource> FindByName(String, String, Object, CancellationToken)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
   interface IGetAll`1
   {
-    Task<List<TResource>> GetAll()
+    Task<List<TResource>> GetAll(CancellationToken)
   }
   interface IGet`1
   {
-    Task<TResource> Get(String)
-    Task<List<TResource>> Get(String[])
-    Task<TResource> Refresh(Octopus.Client.Repositories.Async.TResource)
+    Task<TResource> Get(String, CancellationToken)
+    Task<List<TResource>> Get(CancellationToken, String[])
+    Task<TResource> Refresh(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IInterruptionRepository
     Octopus.Client.Repositories.Async.IGet<InterruptionResource>
   {
-    Task<UserResource> GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Task<ResourceCollection<InterruptionResource>> List(Int32, Nullable<Int32>, Boolean, String)
-    Task Submit(Octopus.Client.Model.InterruptionResource)
-    Task TakeResponsibility(Octopus.Client.Model.InterruptionResource)
+    Task<UserResource> GetResponsibleUser(Octopus.Client.Model.InterruptionResource, CancellationToken)
+    Task<ResourceCollection<InterruptionResource>> List(Int32, Nullable<Int32>, Boolean, String, CancellationToken)
+    Task Submit(Octopus.Client.Model.InterruptionResource, CancellationToken)
+    Task TakeResponsibility(Octopus.Client.Model.InterruptionResource, CancellationToken)
   }
   interface ILibraryVariableSetRepository
     Octopus.Client.Repositories.Async.ICreate<LibraryVariableSetResource>
@@ -7557,14 +7555,14 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<LibraryVariableSetResource>
     Octopus.Client.Repositories.Async.IPaginate<LibraryVariableSetResource>
   {
-    Task<LibraryVariableSetEditor> CreateOrModify(String)
-    Task<LibraryVariableSetEditor> CreateOrModify(String, String)
+    Task<LibraryVariableSetEditor> CreateOrModify(String, CancellationToken)
+    Task<LibraryVariableSetEditor> CreateOrModify(String, String, CancellationToken)
   }
   interface ILicensesRepository
   {
-    Task<LicenseResource> GetCurrent()
-    Task<LicenseStatusResource> GetStatus()
-    Task<LicenseResource> UpdateCurrent(Octopus.Client.Model.LicenseResource)
+    Task<LicenseResource> GetCurrent(CancellationToken)
+    Task<LicenseStatusResource> GetStatus(CancellationToken)
+    Task<LicenseResource> UpdateCurrent(Octopus.Client.Model.LicenseResource, CancellationToken)
   }
   interface ILifecyclesRepository
     Octopus.Client.Repositories.Async.IGet<LifecycleResource>
@@ -7574,8 +7572,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<LifecycleResource>
     Octopus.Client.Repositories.Async.IPaginate<LifecycleResource>
   {
-    Task<LifecycleEditor> CreateOrModify(String)
-    Task<LifecycleEditor> CreateOrModify(String, String)
+    Task<LifecycleEditor> CreateOrModify(String, CancellationToken)
+    Task<LifecycleEditor> CreateOrModify(String, String, CancellationToken)
   }
   interface IMachinePolicyRepository
     Octopus.Client.Repositories.Async.IFindByName<MachinePolicyResource>
@@ -7585,8 +7583,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<MachinePolicyResource>
     Octopus.Client.Repositories.Async.IDelete<MachinePolicyResource>
   {
-    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.MachinePolicyResource)
-    Task<MachinePolicyResource> GetTemplate()
+    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.MachinePolicyResource, CancellationToken)
+    Task<MachinePolicyResource> GetTemplate(CancellationToken)
   }
   interface IMachineRepository
     Octopus.Client.Repositories.Async.IFindByName<MachineResource>
@@ -7596,28 +7594,28 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<MachineResource>
     Octopus.Client.Repositories.Async.IDelete<MachineResource>
   {
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
-    Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions)
-    Task<List<MachineResource>> FindByThumbprint(String)
-    Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource)
-    Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource)
-    Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Task<ResourceCollection<MachineResource>> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>, CancellationToken)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], CancellationToken)
+    Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>, CancellationToken)
+    Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions, CancellationToken)
+    Task<List<MachineResource>> FindByThumbprint(String, CancellationToken)
+    Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource, CancellationToken)
+    Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, CancellationToken)
+    Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, Object, CancellationToken)
+    Task<ResourceCollection<MachineResource>> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String, CancellationToken)
   }
   interface IMachineRoleRepository
   {
-    Task<List<String>> GetAllRoleNames()
+    Task<List<String>> GetAllRoleNames(CancellationToken)
   }
   interface IMigrationRepository
   {
-    Task<MigrationImportResource> Import(Octopus.Client.Model.Migrations.MigrationImportResource)
-    Task<MigrationPartialExportResource> PartialExport(Octopus.Client.Model.Migrations.MigrationPartialExportResource)
+    Task<MigrationImportResource> Import(Octopus.Client.Model.Migrations.MigrationImportResource, CancellationToken)
+    Task<MigrationPartialExportResource> PartialExport(Octopus.Client.Model.Migrations.MigrationPartialExportResource, CancellationToken)
   }
   interface IModify`1
   {
-    Task<TResource> Modify(Octopus.Client.Repositories.Async.TResource)
+    Task<TResource> Modify(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IOctopusServerNodeRepository
     Octopus.Client.Repositories.Async.IModify<OctopusServerNodeResource>
@@ -7626,8 +7624,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<OctopusServerNodeResource>
     Octopus.Client.Repositories.Async.IPaginate<OctopusServerNodeResource>
   {
-    Task<OctopusServerNodeDetailsResource> Details(Octopus.Client.Model.OctopusServerNodeResource)
-    Task<OctopusServerClusterSummaryResource> Summary()
+    Task<OctopusServerNodeDetailsResource> Details(Octopus.Client.Model.OctopusServerNodeResource, CancellationToken)
+    Task<OctopusServerClusterSummaryResource> Summary(CancellationToken)
   }
   interface IOctopusSpaceAsyncBetaRepository
   {
@@ -7635,26 +7633,26 @@ Octopus.Client.Repositories.Async
   }
   interface IPackageMetadataRepository
   {
-    Task<OctopusPackageMetadataMappedResource> Get(String)
-    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode)
-    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Boolean)
+    Task<OctopusPackageMetadataMappedResource> Get(String, CancellationToken)
+    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Octopus.Client.Model.OverwriteMode, CancellationToken)
+    Task<OctopusPackageMetadataMappedResource> Push(String, String, Octopus.Client.Model.PackageMetadata.OctopusPackageMetadata, Boolean, CancellationToken)
   }
   interface IPaginate`1
   {
-    Task<List<TResource>> FindAll(String, Object)
-    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object)
-    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object)
-    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
+    Task<List<TResource>> FindAll(String, Object, CancellationToken)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object, CancellationToken)
+    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object, CancellationToken)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object, CancellationToken)
   }
   interface IPerformanceConfigurationRepository
   {
-    Task<PerformanceConfigurationResource> Get()
-    Task<PerformanceConfigurationResource> Modify(Octopus.Client.Model.PerformanceConfigurationResource)
+    Task<PerformanceConfigurationResource> Get(CancellationToken)
+    Task<PerformanceConfigurationResource> Modify(Octopus.Client.Model.PerformanceConfigurationResource, CancellationToken)
   }
   interface IProjectBetaRepository
   {
-    Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
-    Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
+    Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource, CancellationToken)
   }
   interface IProjectGroupRepository
     Octopus.Client.Repositories.Async.IFindByName<ProjectGroupResource>
@@ -7665,9 +7663,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ProjectGroupResource>
     Octopus.Client.Repositories.Async.IGetAll<ProjectGroupResource>
   {
-    Task<ProjectGroupEditor> CreateOrModify(String)
-    Task<ProjectGroupEditor> CreateOrModify(String, String)
-    Task<List<ProjectResource>> GetProjects(Octopus.Client.Model.ProjectGroupResource)
+    Task<ProjectGroupEditor> CreateOrModify(String, CancellationToken)
+    Task<ProjectGroupEditor> CreateOrModify(String, String, CancellationToken)
+    Task<List<ProjectResource>> GetProjects(Octopus.Client.Model.ProjectGroupResource, CancellationToken)
   }
   interface IProjectRepository
     Octopus.Client.Repositories.Async.IFindByName<ProjectResource>
@@ -7679,22 +7677,22 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGetAll<ProjectResource>
   {
     Octopus.Client.Repositories.Async.IProjectBetaRepository Beta()
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
-    Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)
-    Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ProjectResource)
-    Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(Octopus.Client.Model.ProjectResource)
-    Task<IReadOnlyList<RunbookSnapshotResource>> GetAllRunbookSnapshots(Octopus.Client.Model.ProjectResource)
-    Task<IReadOnlyList<ProjectTriggerResource>> GetAllTriggers(Octopus.Client.Model.ProjectResource)
-    Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource)
-    Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
-    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
-    Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
-    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
-    Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
-    Task SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, CancellationToken)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
+    Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<IReadOnlyList<RunbookSnapshotResource>> GetAllRunbookSnapshots(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<IReadOnlyList<ProjectTriggerResource>> GetAllTriggers(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
+    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
+    Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
+    Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task SetLogo(Octopus.Client.Model.ProjectResource, String, Stream, CancellationToken)
   }
   interface IProjectTriggerRepository
     Octopus.Client.Repositories.Async.ICreate<ProjectTriggerResource>
@@ -7702,9 +7700,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<ProjectTriggerResource>
     Octopus.Client.Repositories.Async.IDelete<ProjectTriggerResource>
   {
-    Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource)
-    Task<ProjectTriggerResource> FindByName(Octopus.Client.Model.ProjectResource, String)
-    Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(String[])
+    Task<ProjectTriggerEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.Triggers.TriggerFilterResource, Octopus.Client.Model.Triggers.TriggerActionResource, CancellationToken)
+    Task<ProjectTriggerResource> FindByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(CancellationToken, String[])
   }
   interface IProxyRepository
     Octopus.Client.Repositories.Async.IGet<ProxyResource>
@@ -7722,13 +7720,13 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<ReleaseResource>
     Octopus.Client.Repositories.Async.IDelete<ReleaseResource>
   {
-    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
-    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
-    Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<LifecycleProgressionResource> GetProgression(Octopus.Client.Model.ReleaseResource)
-    Task<DeploymentTemplateResource> GetTemplate(Octopus.Client.Model.ReleaseResource)
-    Task<ReleaseResource> SnapshotVariables(Octopus.Client.Model.ReleaseResource)
+    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean, CancellationToken)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
+    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
+    Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget, CancellationToken)
+    Task<LifecycleProgressionResource> GetProgression(Octopus.Client.Model.ReleaseResource, CancellationToken)
+    Task<DeploymentTemplateResource> GetTemplate(Octopus.Client.Model.ReleaseResource, CancellationToken)
+    Task<ReleaseResource> SnapshotVariables(Octopus.Client.Model.ReleaseResource, CancellationToken)
   }
   interface IResourceRepository
   {
@@ -7736,13 +7734,13 @@ Octopus.Client.Repositories.Async
   }
   interface IRetentionPolicyRepository
   {
-    Task<TaskResource> ApplyNow(String)
+    Task<TaskResource> ApplyNow(String, CancellationToken)
   }
   interface IRunbookProcessRepository
     Octopus.Client.Repositories.Async.IGet<RunbookProcessResource>
     Octopus.Client.Repositories.Async.IModify<RunbookProcessResource>
   {
-    Task<RunbookSnapshotTemplateResource> GetTemplate(Octopus.Client.Model.RunbookProcessResource)
+    Task<RunbookSnapshotTemplateResource> GetTemplate(Octopus.Client.Model.RunbookProcessResource, CancellationToken)
   }
   interface IRunbookRepository
     Octopus.Client.Repositories.Async.IFindByName<RunbookResource>
@@ -7752,13 +7750,13 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<RunbookResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookResource>
   {
-    Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
-    Task<RunbookResource> FindByName(Octopus.Client.Model.ProjectResource, String)
-    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.RunbookResource)
-    Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.RunbookResource)
-    Task<RunbookRunResource> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunResource)
-    Task<RunbookRunResource[]> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunParameters)
+    Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
+    Task<RunbookResource> FindByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
+    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget, CancellationToken)
+    Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.RunbookResource, CancellationToken)
+    Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.RunbookResource, CancellationToken)
+    Task<RunbookRunResource> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunResource, CancellationToken)
+    Task<RunbookRunResource[]> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunParameters, CancellationToken)
   }
   interface IRunbookRunRepository
     Octopus.Client.Repositories.Async.IGet<RunbookRunResource>
@@ -7766,10 +7764,10 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookRunResource>
   {
-    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
-    Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource)
-    Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
-    Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
+    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32, Nullable<Int32>, CancellationToken)
+    Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource, CancellationToken)
+    Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>, CancellationToken)
+    Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>, CancellationToken)
   }
   interface IRunbookSnapshotRepository
     Octopus.Client.Repositories.Async.IGet<RunbookSnapshotResource>
@@ -7778,23 +7776,23 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<RunbookSnapshotResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookSnapshotResource>
   {
-    Task<RunbookSnapshotResource> Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
-    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
-    Task<RunbookRunTemplateResource> GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
-    Task<RunbookSnapshotResource> SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
+    Task<RunbookSnapshotResource> Create(Octopus.Client.Model.RunbookSnapshotResource, CancellationToken)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>, CancellationToken)
+    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget, CancellationToken)
+    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>, CancellationToken)
+    Task<RunbookRunTemplateResource> GetTemplate(Octopus.Client.Model.RunbookSnapshotResource, CancellationToken)
+    Task<RunbookSnapshotResource> SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource, CancellationToken)
   }
   interface ISchedulerRepository
   {
-    Task<ScheduledTaskDetailsResource> GetLogs(String)
-    Task<Stream> GetRawLogs(String)
-    Task Start()
-    Task Start(String)
-    Task<SchedulerStatusResource> Status()
-    Task Stop()
-    Task Stop(String)
-    Task Trigger(String)
+    Task<ScheduledTaskDetailsResource> GetLogs(String, CancellationToken)
+    Task<Stream> GetRawLogs(String, CancellationToken)
+    Task Start(CancellationToken)
+    Task Start(String, CancellationToken)
+    Task<SchedulerStatusResource> Status(CancellationToken)
+    Task Stop(CancellationToken)
+    Task Stop(String, CancellationToken)
+    Task Trigger(String, CancellationToken)
   }
   interface IScopedUserRoleRepository
     Octopus.Client.Repositories.Async.ICreate<ScopedUserRoleResource>
@@ -7806,9 +7804,9 @@ Octopus.Client.Repositories.Async
   }
   interface IServerStatusRepository
   {
-    Task<ServerStatusHealthResource> GetServerHealth()
-    Task<ServerStatusResource> GetServerStatus()
-    Task<SystemInfoResource> GetSystemInfo(Octopus.Client.Model.ServerStatusResource)
+    Task<ServerStatusHealthResource> GetServerHealth(CancellationToken)
+    Task<ServerStatusResource> GetServerStatus(CancellationToken)
+    Task<SystemInfoResource> GetSystemInfo(Octopus.Client.Model.ServerStatusResource, CancellationToken)
   }
   interface ISpaceRepository
     Octopus.Client.Repositories.Async.ICreate<SpaceResource>
@@ -7818,7 +7816,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<SpaceResource>
     Octopus.Client.Repositories.Async.IGet<SpaceResource>
   {
-    Task SetLogo(Octopus.Client.Model.SpaceResource, String, Stream)
+    Task SetLogo(Octopus.Client.Model.SpaceResource, String, Stream, CancellationToken)
   }
   interface ISubscriptionRepository
     Octopus.Client.Repositories.Async.IFindByName<SubscriptionResource>
@@ -7828,7 +7826,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<SubscriptionResource>
     Octopus.Client.Repositories.Async.IDelete<SubscriptionResource>
   {
-    Task<SubscriptionEditor> CreateOrModify(String, Octopus.Client.Model.EventNotificationSubscription, Boolean)
+    Task<SubscriptionEditor> CreateOrModify(String, Octopus.Client.Model.EventNotificationSubscription, Boolean, CancellationToken)
   }
   interface ITagSetRepository
     Octopus.Client.Repositories.Async.ICreate<TagSetResource>
@@ -7839,9 +7837,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<TagSetResource>
     Octopus.Client.Repositories.Async.IGetAll<TagSetResource>
   {
-    Task<TagSetEditor> CreateOrModify(String)
-    Task<TagSetEditor> CreateOrModify(String, String)
-    Task Sort(String[])
+    Task<TagSetEditor> CreateOrModify(String, CancellationToken)
+    Task<TagSetEditor> CreateOrModify(String, String, CancellationToken)
+    Task Sort(String[], CancellationToken)
   }
   interface ITaskRepository
     Octopus.Client.Repositories.Async.IPaginate<TaskResource>
@@ -7849,27 +7847,27 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.ICreate<TaskResource>
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<ITaskRepository>
   {
-    Task Cancel(Octopus.Client.Model.TaskResource)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteBackup(String)
-    Task<TaskResource> ExecuteCalamariUpdate(String, String[])
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String)
-    Task<TaskResource> ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
-    Task<TaskResource> ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
-    Task<TaskResourceCollection> GetActiveWithSummary(Int32, Int32)
-    Task<List<TaskResource>> GetAllActive(Int32)
-    Task<TaskResourceCollection> GetAllWithSummary(Int32, Int32)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
-    Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
-    Task<String> GetRawOutputLog(Octopus.Client.Model.TaskResource)
-    Task<TaskTypeResource[]> GetTaskTypes()
-    Task ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String)
-    Task Rerun(Octopus.Client.Model.TaskResource)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Func<TaskResource[], Task>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Func<TaskResource[], Task>)
+    Task Cancel(Octopus.Client.Model.TaskResource, CancellationToken)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>, CancellationToken)
+    Task<TaskResource> ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>, CancellationToken)
+    Task<TaskResource> ExecuteBackup(String, CancellationToken)
+    Task<TaskResource> ExecuteCalamariUpdate(String, String[], CancellationToken)
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String, CancellationToken)
+    Task<TaskResource> ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[], CancellationToken)
+    Task<TaskResource> ExecuteTentacleUpgrade(String, String, String[], String, String, String[], CancellationToken)
+    Task<TaskResourceCollection> GetActiveWithSummary(Int32, Int32, CancellationToken)
+    Task<List<TaskResource>> GetAllActive(Int32, CancellationToken)
+    Task<TaskResourceCollection> GetAllWithSummary(Int32, Int32, CancellationToken)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>, CancellationToken)
+    Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource, CancellationToken)
+    Task<String> GetRawOutputLog(Octopus.Client.Model.TaskResource, CancellationToken)
+    Task<TaskTypeResource[]> GetTaskTypes(CancellationToken)
+    Task ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String, CancellationToken)
+    Task Rerun(Octopus.Client.Model.TaskResource, CancellationToken)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>, CancellationToken)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>, CancellationToken)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Func<TaskResource[], Task>, CancellationToken)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Func<TaskResource[], Task>, CancellationToken)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.Async.ICreate<TeamResource>
@@ -7880,7 +7878,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<TeamResource>
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<ITeamsRepository>
   {
-    Task<List<ScopedUserRoleResource>> GetScopedUserRoles(Octopus.Client.Model.TeamResource)
+    Task<List<ScopedUserRoleResource>> GetScopedUserRoles(Octopus.Client.Model.TeamResource, CancellationToken)
   }
   interface ITenantRepository
     Octopus.Client.Repositories.Async.ICreate<TenantResource>
@@ -7891,38 +7889,38 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<TenantResource>
     Octopus.Client.Repositories.Async.IGetAll<TenantResource>
   {
-    Task<TenantEditor> CreateOrModify(String)
-    Task<TenantEditor> CreateOrModify(String, String)
-    Task<TenantEditor> CreateOrModify(String, String, String)
-    Task<List<TenantResource>> FindAll(String, String[], Int32)
-    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String, String, String)
-    Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource)
-    Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
-    Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
-    Task<MultiTenancyStatusResource> Status()
+    Task<TenantEditor> CreateOrModify(String, CancellationToken)
+    Task<TenantEditor> CreateOrModify(String, String, CancellationToken)
+    Task<TenantEditor> CreateOrModify(String, String, String, CancellationToken)
+    Task<List<TenantResource>> FindAll(String, String[], Int32, CancellationToken)
+    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String, String, String, CancellationToken)
+    Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource, CancellationToken)
+    Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource, CancellationToken)
+    Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream, CancellationToken)
+    Task<MultiTenancyStatusResource> Status(CancellationToken)
   }
   interface ITenantVariablesRepository
     Octopus.Client.Repositories.Async.IGetAll<TenantVariableResource>
   {
-    Task<List<TenantVariableResource>> GetAll(Octopus.Client.Model.ProjectResource)
+    Task<List<TenantVariableResource>> GetAll(Octopus.Client.Model.ProjectResource, CancellationToken)
   }
   interface IUpgradeConfigurationRepository
     Octopus.Client.Repositories.Async.IGet<UpgradeConfigurationResource>
     Octopus.Client.Repositories.Async.IModify<UpgradeConfigurationResource>
   {
-    Task<UpgradeConfigurationResource> Get()
+    Task<UpgradeConfigurationResource> Get(CancellationToken)
   }
   interface IUserInvitesRepository
   {
-    Task<InvitationResource> Invite(String)
-    Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection)
+    Task<InvitationResource> Invite(String, CancellationToken)
+    Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection, CancellationToken)
   }
   interface IUserPermissionsRepository
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<IUserPermissionsRepository>
   {
-    Task<Stream> Export(Octopus.Client.Model.UserPermissionSetResource)
-    Task<UserPermissionSetResource> Get(Octopus.Client.Model.UserResource)
-    Task<UserPermissionSetResource> GetConfiguration(Octopus.Client.Model.UserResource)
+    Task<Stream> Export(Octopus.Client.Model.UserPermissionSetResource, CancellationToken)
+    Task<UserPermissionSetResource> Get(Octopus.Client.Model.UserResource, CancellationToken)
+    Task<UserPermissionSetResource> GetConfiguration(Octopus.Client.Model.UserResource, CancellationToken)
   }
   interface IUserRepository
     Octopus.Client.Repositories.Async.IPaginate<UserResource>
@@ -7931,20 +7929,20 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<UserResource>
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
-    Task<UserResource> Create(String, String, String, String)
-    Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
-    Task<UserResource> CreateServiceAccount(String, String)
-    Task<UserResource> FindByUsername(String)
-    Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
-    Task<UserResource> GetCurrent()
-    Task<SpaceResource[]> GetSpaces(Octopus.Client.Model.UserResource)
-    Task<InvitationResource> Invite(String)
-    Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection)
-    Task<UserResource> Register(Octopus.Client.Model.RegisterCommand)
-    Task RevokeApiKey(Octopus.Client.Model.ApiKeyResource)
-    Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignIn(String, String, Boolean)
-    Task SignOut()
+    Task<UserResource> Create(String, String, String, String, CancellationToken)
+    Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String, CancellationToken)
+    Task<UserResource> CreateServiceAccount(String, String, CancellationToken)
+    Task<UserResource> FindByUsername(String, CancellationToken)
+    Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource, CancellationToken)
+    Task<UserResource> GetCurrent(CancellationToken)
+    Task<SpaceResource[]> GetSpaces(Octopus.Client.Model.UserResource, CancellationToken)
+    Task<InvitationResource> Invite(String, CancellationToken)
+    Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection, CancellationToken)
+    Task<UserResource> Register(Octopus.Client.Model.RegisterCommand, CancellationToken)
+    Task RevokeApiKey(Octopus.Client.Model.ApiKeyResource, CancellationToken)
+    Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
+    Task SignIn(String, String, Boolean, CancellationToken)
+    Task SignOut(CancellationToken)
   }
   interface IUserRolesRepository
     Octopus.Client.Repositories.Async.IFindByName<UserRoleResource>
@@ -7958,23 +7956,23 @@ Octopus.Client.Repositories.Async
   interface IUserTeamsRepository
     Octopus.Client.Repositories.Async.ICanExtendSpaceContext<IUserTeamsRepository>
   {
-    Task<TeamNameResource[]> Get(Octopus.Client.Model.UserResource)
+    Task<TeamNameResource[]> Get(Octopus.Client.Model.UserResource, CancellationToken)
   }
   interface IVariableSetRepository
     Octopus.Client.Repositories.Async.IGet<VariableSetResource>
     Octopus.Client.Repositories.Async.IModify<VariableSetResource>
     Octopus.Client.Repositories.Async.IGetAll<VariableSetResource>
   {
-    Task<String[]> GetVariableNames(String, String[])
-    Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String)
+    Task<String[]> GetVariableNames(String, String[], CancellationToken)
+    Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String, CancellationToken)
   }
   interface IVcsRunbookRepository
   {
-    Task<VcsRunbookResource> Create(Octopus.Client.Model.VcsRunbookResource, String)
-    Task Delete(Octopus.Client.Model.VcsRunbookResource, String)
-    Task<VcsRunbookResource> Get(String)
-    Task<ResourceCollection<VcsRunbookResource>> List(String, Int32, Nullable<Int32>)
-    Task<VcsRunbookResource> Modify(Octopus.Client.Model.VcsRunbookResource, String)
+    Task<VcsRunbookResource> Create(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
+    Task Delete(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
+    Task<VcsRunbookResource> Get(String, CancellationToken)
+    Task<ResourceCollection<VcsRunbookResource>> List(String, Int32, Nullable<Int32>, CancellationToken)
+    Task<VcsRunbookResource> Modify(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerPoolResource>
@@ -7985,11 +7983,11 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<WorkerPoolResource>
     Octopus.Client.Repositories.Async.IGetAll<WorkerPoolResource>
   {
-    Task<WorkerPoolEditor> CreateOrModify(String)
-    Task<WorkerPoolEditor> CreateOrModify(String, String)
-    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
-    Task Sort(String[])
-    Task<WorkerPoolsSummaryResource> Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
+    Task<WorkerPoolEditor> CreateOrModify(String, CancellationToken)
+    Task<WorkerPoolEditor> CreateOrModify(String, String, CancellationToken)
+    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String, CancellationToken)
+    Task Sort(String[], CancellationToken)
+    Task<WorkerPoolsSummaryResource> Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>, CancellationToken)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerResource>
@@ -7999,11 +7997,11 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<WorkerResource>
     Octopus.Client.Repositories.Async.IDelete<WorkerResource>
   {
-    Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Task<WorkerResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
-    Task<List<WorkerResource>> FindByThumbprint(String)
-    Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+    Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[], CancellationToken)
+    Task<WorkerResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>, CancellationToken)
+    Task<List<WorkerResource>> FindByThumbprint(String, CancellationToken)
+    Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource, CancellationToken)
+    Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String, CancellationToken)
   }
   class OctopusSpaceAsyncBetaRepository
     Octopus.Client.Repositories.Async.IOctopusSpaceAsyncBetaRepository
@@ -8022,11 +8020,11 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IVcsRunbookRepository
   {
     .ctor(Octopus.Client.IOctopusAsyncRepository, Octopus.Client.Model.VersionControlBranchResource)
-    Task<VcsRunbookResource> Create(Octopus.Client.Model.VcsRunbookResource, String)
-    Task Delete(Octopus.Client.Model.VcsRunbookResource, String)
-    Task<VcsRunbookResource> Get(String)
-    Task<ResourceCollection<VcsRunbookResource>> List(String, Int32, Nullable<Int32>)
-    Task<VcsRunbookResource> Modify(Octopus.Client.Model.VcsRunbookResource, String)
+    Task<VcsRunbookResource> Create(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
+    Task Delete(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
+    Task<VcsRunbookResource> Get(String, CancellationToken)
+    Task<ResourceCollection<VcsRunbookResource>> List(String, Int32, Nullable<Int32>, CancellationToken)
+    Task<VcsRunbookResource> Modify(Octopus.Client.Model.VcsRunbookResource, String, CancellationToken)
   }
 }
 Octopus.Client.Serialization

--- a/source/Octopus.Client/Editors/Async/AccountEditor.cs
+++ b/source/Octopus.Client/Editors/Async/AccountEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model.Accounts;
 using Octopus.Client.Model.Accounts.Usages;
@@ -19,7 +20,7 @@ namespace Octopus.Client.Editors.Async
 
         public TAccountResource Instance { get; private set; }
 
-        public async Task<TAccountEditor> CreateOrModify(string name)
+        public async Task<TAccountEditor> CreateOrModify(string name, CancellationToken token = default)
         {
             var existing = await Repository.FindByName(name).ConfigureAwait(false);
             if (existing == null)
@@ -27,7 +28,7 @@ namespace Octopus.Client.Editors.Async
                 Instance = (TAccountResource)await Repository.Create(new TAccountResource
                 {
                     Name = name
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
@@ -42,9 +43,9 @@ namespace Octopus.Client.Editors.Async
             return (TAccountEditor)this;
         }
 
-        public async Task<TAccountEditor> FindByName(string name)
+        public async Task<TAccountEditor> FindByName(string name, CancellationToken token = default)
         {
-            var existing = await Repository.FindByName(name).ConfigureAwait(false);
+            var existing = await Repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 throw new ArgumentException($"An account with the name {name} could not be found");
@@ -68,15 +69,15 @@ namespace Octopus.Client.Editors.Async
             return (TAccountEditor)this;
         }
 
-        public virtual async Task<TAccountEditor> Save()
+        public virtual async Task<TAccountEditor> Save(CancellationToken token = default)
         {
-            Instance = (TAccountResource)await Repository.Modify(Instance).ConfigureAwait(false);
+            Instance = (TAccountResource)await Repository.Modify(Instance, token).ConfigureAwait(false);
             return (TAccountEditor)this;
         }
 
-        public Task<AccountUsageResource> Usages()
+        public Task<AccountUsageResource> Usages(CancellationToken token = default)
         {
-            return Repository.Client.Get<AccountUsageResource>(Instance.Link("Usages"));
+            return Repository.Client.Get<AccountUsageResource>(Instance.Link("Usages"), token: token);
         }
     }
 }

--- a/source/Octopus.Client/Editors/Async/AzureServicePrincipalAccountEditor.cs
+++ b/source/Octopus.Client/Editors/Async/AzureServicePrincipalAccountEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model.Accounts;
 using Octopus.Client.Repositories.Async;
@@ -12,25 +13,25 @@ namespace Octopus.Client.Editors.Async
         {
         }
 
-        public Task<List<AzureServicePrincipalAccountResource.ResourceGroup>> ResourceGroups()
+        public Task<List<AzureServicePrincipalAccountResource.ResourceGroup>> ResourceGroups(CancellationToken token = default)
         {
-            return Repository.Client.Get<List<AzureServicePrincipalAccountResource.ResourceGroup>>(Instance.Link("ResourceGroups"));
+            return Repository.Client.Get<List<AzureServicePrincipalAccountResource.ResourceGroup>>(Instance.Link("ResourceGroups"), token: token);
         }
 
-        public Task<List<AzureServicePrincipalAccountResource.WebSite>> WebSites()
+        public Task<List<AzureServicePrincipalAccountResource.WebSite>> WebSites(CancellationToken token = default)
         {
-            return Repository.Client.Get<List<AzureServicePrincipalAccountResource.WebSite>>(Instance.Link("WebSites"));
+            return Repository.Client.Get<List<AzureServicePrincipalAccountResource.WebSite>>(Instance.Link("WebSites"), token: token);
         }
 
-        public Task<List<AzureServicePrincipalAccountResource.WebSlot>> WebSlots(AzureServicePrincipalAccountResource.WebSite site)
+        public Task<List<AzureServicePrincipalAccountResource.WebSlot>> WebSlots(AzureServicePrincipalAccountResource.WebSite site, CancellationToken token = default)
         {
             return Repository.Client.Get<List<AzureServicePrincipalAccountResource.WebSlot>>(Instance.Link("WebSlots"),
-                new {id = Instance.Id, resourceGroupName = site.ResourceGroup, webSiteName = site.WebSpace});
+                new {id = Instance.Id, resourceGroupName = site.ResourceGroup, webSiteName = site.WebSpace}, token);
         }
 
-        public Task<List<AzureStorageAccount>> StorageAccounts()
+        public Task<List<AzureStorageAccount>> StorageAccounts(CancellationToken token = default)
         {
-            return Repository.Client.Get<List<AzureStorageAccount>>(Instance.Link("StorageAccounts"));
+            return Repository.Client.Get<List<AzureStorageAccount>>(Instance.Link("StorageAccounts"), token: token);
         }
     }
 }

--- a/source/Octopus.Client/Editors/Async/AzureSubscriptionAccountEditor.cs
+++ b/source/Octopus.Client/Editors/Async/AzureSubscriptionAccountEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model.Accounts;
 using Octopus.Client.Repositories.Async;
@@ -11,32 +12,32 @@ namespace Octopus.Client.Editors.Async
         {
         }
 
-        public Task<List<AzureStorageAccount>> StorageAccounts(AzureSubscriptionAccountResource account)
+        public Task<List<AzureStorageAccount>> StorageAccounts(AzureSubscriptionAccountResource account, CancellationToken token = default)
         {
-            return Repository.Client.Get<List<AzureStorageAccount>>(account.Link("StorageAccounts"));
+            return Repository.Client.Get<List<AzureStorageAccount>>(account.Link("StorageAccounts"), token: token);
         }
 
-        public Task<List<AzureSubscriptionAccountResource.WebSite>> WebSites(AzureSubscriptionAccountResource account)
+        public Task<List<AzureSubscriptionAccountResource.WebSite>> WebSites(AzureSubscriptionAccountResource account, CancellationToken token = default)
         {
-            return Repository.Client.Get<List<AzureSubscriptionAccountResource.WebSite>>(account.Link("WebSites"));
+            return Repository.Client.Get<List<AzureSubscriptionAccountResource.WebSite>>(account.Link("WebSites"), token: token);
         }
 
-        public Task<List<AzureSubscriptionAccountResource.WebSite>> WebSites()
+        public Task<List<AzureSubscriptionAccountResource.WebSite>> WebSites(CancellationToken token = default)
         {
-            return Repository.Client.Get<List<AzureSubscriptionAccountResource.WebSite>>(Instance.Link("WebSites"));
+            return Repository.Client.Get<List<AzureSubscriptionAccountResource.WebSite>>(Instance.Link("WebSites"), token: token);
         }
 
         public Task<List<AzureSubscriptionAccountResource.WebSlot>> WebSlots(AzureSubscriptionAccountResource account,
-            AzureSubscriptionAccountResource.WebSite site)
+            AzureSubscriptionAccountResource.WebSite site, CancellationToken token = default)
         {
             return Repository.Client.Get<List<AzureSubscriptionAccountResource.WebSlot>>(account.Link("WebSlots"),
-                new { resourceGroupName = site.ResourceGroup, webSiteName = site.WebSpace});
+                new { resourceGroupName = site.ResourceGroup, webSiteName = site.WebSpace}, token);
         }
 
-        public Task<List<AzureSubscriptionAccountResource.WebSlot>> WebSlots(AzureSubscriptionAccountResource.WebSite site)
+        public Task<List<AzureSubscriptionAccountResource.WebSlot>> WebSlots(AzureSubscriptionAccountResource.WebSite site, CancellationToken token = default)
         {
             return Repository.Client.Get<List<AzureSubscriptionAccountResource.WebSlot>>(Instance.Link("WebSlots"),
-                new { resourceGroupName = site.ResourceGroup, webSiteName = site.WebSpace });
+                new { resourceGroupName = site.ResourceGroup, webSiteName = site.WebSpace }, token: token);
         }
     }
 }

--- a/source/Octopus.Client/Editors/Async/CertificateEditor.cs
+++ b/source/Octopus.Client/Editors/Async/CertificateEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -16,9 +17,9 @@ namespace Octopus.Client.Editors.Async
 
         public CertificateResource Instance { get; private set; }
 
-        public async Task<CertificateEditor> Create(string name, string certificateData)
+        public async Task<CertificateEditor> Create(string name, string certificateData, CancellationToken token = default)
         {
-            var existing = repository.FindByName(name);
+            var existing = repository.FindByName(name, token: token);
             if (existing != null)
             {
                 throw new ArgumentException($"A certificate with the name {name} already exists");
@@ -29,9 +30,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<CertificateEditor> FindByName(string name)
+        public async Task<CertificateEditor> FindByName(string name, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 throw new ArgumentException($"A certificate with the name {name} could not be found");
@@ -50,15 +51,15 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<CertificateEditor> Save()
+        public async Task<CertificateEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
 
-        public async Task<CertificateUsageResource> Usages()
+        public async Task<CertificateUsageResource> Usages(CancellationToken token = default)
         {
-            return await repository.Client.Get<CertificateUsageResource>(Instance.Link("Usages")).ConfigureAwait(false);
+            return await repository.Client.Get<CertificateUsageResource>(Instance.Link("Usages"), token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Editors/Async/ChannelEditor.cs
+++ b/source/Octopus.Client/Editors/Async/ChannelEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -16,9 +17,9 @@ namespace Octopus.Client.Editors.Async
 
         public ChannelResource Instance { get; private set; }
 
-        public async Task<ChannelEditor> CreateOrModify(ProjectResource project, string name)
+        public async Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(project, name).ConfigureAwait(false);
+            var existing = await repository.FindByName(project, name, token).ConfigureAwait(false);
 
             if (existing == null)
             {
@@ -26,21 +27,21 @@ namespace Octopus.Client.Editors.Async
                 {
                     ProjectId = project.Id,
                     Name = name
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
         }
 
-        public async Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, string description)
+        public async Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, string description, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(project, name).ConfigureAwait(false);
+            var existing = await repository.FindByName(project, name, token).ConfigureAwait(false);
 
             if (existing == null)
             {
@@ -49,14 +50,14 @@ namespace Octopus.Client.Editors.Async
                     ProjectId = project.Id,
                     Name = name,
                     Description = description
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
                 existing.Description = description;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -116,9 +117,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<ChannelEditor> Save()
+        public async Task<ChannelEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/DeploymentProcessEditor.cs
+++ b/source/Octopus.Client/Editors/Async/DeploymentProcessEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -16,9 +17,9 @@ namespace Octopus.Client.Editors.Async
 
         public DeploymentProcessResource Instance { get; private set; }
 
-        public async Task<DeploymentProcessEditor> Load(string id)
+        public async Task<DeploymentProcessEditor> Load(string id, CancellationToken token = default)
         {
-            Instance = await repository.Get(id).ConfigureAwait(false);
+            Instance = await repository.Get(id, token).ConfigureAwait(false);
             return this;
         }
 
@@ -50,9 +51,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<DeploymentProcessEditor> Save()
+        public async Task<DeploymentProcessEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/EnvironmentEditor.cs
+++ b/source/Octopus.Client/Editors/Async/EnvironmentEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -16,29 +17,29 @@ namespace Octopus.Client.Editors.Async
 
         public EnvironmentResource Instance { get; private set; }
 
-        public async Task<EnvironmentEditor> CreateOrModify(string name)
+        public async Task<EnvironmentEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new EnvironmentResource
                 {
                     Name = name,
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
         }
 
-        public async Task<EnvironmentEditor> CreateOrModify(string name, string description, bool allowDynamicInfrastructure = false)
+        public async Task<EnvironmentEditor> CreateOrModify(string name, string description, bool allowDynamicInfrastructure = false, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new EnvironmentResource
@@ -46,7 +47,7 @@ namespace Octopus.Client.Editors.Async
                     Name = name,
                     Description = description,
                     AllowDynamicInfrastructure = allowDynamicInfrastructure
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
@@ -54,13 +55,13 @@ namespace Octopus.Client.Editors.Async
                 existing.Description = description;
                 existing.AllowDynamicInfrastructure = allowDynamicInfrastructure;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
         }
 
-        public async Task<EnvironmentEditor> CreateOrModify(string name, string description)
+        public async Task<EnvironmentEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
             var existing = await repository.FindByName(name).ConfigureAwait(false);
             if (existing == null)
@@ -69,14 +70,14 @@ namespace Octopus.Client.Editors.Async
                 {
                     Name = name,
                     Description = description,
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
                 existing.Description = description;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -88,9 +89,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<EnvironmentEditor> Save()
+        public async Task<EnvironmentEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/IResourceEditor.cs
+++ b/source/Octopus.Client/Editors/Async/IResourceEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -10,7 +11,7 @@ namespace Octopus.Client.Editors.Async
     {
         TResource Instance { get; }
         TResourceBuilder Customize(Action<TResource> customize);
-        Task<TResourceBuilder> Save();
+        Task<TResourceBuilder> Save(CancellationToken token = default);
     }
 
     public interface IResourceBuilder

--- a/source/Octopus.Client/Editors/Async/LibraryVariableSetEditor.cs
+++ b/source/Octopus.Client/Editors/Async/LibraryVariableSetEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -22,30 +23,30 @@ namespace Octopus.Client.Editors.Async
 
         public IVariableTemplateContainerEditor<LibraryVariableSetResource> VariableTemplates => Instance;
 
-        public async Task<LibraryVariableSetEditor> CreateOrModify(string name)
+        public async Task<LibraryVariableSetEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
 
             if (existing == null)
             {
                 Instance = await repository.Create(new LibraryVariableSetResource
                 {
                     Name = name,
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
         }
 
-        public async Task<LibraryVariableSetEditor> CreateOrModify(string name, string description)
+        public async Task<LibraryVariableSetEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
 
             if (existing == null)
             {
@@ -53,14 +54,14 @@ namespace Octopus.Client.Editors.Async
                 {
                     Name = name,
                     Description = description
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
                 existing.Description = description;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -72,9 +73,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<LibraryVariableSetEditor> Save()
+        public async Task<LibraryVariableSetEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             if (variables.IsValueCreated)
             {
                 var vars = await variables.Value.ConfigureAwait(false);

--- a/source/Octopus.Client/Editors/Async/LifecycleEditor.cs
+++ b/source/Octopus.Client/Editors/Async/LifecycleEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -17,7 +18,7 @@ namespace Octopus.Client.Editors.Async
 
         public LifecycleResource Instance { get; private set; }
 
-        public async Task<LifecycleEditor> CreateOrModify(string name)
+        public async Task<LifecycleEditor> CreateOrModify(string name, CancellationToken token = default)
         {
             var existing = await repository.FindByName(name).ConfigureAwait(false);
             if (existing == null)
@@ -25,35 +26,35 @@ namespace Octopus.Client.Editors.Async
                 Instance = await repository.Create(new LifecycleResource
                 {
                     Name = name,
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
         }
 
-        public async Task<LifecycleEditor> CreateOrModify(string name, string description)
+        public async Task<LifecycleEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new LifecycleResource
                 {
                     Name = name,
                     Description = description
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
                 existing.Description = description;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token: token).ConfigureAwait(false);
             }
 
             return this;
@@ -88,9 +89,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<LifecycleEditor> Save()
+        public async Task<LifecycleEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/MachineEditor.cs
+++ b/source/Octopus.Client/Editors/Async/MachineEditor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
@@ -22,9 +23,10 @@ namespace Octopus.Client.Editors.Async
             string name,
             EndpointResource endpoint,
             EnvironmentResource[] environments,
-            string[] roles)
+            string[] roles,
+            CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new MachineResource
@@ -33,7 +35,7 @@ namespace Octopus.Client.Editors.Async
                     Endpoint = endpoint,
                     EnvironmentIds = new ReferenceCollection(environments.Select(e => e.Id)),
                     Roles = new ReferenceCollection(roles)
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
@@ -42,7 +44,7 @@ namespace Octopus.Client.Editors.Async
                 existing.EnvironmentIds.ReplaceAll(environments.Select(e => e.Id));
                 existing.Roles.ReplaceAll(roles);
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -55,9 +57,10 @@ namespace Octopus.Client.Editors.Async
             string[] roles,
             TenantResource[] tenants,
             TagResource[] tenantTags, 
-            TenantedDeploymentMode? tenantedDeploymentParticipation = null)
+            TenantedDeploymentMode? tenantedDeploymentParticipation = null,
+            CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             
             if (existing == null)
             {
@@ -76,7 +79,7 @@ namespace Octopus.Client.Editors.Async
                     resource.TenantedDeploymentParticipation = tenantedDeploymentParticipation.Value;
                 }
                 
-                Instance = await repository.Create(resource).ConfigureAwait(false);
+                Instance = await repository.Create(resource, token: token).ConfigureAwait(false);
             }
             else
             {
@@ -92,7 +95,7 @@ namespace Octopus.Client.Editors.Async
                     existing.TenantedDeploymentParticipation = tenantedDeploymentParticipation.Value;
                 }
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -134,9 +137,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<MachineEditor> Save()
+        public async Task<MachineEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/ProjectChannelsEditor.cs
+++ b/source/Octopus.Client/Editors/Async/ProjectChannelsEditor.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
+using System.Threading;
 
 namespace Octopus.Client.Editors.Async
 {
@@ -19,32 +20,32 @@ namespace Octopus.Client.Editors.Async
             this.owner = owner;
         }
 
-        public async Task<ChannelEditor> CreateOrModify(string name)
+        public async Task<ChannelEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            var channelBuilder = await new ChannelEditor(repository).CreateOrModify(owner, name).ConfigureAwait(false);
+            var channelBuilder = await new ChannelEditor(repository).CreateOrModify(owner, name, token).ConfigureAwait(false);
             trackedChannelBuilders.Add(channelBuilder);
             return channelBuilder;
         }
 
-        public async Task<ChannelEditor> CreateOrModify(string name, string description)
+        public async Task<ChannelEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            var channelBuilder = await new ChannelEditor(repository).CreateOrModify(owner, name, description).ConfigureAwait(false);
+            var channelBuilder = await new ChannelEditor(repository).CreateOrModify(owner, name, description, token).ConfigureAwait(false);
             trackedChannelBuilders.Add(channelBuilder);
             return channelBuilder;
         }
 
-        public async Task<ProjectChannelsEditor> Delete(string name)
+        public async Task<ProjectChannelsEditor> Delete(string name, CancellationToken token = default)
         {
-            var channel = await repository.FindByName(owner, name).ConfigureAwait(false);
+            var channel = await repository.FindByName(owner, name, token).ConfigureAwait(false);
             if (channel != null)
-                await repository.Delete(channel).ConfigureAwait(false);
+                await repository.Delete(channel, token).ConfigureAwait(false);
             return this;
         }
 
-        public async Task<ProjectChannelsEditor> SaveAll()
+        public async Task<ProjectChannelsEditor> SaveAll(CancellationToken token = default)
         {
             await Task.WhenAll(
-                trackedChannelBuilders.Select(x => x.Save())
+                trackedChannelBuilders.Select(x => x.Save(token))
             ).ConfigureAwait(false);
             return this;
         }

--- a/source/Octopus.Client/Editors/Async/ProjectGroupEditor.cs
+++ b/source/Octopus.Client/Editors/Async/ProjectGroupEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -16,7 +17,7 @@ namespace Octopus.Client.Editors.Async
 
         public ProjectGroupResource Instance { get; private set; }
 
-        public async Task<ProjectGroupEditor> CreateOrModify(string name)
+        public async Task<ProjectGroupEditor> CreateOrModify(string name, CancellationToken token)
         {
             var existing = await repository.FindByName(name).ConfigureAwait(false);
             if (existing == null)
@@ -24,18 +25,18 @@ namespace Octopus.Client.Editors.Async
                 Instance = await repository.Create(new ProjectGroupResource
                 {
                     Name = name,
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
         }
-        public async Task<ProjectGroupEditor> CreateOrModify(string name, string description)
+        public async Task<ProjectGroupEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
             var existing = await repository.FindByName(name).ConfigureAwait(false);
             if (existing == null)
@@ -44,14 +45,14 @@ namespace Octopus.Client.Editors.Async
                 {
                     Name = name,
                     Description = description
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
                 existing.Description = description;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -63,9 +64,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<ProjectGroupEditor> Save()
+        public async Task<ProjectGroupEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/ProjectTriggerEditor.cs
+++ b/source/Octopus.Client/Editors/Async/ProjectTriggerEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Triggers;
@@ -17,9 +18,9 @@ namespace Octopus.Client.Editors.Async
 
         public ProjectTriggerResource Instance { get; private set; }
 
-        public async Task<ProjectTriggerEditor> CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action)
+        public async Task<ProjectTriggerEditor> CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(project, name).ConfigureAwait(false);
+            var existing = await repository.FindByName(project, name, token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new ProjectTriggerResource
@@ -28,14 +29,14 @@ namespace Octopus.Client.Editors.Async
                     ProjectId = project.Id,
                     Filter = filter,
                     Action = action
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
                 existing.Filter = filter;
                 existing.Action = action;
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -47,9 +48,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<ProjectTriggerEditor> Save()
+        public async Task<ProjectTriggerEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/ProjectTriggersEditor.cs
+++ b/source/Octopus.Client/Editors/Async/ProjectTriggersEditor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Triggers;
@@ -20,24 +21,24 @@ namespace Octopus.Client.Editors.Async
             this.owner = owner;
         }
 
-        public async Task<ProjectTriggerEditor> CreateOrModify(string name, TriggerFilterResource filter, TriggerActionResource action)
+        public async Task<ProjectTriggerEditor> CreateOrModify(string name, TriggerFilterResource filter, TriggerActionResource action, CancellationToken token = default)
         {
-            var projectTriggerBuilder = await new ProjectTriggerEditor(repository).CreateOrModify(owner, name, filter, action).ConfigureAwait(false);
+            var projectTriggerBuilder = await new ProjectTriggerEditor(repository).CreateOrModify(owner, name, filter, action, token).ConfigureAwait(false);
             trackedProjectTriggerBuilders.Add(projectTriggerBuilder);
             return projectTriggerBuilder;
         }
 
-        public async Task<ProjectTriggersEditor> Delete(string name)
+        public async Task<ProjectTriggersEditor> Delete(string name, CancellationToken token = default)
         {
-            var trigger = await repository.FindByName(owner, name).ConfigureAwait(false);
+            var trigger = await repository.FindByName(owner, name, token).ConfigureAwait(false);
             if (trigger != null)
-                await repository.Delete(trigger).ConfigureAwait(false);
+                await repository.Delete(trigger, token).ConfigureAwait(false);
             return this;
         }
 
-        public async Task<ProjectTriggersEditor> SaveAll()
+        public async Task<ProjectTriggersEditor> SaveAll(CancellationToken token = default)
         {
-            await Task.WhenAll(trackedProjectTriggerBuilders.Select(x => x.Save())).ConfigureAwait(false);
+            await Task.WhenAll(trackedProjectTriggerBuilders.Select(x => x.Save(token))).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/RunbookProcessEditor.cs
+++ b/source/Octopus.Client/Editors/Async/RunbookProcessEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -50,9 +51,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<RunbookProcessEditor> Save()
+        public async Task<RunbookProcessEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/RunbookProcessEditor.cs
+++ b/source/Octopus.Client/Editors/Async/RunbookProcessEditor.cs
@@ -17,9 +17,9 @@ namespace Octopus.Client.Editors.Async
 
         public RunbookProcessResource Instance { get; private set; }
 
-        public async Task<RunbookProcessEditor> Load(string id)
+        public async Task<RunbookProcessEditor> Load(string id, CancellationToken token = default)
         {
-            Instance = await repository.Get(id).ConfigureAwait(false);
+            Instance = await repository.Get(id, token).ConfigureAwait(false);
             return this;
         }
 

--- a/source/Octopus.Client/Editors/Async/SubscriptionEditor.cs
+++ b/source/Octopus.Client/Editors/Async/SubscriptionEditor.cs
@@ -1,6 +1,7 @@
 ﻿using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Editors.Async
@@ -17,9 +18,9 @@ namespace Octopus.Client.Editors.Async
 
         public SubscriptionResource Instance { get; private set; }
 
-        public async Task<SubscriptionEditor> CreateOrModify(string name, EventNotificationSubscription eventNotificationSubscription, bool isDisabled)
+        public async Task<SubscriptionEditor> CreateOrModify(string name, EventNotificationSubscription eventNotificationSubscription, bool isDisabled, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
 
             if (existing == null)
             {
@@ -29,7 +30,7 @@ namespace Octopus.Client.Editors.Async
                         Type = SubscriptionType.Event,
                         IsDisabled = isDisabled,
                         EventNotificationSubscription = eventNotificationSubscription,
-                    })
+                    }, token: token)
                     .ConfigureAwait(false);
             }
             else
@@ -38,7 +39,7 @@ namespace Octopus.Client.Editors.Async
                 existing.IsDisabled = isDisabled;
                 existing.EventNotificationSubscription = eventNotificationSubscription;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -50,9 +51,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<SubscriptionEditor> Save()
+        public async Task<SubscriptionEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/TagSetEditor.cs
+++ b/source/Octopus.Client/Editors/Async/TagSetEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -16,39 +17,39 @@ namespace Octopus.Client.Editors.Async
 
         public TagSetResource Instance { get; private set; }
 
-        public async Task<TagSetEditor> CreateOrModify(string name)
+        public async Task<TagSetEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new TagSetResource
                 {
                     Name = name,
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
         }
 
-        public async Task<TagSetEditor> CreateOrModify(string name, string description)
+        public async Task<TagSetEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new TagSetResource
                 {
                     Name = name,
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Description = description;
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -81,9 +82,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<TagSetEditor> Save()
+        public async Task<TagSetEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/TenantVariablesEditor.cs
+++ b/source/Octopus.Client/Editors/Async/TenantVariablesEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -18,9 +19,9 @@ namespace Octopus.Client.Editors.Async
 
         public TenantVariableResource Instance { get; private set; }
 
-        public async Task<TenantVariablesEditor> Load()
+        public async Task<TenantVariablesEditor> Load(CancellationToken token = default)
         {
-            Instance = await repository.GetVariables(tenant).ConfigureAwait(false);
+            Instance = await repository.GetVariables(tenant, token).ConfigureAwait(false);
             return this;
         }
 
@@ -30,9 +31,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<TenantVariablesEditor> Save()
+        public async Task<TenantVariablesEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.ModifyVariables(tenant, Instance).ConfigureAwait(false);
+            Instance = await repository.ModifyVariables(tenant, Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/VariableSetEditor.cs
+++ b/source/Octopus.Client/Editors/Async/VariableSetEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -16,9 +17,9 @@ namespace Octopus.Client.Editors.Async
 
         public VariableSetResource Instance { get; private set; }
 
-        public async Task<VariableSetEditor> Load(string id)
+        public async Task<VariableSetEditor> Load(string id, CancellationToken token = default)
         {
-            Instance = await repository.Get(id).ConfigureAwait(false);
+            Instance = await repository.Get(id, token).ConfigureAwait(false);
             return this;
         }
 
@@ -58,9 +59,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<VariableSetEditor> Save()
+        public async Task<VariableSetEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/Editors/Async/WorkerPoolEditor.cs
+++ b/source/Octopus.Client/Editors/Async/WorkerPoolEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -16,43 +17,43 @@ namespace Octopus.Client.Editors.Async
 
         public WorkerPoolResource Instance { get; private set; }
 
-        public async Task<WorkerPoolEditor> CreateOrModify(string name)
+        public async Task<WorkerPoolEditor> CreateOrModify(string name, CancellationToken token)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new WorkerPoolResource
                 {
                     Name = name,
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
         }
 
-        public async Task<WorkerPoolEditor> CreateOrModify(string name, string description)
+        public async Task<WorkerPoolEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            var existing = await repository.FindByName(name).ConfigureAwait(false);
+            var existing = await repository.FindByName(name, token: token).ConfigureAwait(false);
             if (existing == null)
             {
                 Instance = await repository.Create(new WorkerPoolResource
                 {
                     Name = name,
                     Description = description
-                }).ConfigureAwait(false);
+                }, token: token).ConfigureAwait(false);
             }
             else
             {
                 existing.Name = name;
                 existing.Description = description;
 
-                Instance = await repository.Modify(existing).ConfigureAwait(false);
+                Instance = await repository.Modify(existing, token).ConfigureAwait(false);
             }
 
             return this;
@@ -64,9 +65,9 @@ namespace Octopus.Client.Editors.Async
             return this;
         }
 
-        public async Task<WorkerPoolEditor> Save()
+        public async Task<WorkerPoolEditor> Save(CancellationToken token = default)
         {
-            Instance = await repository.Modify(Instance).ConfigureAwait(false);
+            Instance = await repository.Modify(Instance, token).ConfigureAwait(false);
             return this;
         }
     }

--- a/source/Octopus.Client/IOctopusAsyncClient.cs
+++ b/source/Octopus.Client/IOctopusAsyncClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
@@ -83,8 +84,9 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path from which to fetch the resources.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <param name="token"></param>
         /// <returns>The collection of resources from the server.</returns>
-        Task<ResourceCollection<TResource>> List<TResource>(string path, object pathParameters = null);
+        Task<ResourceCollection<TResource>> List<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Fetches a collection of resources from the server using the HTTP GET verb. All result pages will be retrieved.
@@ -101,8 +103,9 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path from which to fetch the resources.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <param name="token"></param>
         /// <returns>The collection of resources from the server.</returns>
-        Task<IReadOnlyList<TResource>> ListAll<TResource>(string path, object pathParameters = null);
+        Task<IReadOnlyList<TResource>> ListAll<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Fetches a collection of resources from the server one page at a time using the HTTP GET verb.
@@ -122,8 +125,9 @@ namespace Octopus.Client
         /// A callback invoked for each page of data found. If the callback returns <c>true</c>, the next
         /// page will also be requested.
         /// </param>
+        /// <param name="token"></param>
         /// <returns>The collection of resources from the server.</returns>
-        Task Paginate<TResource>(string path, Func<ResourceCollection<TResource>, bool> getNextPage);
+        Task Paginate<TResource>(string path, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Fetches a collection of resources from the server one page at a time using the HTTP GET verb.
@@ -144,8 +148,9 @@ namespace Octopus.Client
         /// A callback invoked for each page of data found. If the callback returns <c>true</c>, the next
         /// page will also be requested.
         /// </param>
+        /// <param name="token"></param>
         /// <returns>The collection of resources from the server.</returns>
-        Task Paginate<TResource>(string path, object pathParameters, Func<ResourceCollection<TResource>, bool> getNextPage);
+        Task Paginate<TResource>(string path, object pathParameters, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Fetches a single resource from the server using the HTTP GET verb.
@@ -162,8 +167,9 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path from which to fetch the resource.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <param name="token"></param>
         /// <returns>The resource from the server.</returns>
-        Task<TResource> Get<TResource>(string path, object pathParameters = null);
+        Task<TResource> Get<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Creates a resource at the given URI on the server using the POST verb, then performs a fresh GET request to fetch
@@ -182,8 +188,9 @@ namespace Octopus.Client
         /// <param name="path">The path to the container resource.</param>
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <param name="token"></param>
         /// <returns>The latest copy of the resource from the server.</returns>
-        Task<TResource> Create<TResource>(string path, TResource resource, object pathParameters = null);
+        Task<TResource> Create<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the POST verb.
@@ -201,7 +208,8 @@ namespace Octopus.Client
         /// <param name="path">The path to the container resource.</param>
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
-        Task Post<TResource>(string path, TResource resource, object pathParameters = null);
+        /// <param name="token"></param>
+        Task Post<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the POST verb, and retrieve the response.
@@ -219,7 +227,8 @@ namespace Octopus.Client
         /// <param name="path">The path to the container resource.</param>
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
-        Task<TResponse> Post<TResource, TResponse>(string path, TResource resource, object pathParameters = null);
+        /// <param name="token"></param>
+        Task<TResponse> Post<TResource, TResponse>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the POST verb.
@@ -235,7 +244,8 @@ namespace Octopus.Client
         /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the container resource.</param>
-        Task Post(string path);
+        /// <param name="token"></param>
+        Task Post(string path, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the PUT verb.
@@ -252,7 +262,8 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the container resource.</param>
         /// <param name="resource">The resource to create.</param>
-        Task Put<TResource>(string path, TResource resource);
+        /// <param name="token"></param>
+        Task Put<TResource>(string path, TResource resource, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the PUT verb.
@@ -268,7 +279,8 @@ namespace Octopus.Client
         /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the container resource.</param>
-        Task Put(string path);
+        /// <param name="token"></param>
+        Task Put(string path, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the PUT verb.
@@ -286,7 +298,8 @@ namespace Octopus.Client
         /// <param name="path">The path to the container resource.</param>
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
-        Task Put<TResource>(string path, TResource resource, object pathParameters = null);
+        /// <param name="token"></param>
+        Task Put<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Updates the resource at the given URI on the server using the PUT verb, then performs a fresh GET request to reload
@@ -305,8 +318,9 @@ namespace Octopus.Client
         /// <param name="path">The path to the resource to update.</param>
         /// <param name="resource">The resource to update.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <param name="token"></param>
         /// <returns>The latest copy of the resource from the server.</returns>
-        Task<TResource> Update<TResource>(string path, TResource resource, object pathParameters = null);
+        Task<TResource> Update<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Deletes the resource at the given URI from the server using a the DELETE verb. Deletes in Octopus happen
@@ -328,7 +342,7 @@ namespace Octopus.Client
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="resource">An optional resource to pass as the body of the request.</param>
         /// <returns>A task resource that provides details about the background task that deletes the specified resource.</returns>
-        Task Delete(string path, object pathParameters = null, object resource = null);
+        Task Delete(string path, object pathParameters = null, object resource = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Fetches raw content from the resource at the specified path, using the GET verb.
@@ -345,15 +359,17 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the resource to fetch.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
+        /// <param name="token"></param>
         /// <returns>A stream containing the content of the resource.</returns>
-        Task<Stream> GetContent(string path, object pathParameters = null);
+        Task<Stream> GetContent(string path, object pathParameters = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Creates or updates the raw content of the resource at the specified path, using the PUT verb.
         /// </summary>
         /// <param name="path">The path to the resource to create or update.</param>
         /// <param name="contentStream">A stream containing content of the resource.</param>
-        Task PutContent(string path, Stream contentStream);
+        /// <param name="token"></param>
+        Task PutContent(string path, Stream contentStream, CancellationToken token = default(CancellationToken));
 
         Uri QualifyUri(string path, object parameters = null);
 
@@ -361,14 +377,16 @@ namespace Octopus.Client
         /// Sign in
         /// </summary>
         /// <param name="loginCommand"></param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task SignIn(LoginCommand loginCommand);
+        Task SignIn(LoginCommand loginCommand, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Sign out
         /// </summary>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task SignOut();
+        Task SignOut(CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Get a repository for the given space

--- a/source/Octopus.Client/IOctopusAsyncClient.cs
+++ b/source/Octopus.Client/IOctopusAsyncClient.cs
@@ -86,7 +86,7 @@ namespace Octopus.Client
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
         /// <returns>The collection of resources from the server.</returns>
-        Task<ResourceCollection<TResource>> List<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task<ResourceCollection<TResource>> List<TResource>(string path, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Fetches a collection of resources from the server using the HTTP GET verb. All result pages will be retrieved.
@@ -105,7 +105,7 @@ namespace Octopus.Client
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
         /// <returns>The collection of resources from the server.</returns>
-        Task<IReadOnlyList<TResource>> ListAll<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task<IReadOnlyList<TResource>> ListAll<TResource>(string path, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Fetches a collection of resources from the server one page at a time using the HTTP GET verb.
@@ -127,7 +127,7 @@ namespace Octopus.Client
         /// </param>
         /// <param name="token"></param>
         /// <returns>The collection of resources from the server.</returns>
-        Task Paginate<TResource>(string path, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default(CancellationToken));
+        Task Paginate<TResource>(string path, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default);
 
         /// <summary>
         /// Fetches a collection of resources from the server one page at a time using the HTTP GET verb.
@@ -150,7 +150,7 @@ namespace Octopus.Client
         /// </param>
         /// <param name="token"></param>
         /// <returns>The collection of resources from the server.</returns>
-        Task Paginate<TResource>(string path, object pathParameters, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default(CancellationToken));
+        Task Paginate<TResource>(string path, object pathParameters, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default);
 
         /// <summary>
         /// Fetches a single resource from the server using the HTTP GET verb.
@@ -169,7 +169,7 @@ namespace Octopus.Client
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
         /// <returns>The resource from the server.</returns>
-        Task<TResource> Get<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task<TResource> Get<TResource>(string path, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Creates a resource at the given URI on the server using the POST verb, then performs a fresh GET request to fetch
@@ -190,7 +190,7 @@ namespace Octopus.Client
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
         /// <returns>The latest copy of the resource from the server.</returns>
-        Task<TResource> Create<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task<TResource> Create<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the POST verb.
@@ -209,7 +209,7 @@ namespace Octopus.Client
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
-        Task Post<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task Post<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the POST verb, and retrieve the response.
@@ -228,7 +228,7 @@ namespace Octopus.Client
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
-        Task<TResponse> Post<TResource, TResponse>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task<TResponse> Post<TResource, TResponse>(string path, TResource resource, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the POST verb.
@@ -245,25 +245,7 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the container resource.</param>
         /// <param name="token"></param>
-        Task Post(string path, CancellationToken token = default(CancellationToken));
-
-        /// <summary>
-        /// Sends a command to a resource at the given URI on the server using the PUT verb.
-        /// </summary>
-        /// <exception cref="OctopusSecurityException">
-        /// HTTP 401 or 403: Thrown when the current user's API key was not valid, their
-        /// account is disabled, or they don't have permission to perform the specified action.
-        /// </exception>
-        /// <exception cref="OctopusServerException">
-        /// If any other error is successfully returned from the server (e.g., a 500
-        /// server error).
-        /// </exception>
-        /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
-        /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
-        /// <param name="path">The path to the container resource.</param>
-        /// <param name="resource">The resource to create.</param>
-        /// <param name="token"></param>
-        Task Put<TResource>(string path, TResource resource, CancellationToken token = default(CancellationToken));
+        Task Post(string path, CancellationToken token = default);
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the PUT verb.
@@ -280,7 +262,7 @@ namespace Octopus.Client
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the container resource.</param>
         /// <param name="token"></param>
-        Task Put(string path, CancellationToken token = default(CancellationToken));
+        Task Put(string path, CancellationToken token = default);
 
         /// <summary>
         /// Sends a command to a resource at the given URI on the server using the PUT verb.
@@ -299,7 +281,7 @@ namespace Octopus.Client
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
-        Task Put<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task Put<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Updates the resource at the given URI on the server using the PUT verb, then performs a fresh GET request to reload
@@ -320,7 +302,7 @@ namespace Octopus.Client
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
         /// <returns>The latest copy of the resource from the server.</returns>
-        Task<TResource> Update<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task<TResource> Update<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Deletes the resource at the given URI from the server using a the DELETE verb. Deletes in Octopus happen
@@ -341,8 +323,9 @@ namespace Octopus.Client
         /// <param name="path">The path to the resource to delete.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="resource">An optional resource to pass as the body of the request.</param>
+        /// <param name="token"></param>
         /// <returns>A task resource that provides details about the background task that deletes the specified resource.</returns>
-        Task Delete(string path, object pathParameters = null, object resource = null, CancellationToken token = default(CancellationToken));
+        Task Delete(string path, object pathParameters = null, object resource = null, CancellationToken token = default);
 
         /// <summary>
         /// Fetches raw content from the resource at the specified path, using the GET verb.
@@ -361,7 +344,7 @@ namespace Octopus.Client
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
         /// <returns>A stream containing the content of the resource.</returns>
-        Task<Stream> GetContent(string path, object pathParameters = null, CancellationToken token = default(CancellationToken));
+        Task<Stream> GetContent(string path, object pathParameters = null, CancellationToken token = default);
 
         /// <summary>
         /// Creates or updates the raw content of the resource at the specified path, using the PUT verb.
@@ -369,7 +352,7 @@ namespace Octopus.Client
         /// <param name="path">The path to the resource to create or update.</param>
         /// <param name="contentStream">A stream containing content of the resource.</param>
         /// <param name="token"></param>
-        Task PutContent(string path, Stream contentStream, CancellationToken token = default(CancellationToken));
+        Task PutContent(string path, Stream contentStream, CancellationToken token = default);
 
         Uri QualifyUri(string path, object parameters = null);
 
@@ -379,14 +362,14 @@ namespace Octopus.Client
         /// <param name="loginCommand"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task SignIn(LoginCommand loginCommand, CancellationToken token = default(CancellationToken));
+        Task SignIn(LoginCommand loginCommand, CancellationToken token = default);
 
         /// <summary>
         /// Sign out
         /// </summary>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task SignOut(CancellationToken token = default(CancellationToken));
+        Task SignOut(CancellationToken token = default);
 
         /// <summary>
         /// Get a repository for the given space

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -169,7 +169,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// </summary>
         public bool IsUsingSecureConnection => serverEndpoint.IsUsingSecureConnection;
 
-        public async Task SignIn(LoginCommand loginCommand, CancellationToken token = default(CancellationToken))
+        public async Task SignIn(LoginCommand loginCommand, CancellationToken token = default)
         {
             if (loginCommand.State == null)
             {
@@ -185,7 +185,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
             Repository = new OctopusAsyncRepository(this);
         }
 
-        public async Task SignOut(CancellationToken token = default(CancellationToken))
+        public async Task SignOut(CancellationToken token = default)
         {
             await Post(await Repository.Link("SignOut").ConfigureAwait(false), token: token).ConfigureAwait(false);
             antiforgeryCookieName = null;
@@ -230,7 +230,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <returns>
         /// The resource from the server.
         /// </returns>
-        public async Task<TResource> Get<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public async Task<TResource> Get<TResource>(string path, object pathParameters = null, CancellationToken token = default)
         {
             var uri = QualifyUri(path, pathParameters);
 
@@ -252,7 +252,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <returns>
         /// The collection of resources from the server.
         /// </returns>
-        public async Task<ResourceCollection<TResource>> List<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public async Task<ResourceCollection<TResource>> List<TResource>(string path, object pathParameters = null, CancellationToken token = default)
         {
             return await Get<ResourceCollection<TResource>>(path, pathParameters, token).ConfigureAwait(false);
         }
@@ -268,7 +268,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <returns>
         /// The collection of resources from the server.
         /// </returns>
-        public async Task<IReadOnlyList<TResource>> ListAll<TResource>(string path, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public async Task<IReadOnlyList<TResource>> ListAll<TResource>(string path, object pathParameters = null, CancellationToken token = default)
         {
             var resources = new List<TResource>();
             await Paginate<TResource>(path, pathParameters, r =>
@@ -290,7 +290,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// page will also be requested.
         /// </param>
         /// <param name="token"></param>
-        public async Task Paginate<TResource>(string path, object pathParameters, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default(CancellationToken))
+        public async Task Paginate<TResource>(string path, object pathParameters, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default)
         {
             var page = await List<TResource>(path, pathParameters, token).ConfigureAwait(false);
 
@@ -310,7 +310,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// page will also be requested.
         /// </param>
         /// <param name="token"></param>
-        public Task Paginate<TResource>(string path, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default(CancellationToken))
+        public Task Paginate<TResource>(string path, Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken token = default)
         {
             return Paginate(path, null, getNextPage, token);
         }
@@ -327,7 +327,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <returns>
         /// The latest copy of the resource from the server.
         /// </returns>
-        public async Task<TResource> Create<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public async Task<TResource> Create<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default)
         {
             var uri = QualifyUri(path, pathParameters);
 
@@ -343,7 +343,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
-        public Task Post<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public Task Post<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default)
         {
             var uri = QualifyUri(path, pathParameters);
 
@@ -359,7 +359,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <param name="resource">The resource to post.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
-        public async Task<TResponse> Post<TResource, TResponse>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public async Task<TResponse> Post<TResource, TResponse>(string path, TResource resource, object pathParameters = null, CancellationToken token = default)
         {
             var uri = QualifyUri(path, pathParameters);
             var response = await DispatchRequest<TResponse>(new OctopusRequest("POST", uri, requestResource: resource), true, token).ConfigureAwait(false);
@@ -371,7 +371,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// </summary>
         /// <param name="path">The path to the container resource.</param>
         /// <param name="token"></param>
-        public Task Post(string path, CancellationToken token = default(CancellationToken))
+        public Task Post(string path, CancellationToken token = default)
         {
             var uri = QualifyUri(path);
 
@@ -392,31 +392,8 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
         /// <param name="path">The path to the container resource.</param>
-        /// <param name="resource">The resource to create.</param>
         /// <param name="token"></param>
-        public Task Put<TResource>(string path, TResource resource, CancellationToken token = default(CancellationToken))
-        {
-            var uri = QualifyUri(path);
-
-            return DispatchRequest<TResource>(new OctopusRequest("PUT", uri, requestResource: resource), false, token);
-        }
-
-        /// <summary>
-        /// Sends a command to a resource at the given URI on the server using the PUT verb.
-        /// </summary>
-        /// <exception cref="OctopusSecurityException">
-        /// HTTP 401 or 403: Thrown when the current user's API key was not valid, their
-        /// account is disabled, or they don't have permission to perform the specified action.
-        /// </exception>
-        /// <exception cref="OctopusServerException">
-        /// If any other error is successfully returned from the server (e.g., a 500
-        /// server error).
-        /// </exception>
-        /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
-        /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
-        /// <param name="path">The path to the container resource.</param>
-        /// <param name="token"></param>
-        public Task Put(string path, CancellationToken token = default(CancellationToken))
+        public Task Put(string path, CancellationToken token = default)
         {
             var uri = QualifyUri(path);
 
@@ -431,7 +408,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <param name="resource">The resource to create.</param>
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
-        public Task Put<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public Task Put<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default)
         {
             var uri = QualifyUri(path, pathParameters);
 
@@ -445,7 +422,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="resource">An optional resource to pass as the body of the request.</param>
         /// <param name="token"></param>
-        public Task Delete(string path, object pathParameters = null, object resource = null, CancellationToken token = default(CancellationToken))
+        public Task Delete(string path, object pathParameters = null, object resource = null, CancellationToken token = default)
         {
             var uri = QualifyUri(path, pathParameters);
 
@@ -464,7 +441,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <returns>
         /// The latest copy of the resource from the server.
         /// </returns>
-        public async Task<TResource> Update<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public async Task<TResource> Update<TResource>(string path, TResource resource, object pathParameters = null, CancellationToken token = default)
         {
             var uri = QualifyUri(path, pathParameters);
 
@@ -490,7 +467,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <param name="pathParameters">If the <c>path</c> is a URI template, parameters to use for substitution.</param>
         /// <param name="token"></param>
         /// <returns>A stream containing the content of the resource.</returns>
-        public async Task<Stream> GetContent(string path, object pathParameters = null, CancellationToken token = default(CancellationToken))
+        public async Task<Stream> GetContent(string path, object pathParameters = null, CancellationToken token = default)
         {
             var uri = QualifyUri(path, pathParameters);
             var response = await DispatchRequest<Stream>(new OctopusRequest("GET", uri), true, token).ConfigureAwait(false);
@@ -503,7 +480,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
         /// <param name="path">The path to the resource to create or update.</param>
         /// <param name="contentStream">A stream containing content of the resource.</param>
         /// <param name="token"></param>
-        public Task PutContent(string path, Stream contentStream, CancellationToken token = default(CancellationToken))
+        public Task PutContent(string path, Stream contentStream, CancellationToken token = default)
         {
             if (contentStream == null) throw new ArgumentNullException("contentStream");
             var uri = QualifyUri(path);

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -296,7 +296,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
 
             while (getNextPage(page) && page.Items.Count > 0 && page.HasLink("Page.Next"))
             {
-                page = await List<TResource>(page.Link("Page.Next")).ConfigureAwait(false);
+                page = await List<TResource>(page.Link("Page.Next"), token).ConfigureAwait(false);
             }
         }
 

--- a/source/Octopus.Client/Operations/IRegisterMachineOperationBase.cs
+++ b/source/Octopus.Client/Operations/IRegisterMachineOperationBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -77,18 +78,21 @@ namespace Octopus.Client.Operations
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="serverEndpoint">The Octopus Deploy server endpoint.</param>
-        Task ExecuteAsync(OctopusServerEndpoint serverEndpoint);
+        /// <param name="token"></param>
+        Task ExecuteAsync(OctopusServerEndpoint serverEndpoint, CancellationToken token = default);
 
         /// <summary>
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="repository">The Octopus Deploy repository.</param>
-        Task ExecuteAsync(OctopusAsyncRepository repository);
+        /// <param name="token"></param>
+        Task ExecuteAsync(OctopusAsyncRepository repository, CancellationToken token = default);
 
         /// <summary>
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="repository">The Octopus Deploy repository.</param>
-        Task ExecuteAsync(IOctopusSpaceAsyncRepository repository);
+        /// <param name="token"></param>
+        Task ExecuteAsync(IOctopusSpaceAsyncRepository repository, CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Operations/RegisterMachineOperation.cs
+++ b/source/Octopus.Client/Operations/RegisterMachineOperation.cs
@@ -181,7 +181,7 @@ namespace Octopus.Client.Operations
 
             var missing = Tenants.Except(tenantsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToArray();
 
-            var tenantsById = await repository.Tenants.Get(missing).ConfigureAwait(false);
+            var tenantsById = await repository.Tenants.Get(ids: missing).ConfigureAwait(false);
             missing = missing.Except(tenantsById.Select(e => e.Id), StringComparer.OrdinalIgnoreCase).ToArray();
 
             if (missing.Any())

--- a/source/Octopus.Client/Operations/RegisterMachineOperationBase.cs
+++ b/source/Octopus.Client/Operations/RegisterMachineOperationBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
@@ -136,15 +137,16 @@ namespace Octopus.Client.Operations
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="serverEndpoint">The Octopus Deploy server endpoint.</param>
+        /// <param name="token"></param>
         /// <exception cref="System.ArgumentException">
         /// </exception>
-        public async Task ExecuteAsync(OctopusServerEndpoint serverEndpoint)
+        public async Task ExecuteAsync(OctopusServerEndpoint serverEndpoint, CancellationToken token = default)
         {
             using (var client = await clientFactory.CreateAsyncClient(serverEndpoint).ConfigureAwait(false))
             {
                 var repository = new OctopusAsyncRepository(client);
 
-                await ExecuteAsync(repository).ConfigureAwait(false);
+                await ExecuteAsync(repository, token).ConfigureAwait(false);
             }
         }
 
@@ -152,40 +154,42 @@ namespace Octopus.Client.Operations
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="repository">The Octopus Deploy server repository.</param>
+        /// <param name="token"></param>
         /// <exception cref="System.ArgumentException">
         /// </exception>
-        public async Task ExecuteAsync(OctopusAsyncRepository repository)
+        public async Task ExecuteAsync(OctopusAsyncRepository repository, CancellationToken token = default)
         {
-            await ExecuteAsync((IOctopusSpaceAsyncRepository) repository).ConfigureAwait(false);
+            await ExecuteAsync((IOctopusSpaceAsyncRepository) repository, token).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="repository">The Octopus Deploy server repository.</param>
+        /// <param name="token"></param>
         /// <exception cref="System.ArgumentException">
         /// </exception>
-        public abstract Task ExecuteAsync(IOctopusSpaceAsyncRepository repository);
+        public abstract Task ExecuteAsync(IOctopusSpaceAsyncRepository repository, CancellationToken token = default);
 
-        protected async Task<MachinePolicyResource> GetMachinePolicy(IOctopusSpaceAsyncRepository repository)
+        protected async Task<MachinePolicyResource> GetMachinePolicy(IOctopusSpaceAsyncRepository repository, CancellationToken token = default)
         {
 
             var machinePolicy = default(MachinePolicyResource);
             if (!string.IsNullOrEmpty(MachinePolicy))
             {
-                machinePolicy = await repository.MachinePolicies.FindByName(MachinePolicy).ConfigureAwait(false);
+                machinePolicy = await repository.MachinePolicies.FindByName(MachinePolicy, token: token).ConfigureAwait(false);
                 if (machinePolicy == null)
                     throw new ArgumentException(CouldNotFindMessage("machine policy", MachinePolicy));
             }
             return machinePolicy;
         }
 
-        protected async Task<ProxyResource> GetProxy(IOctopusSpaceAsyncRepository repository)
+        protected async Task<ProxyResource> GetProxy(IOctopusSpaceAsyncRepository repository, CancellationToken token = default)
         {
             var proxy = default(ProxyResource);
             if (!string.IsNullOrEmpty(ProxyName))
             {
-                proxy = await repository.Proxies.FindByName(ProxyName).ConfigureAwait(false);
+                proxy = await repository.Proxies.FindByName(ProxyName, token: token).ConfigureAwait(false);
                 if (proxy == null)
                     throw new ArgumentException(CouldNotFindMessage("proxy name", ProxyName));
             }

--- a/source/Octopus.Client/Repositories/Async/AccountRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/AccountRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Extensions;
@@ -14,19 +15,19 @@ namespace Octopus.Client.Repositories.Async
     {
         AccountType DetermineAccountType<TAccount>() where TAccount : AccountResource;
 
-        Task<TAccount> GetOfType<TAccount>(string idOrHref) where TAccount : AccountResource;
-        Task<List<TAccount>> GetOfType<TAccount>(params string[] ids) where TAccount : AccountResource;
-        Task<TAccount> RefreshOfType<TAccount>(TAccount resource) where TAccount : AccountResource;
+        Task<TAccount> GetOfType<TAccount>(string idOrHref, CancellationToken token = default) where TAccount : AccountResource;
+        Task<List<TAccount>> GetOfType<TAccount>(CancellationToken token = default, params string[] ids) where TAccount : AccountResource;
+        Task<TAccount> RefreshOfType<TAccount>(TAccount resource, CancellationToken token = default) where TAccount : AccountResource;
 
-        Task<TAccount> FindByNameOfType<TAccount>(string name) where TAccount : AccountResource;
-        Task<List<TAccount>> FindByNamesOfType<TAccount>(IEnumerable<string> names) where TAccount : AccountResource;
+        Task<TAccount> FindByNameOfType<TAccount>(string name, CancellationToken token = default) where TAccount : AccountResource;
+        Task<List<TAccount>> FindByNamesOfType<TAccount>(IEnumerable<string> names, CancellationToken token = default) where TAccount : AccountResource;
 
-        Task PaginateOfType<TAccount>(Func<ResourceCollection<TAccount>, bool> getNextPage, object pathParameters = null) where TAccount : AccountResource;
-        Task<TAccount> FindOneOfType<TAccount>(Func<TAccount, bool> search, object pathParameters = null) where TAccount : AccountResource;
-        Task<List<TAccount>> FindManyOfType<TAccount>(Func<TAccount, bool> search, object pathParameters = null) where TAccount : AccountResource;
-        Task<List<TAccount>> FindAllOfType<TAccount>(object pathParameters = null) where TAccount : AccountResource;
+        Task PaginateOfType<TAccount>(Func<ResourceCollection<TAccount>, bool> getNextPage, object pathParameters = null, CancellationToken token = default) where TAccount : AccountResource;
+        Task<TAccount> FindOneOfType<TAccount>(Func<TAccount, bool> search, object pathParameters = null, CancellationToken token = default) where TAccount : AccountResource;
+        Task<List<TAccount>> FindManyOfType<TAccount>(Func<TAccount, bool> search, object pathParameters = null, CancellationToken token = default) where TAccount : AccountResource;
+        Task<List<TAccount>> FindAllOfType<TAccount>(object pathParameters = null, CancellationToken token = default) where TAccount : AccountResource;
 
-        Task<AccountUsageResource> GetAccountUsage(AccountResource account);
+        Task<AccountUsageResource> GetAccountUsage(AccountResource account, CancellationToken token = default);
     }
 
     class AccountRepository : BasicRepository<AccountResource>, IAccountRepository
@@ -36,25 +37,25 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<TAccount> GetOfType<TAccount>(string idOrHref) where TAccount : AccountResource
+        public async Task<TAccount> GetOfType<TAccount>(string idOrHref, CancellationToken token = default) where TAccount : AccountResource
         {
-            var account = await base.Get(idOrHref).ConfigureAwait(false);
+            var account = await base.Get(idOrHref, token).ConfigureAwait(false);
             return account as TAccount;
         }
 
-        public async Task<List<TAccount>> GetOfType<TAccount>(params string[] ids) where TAccount : AccountResource
+        public async Task<List<TAccount>> GetOfType<TAccount>(CancellationToken token = default, params string[] ids) where TAccount : AccountResource
         {
-            var accounts = await base.Get(ids).ConfigureAwait(false);
+            var accounts = await base.Get(token, ids).ConfigureAwait(false);
             return accounts as List<TAccount>;
         }
 
-        public async Task<TAccount> RefreshOfType<TAccount>(TAccount resource) where TAccount : AccountResource
+        public async Task<TAccount> RefreshOfType<TAccount>(TAccount resource, CancellationToken token = default) where TAccount : AccountResource
         {
-            var account = await base.Refresh(resource).ConfigureAwait(false);
+            var account = await base.Refresh(resource, token).ConfigureAwait(false);
             return account as TAccount;
         }
 
-        public Task<TAccount> FindByNameOfType<TAccount>(string name) where TAccount : AccountResource
+        public Task<TAccount> FindByNameOfType<TAccount>(string name, CancellationToken token = default) where TAccount : AccountResource
         {
             var accountType = DetermineAccountType<TAccount>();
             name = (name ?? string.Empty).Trim();
@@ -64,10 +65,10 @@ namespace Octopus.Client.Repositories.Async
                 if (r is INamedResource named)
                     return string.Equals((named.Name ?? string.Empty).Trim(), name, StringComparison.OrdinalIgnoreCase);
                 return false;
-            }, pathParameters: new {accountType, name});
+            }, pathParameters: new {accountType, name}, token);
         }
 
-        public Task<List<TAccount>> FindByNamesOfType<TAccount>(IEnumerable<string> names) where TAccount : AccountResource
+        public Task<List<TAccount>> FindByNamesOfType<TAccount>(IEnumerable<string> names, CancellationToken token = default) where TAccount : AccountResource
         {
             var nameSet = new HashSet<string>((names ?? new string[0]).Select(n => (n ?? string.Empty).Trim()), StringComparer.OrdinalIgnoreCase);
             return FindManyOfType<TAccount>(r =>
@@ -75,7 +76,7 @@ namespace Octopus.Client.Repositories.Async
                 if (r is INamedResource named) 
                     return nameSet.Contains((named.Name ?? string.Empty).Trim());
                 return false;
-            }, pathParameters: DetermineAccountType<TAccount>());
+            }, pathParameters: DetermineAccountType<TAccount>(), token);
         }
 
         object PathParametersOfType<TAccount>(object pathParameters) where TAccount : AccountResource
@@ -86,43 +87,43 @@ namespace Octopus.Client.Repositories.Async
             return new {accountType};
         }
 
-        public async Task PaginateOfType<TAccount>(Func<ResourceCollection<TAccount>, bool> getNextPage, object pathParameters = null) where TAccount : AccountResource
+        public async Task PaginateOfType<TAccount>(Func<ResourceCollection<TAccount>, bool> getNextPage, object pathParameters = null, CancellationToken token = default) where TAccount : AccountResource
         {
-            await Client.Paginate(await Repository.Link(CollectionLinkName).ConfigureAwait(false), PathParametersOfType<TAccount>(pathParameters), getNextPage).ConfigureAwait(false);
+            await Client.Paginate(await Repository.Link(CollectionLinkName).ConfigureAwait(false), PathParametersOfType<TAccount>(pathParameters), getNextPage, token).ConfigureAwait(false);
         }
 
-        public async Task<TAccount> FindOneOfType<TAccount>(Func<TAccount, bool> search, object pathParameters = null) where TAccount : AccountResource
+        public async Task<TAccount> FindOneOfType<TAccount>(Func<TAccount, bool> search, object pathParameters = null, CancellationToken token = default) where TAccount : AccountResource
         {
             TAccount resource = null;
             await PaginateOfType<TAccount>(page =>
                 {
                     resource = page.Items.FirstOrDefault(search);
                     return resource == null;
-                }, pathParameters: PathParametersOfType<TAccount>(pathParameters))
+                }, pathParameters: PathParametersOfType<TAccount>(pathParameters), token)
                 .ConfigureAwait(false);
             return resource;
         }
 
-        public async Task<List<TAccount>> FindManyOfType<TAccount>(Func<TAccount, bool> search, object pathParameters = null) where TAccount : AccountResource
+        public async Task<List<TAccount>> FindManyOfType<TAccount>(Func<TAccount, bool> search, object pathParameters = null, CancellationToken token = default) where TAccount : AccountResource
         {
             var resources = new List<TAccount>();
             await PaginateOfType<TAccount>(page =>
                 {
                     resources.AddRange(page.Items.Where(search));
                     return true;
-                }, pathParameters: PathParametersOfType<TAccount>(pathParameters))
+                }, pathParameters: PathParametersOfType<TAccount>(pathParameters), token)
                 .ConfigureAwait(false);
             return resources;
         }
 
-        public Task<List<TAccount>> FindAllOfType<TAccount>(object pathParameters = null) where TAccount : AccountResource
+        public Task<List<TAccount>> FindAllOfType<TAccount>(object pathParameters = null, CancellationToken token = default) where TAccount : AccountResource
         {
-            return FindManyOfType<TAccount>(x => true, PathParametersOfType<TAccount>(pathParameters));
+            return FindManyOfType<TAccount>(x => true, PathParametersOfType<TAccount>(pathParameters), token);
         }
 
-        public async Task<AccountUsageResource> GetAccountUsage(AccountResource account)
+        public async Task<AccountUsageResource> GetAccountUsage(AccountResource account, CancellationToken token = default)
         {
-            return await Client.Get<AccountUsageResource>(account.Link("Usages")).ConfigureAwait(false);
+            return await Client.Get<AccountUsageResource>(account.Link("Usages"), token: token).ConfigureAwait(false);
         }
 
         public AccountType DetermineAccountType<TAccount>() where TAccount : AccountResource

--- a/source/Octopus.Client/Repositories/Async/ActionTemplateRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ActionTemplateRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,10 +8,10 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IActionTemplateRepository : ICreate<ActionTemplateResource>, IModify<ActionTemplateResource>, IDelete<ActionTemplateResource>, IGet<ActionTemplateResource>, IFindByName<ActionTemplateResource>, IGetAll<ActionTemplateResource>
     {
-        Task<List<ActionTemplateSearchResource>> Search();
-        Task<ActionTemplateResource> GetVersion(ActionTemplateResource resource, int version);
-        Task<ActionUpdateResultResource[]> UpdateActions(ActionTemplateResource actionTemplate, ActionsUpdateResource update);
-        Task SetLogo(ActionTemplateResource resource, string fileName, Stream contents);
+        Task<List<ActionTemplateSearchResource>> Search(CancellationToken token = default);
+        Task<ActionTemplateResource> GetVersion(ActionTemplateResource resource, int version, CancellationToken token = default);
+        Task<ActionUpdateResultResource[]> UpdateActions(ActionTemplateResource actionTemplate, ActionsUpdateResource update, CancellationToken token = default);
+        Task SetLogo(ActionTemplateResource resource, string fileName, Stream contents, CancellationToken token = default);
     }
 
     class ActionTemplateRepository : BasicRepository<ActionTemplateResource>, IActionTemplateRepository
@@ -19,29 +20,29 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<List<ActionTemplateSearchResource>> Search()
+        public async Task<List<ActionTemplateSearchResource>> Search(CancellationToken token = default)
         {
-            return await Client.Get<List<ActionTemplateSearchResource>>(await Repository.Link("ActionTemplatesSearch").ConfigureAwait(false)).ConfigureAwait(false);
+            return await Client.Get<List<ActionTemplateSearchResource>>(await Repository.Link("ActionTemplatesSearch").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
 
-        public async Task<List<ActionTemplateCategoryResource>> Categories()
+        public async Task<List<ActionTemplateCategoryResource>> Categories(CancellationToken token = default)
         {
-            return await Client.Get<List<ActionTemplateCategoryResource>>(await Repository.Link("ActionTemplatesCategories").ConfigureAwait(false)).ConfigureAwait(false);
+            return await Client.Get<List<ActionTemplateCategoryResource>>(await Repository.Link("ActionTemplatesCategories").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
 
-        public Task<ActionTemplateResource> GetVersion(ActionTemplateResource resource, int version)
+        public Task<ActionTemplateResource> GetVersion(ActionTemplateResource resource, int version, CancellationToken token = default)
         {
-            return Client.Get<ActionTemplateResource>(resource.Links["Versions"], new { version });
+            return Client.Get<ActionTemplateResource>(resource.Links["Versions"], new { version }, token);
         }
 
-        public Task<ActionUpdateResultResource[]> UpdateActions(ActionTemplateResource actionTemplate, ActionsUpdateResource update)
+        public Task<ActionUpdateResultResource[]> UpdateActions(ActionTemplateResource actionTemplate, ActionsUpdateResource update, CancellationToken token = default)
         {
-            return Client.Post<ActionsUpdateResource, ActionUpdateResultResource[]>(actionTemplate.Links["ActionsUpdate"], update, new { actionTemplate.Id });
+            return Client.Post<ActionsUpdateResource, ActionUpdateResultResource[]>(actionTemplate.Links["ActionsUpdate"], update, new { actionTemplate.Id }, token);
         }
         
-        public Task SetLogo(ActionTemplateResource resource, string fileName, Stream contents)
+        public Task SetLogo(ActionTemplateResource resource, string fileName, Stream contents, CancellationToken token = default)
         {
-            return Client.Post(resource.Link("Logo"), new FileUpload { Contents = contents, FileName = fileName }, false);
+            return Client.Post(resource.Link("Logo"), new FileUpload { Contents = contents, FileName = fileName }, false, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ArtifactRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ArtifactRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Model;
@@ -13,9 +14,9 @@ namespace Octopus.Client.Repositories.Async
         IModify<ArtifactResource>,
         IDelete<ArtifactResource>
     {
-        Task<Stream> GetContent(ArtifactResource artifact);
-        Task PutContent(ArtifactResource artifact, Stream contentStream);
-        Task<ResourceCollection<ArtifactResource>> FindRegarding(IResource resource);
+        Task<Stream> GetContent(ArtifactResource artifact, CancellationToken token = default);
+        Task PutContent(ArtifactResource artifact, Stream contentStream, CancellationToken token = default);
+        Task<ResourceCollection<ArtifactResource>> FindRegarding(IResource resource, CancellationToken token = default);
     }
 
     class ArtifactRepository : BasicRepository<ArtifactResource>, IArtifactRepository
@@ -25,19 +26,19 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<Stream> GetContent(ArtifactResource artifact)
+        public Task<Stream> GetContent(ArtifactResource artifact, CancellationToken token = default)
         {
-            return Client.GetContent(artifact.Link("Content"));
+            return Client.GetContent(artifact.Link("Content"), token: token);
         }
 
-        public Task PutContent(ArtifactResource artifact, Stream contentStream)
+        public Task PutContent(ArtifactResource artifact, Stream contentStream, CancellationToken token = default)
         {
-            return Client.PutContent(artifact.Link("Content"), contentStream);
+            return Client.PutContent(artifact.Link("Content"), contentStream, token);
         }
 
-        public async Task<ResourceCollection<ArtifactResource>> FindRegarding(IResource resource)
+        public async Task<ResourceCollection<ArtifactResource>> FindRegarding(IResource resource, CancellationToken token = default)
         {
-            return await Client.List<ArtifactResource>(await Repository.Link("Artifacts").ConfigureAwait(false), new { regarding = resource.Id }).ConfigureAwait(false);
+            return await Client.List<ArtifactResource>(await Repository.Link("Artifacts").ConfigureAwait(false), new { regarding = resource.Id }, token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/BackupRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BackupRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,8 +7,8 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IBackupRepository
     {
-        Task<BackupConfigurationResource> GetConfiguration();
-        Task<BackupConfigurationResource> ModifyConfiguration(BackupConfigurationResource backupConfiguration);
+        Task<BackupConfigurationResource> GetConfiguration(CancellationToken token = default);
+        Task<BackupConfigurationResource> ModifyConfiguration(BackupConfigurationResource backupConfiguration, CancellationToken token = default);
     }
 
     class BackupRepository : IBackupRepository
@@ -21,14 +22,14 @@ namespace Octopus.Client.Repositories.Async
             this.client = repository.Client;
         }
 
-        public async Task<BackupConfigurationResource> GetConfiguration()
+        public async Task<BackupConfigurationResource> GetConfiguration(CancellationToken token = default)
         {
-            return await client.Get<BackupConfigurationResource>(await repository.Link("BackupConfiguration").ConfigureAwait(false)).ConfigureAwait(false);
+            return await client.Get<BackupConfigurationResource>(await repository.Link("BackupConfiguration").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
 
-        public Task<BackupConfigurationResource> ModifyConfiguration(BackupConfigurationResource backupConfiguration)
+        public Task<BackupConfigurationResource> ModifyConfiguration(BackupConfigurationResource backupConfiguration, CancellationToken token = default)
         {
-            return client.Update(backupConfiguration.Link("Self"), backupConfiguration);
+            return client.Update(backupConfiguration.Link("Self"), backupConfiguration, token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/BuildInformationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/BuildInformationRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Logging;
@@ -19,18 +20,18 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<OctopusPackageVersionBuildInformationMappedResource> Get(string id)
+        public async Task<OctopusPackageVersionBuildInformationMappedResource> Get(string id, CancellationToken token = default)
         {
             var link = await repository.Link("BuildInformation").ConfigureAwait(false);
-            return await repository.Client.Get<OctopusPackageVersionBuildInformationMappedResource>(link, new { id }).ConfigureAwait(false);
+            return await repository.Client.Get<OctopusPackageVersionBuildInformationMappedResource>(link, new { id }, token).ConfigureAwait(false);
         }
 
-        public Task<OctopusPackageVersionBuildInformationMappedResource> Push(string packageId, string version, OctopusBuildInformation octopusMetadata, bool replaceExisting)
+        public Task<OctopusPackageVersionBuildInformationMappedResource> Push(string packageId, string version, OctopusBuildInformation octopusMetadata, bool replaceExisting, CancellationToken token = default)
         {
-            return Push(packageId, version, octopusMetadata, replaceExisting ? OverwriteMode.OverwriteExisting : OverwriteMode.FailIfExists);
+            return Push(packageId, version, octopusMetadata, replaceExisting ? OverwriteMode.OverwriteExisting : OverwriteMode.FailIfExists, token);
         }
         
-        public async Task<OctopusPackageVersionBuildInformationMappedResource> Push(string packageId, string version, OctopusBuildInformation octopusMetadata, OverwriteMode overwriteMode)
+        public async Task<OctopusPackageVersionBuildInformationMappedResource> Push(string packageId, string version, OctopusBuildInformation octopusMetadata, OverwriteMode overwriteMode, CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(packageId))
                 throw new ArgumentException("A package Id must be supplied", nameof(packageId));
@@ -52,40 +53,40 @@ namespace Octopus.Client.Repositories.Async
                 OctopusBuildInformation = octopusMetadata
             };
 
-            return await repository.Client.Post<OctopusPackageVersionBuildInformationResource, OctopusPackageVersionBuildInformationMappedResource>(link, resource, new { overwriteMode = overwriteMode }).ConfigureAwait(false);
+            return await repository.Client.Post<OctopusPackageVersionBuildInformationResource, OctopusPackageVersionBuildInformationMappedResource>(link, resource, new { overwriteMode = overwriteMode }, token).ConfigureAwait(false);
         }
         
-        public async Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(string packageId, int skip = 0, int take = 30)
+        public async Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(string packageId, int skip = 0, int take = 30, CancellationToken token = default)
         {
-            return await repository.Client.List<OctopusPackageVersionBuildInformationMappedResource>(await repository.Link("BuildInformation").ConfigureAwait(false), new { packageId = packageId, take, skip }).ConfigureAwait(false);
+            return await repository.Client.List<OctopusPackageVersionBuildInformationMappedResource>(await repository.Link("BuildInformation").ConfigureAwait(false), new { packageId = packageId, take, skip }, token).ConfigureAwait(false);
         }
 
-        public async Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(int skip = 0, int take = 30)
+        public async Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(int skip = 0, int take = 30, CancellationToken token = default)
         {
-            return await repository.Client.List<OctopusPackageVersionBuildInformationMappedResource>(await repository.Link("BuildInformation").ConfigureAwait(false), new { latest = true, take, skip }).ConfigureAwait(false);
+            return await repository.Client.List<OctopusPackageVersionBuildInformationMappedResource>(await repository.Link("BuildInformation").ConfigureAwait(false), new { latest = true, take, skip }, token).ConfigureAwait(false);
         }
 
-        public async Task Delete(OctopusPackageVersionBuildInformationMappedResource buildInformation)
+        public async Task Delete(OctopusPackageVersionBuildInformationMappedResource buildInformation, CancellationToken token = default)
         {
-            await repository.Client.Delete(await repository.Link("BuildInformation").ConfigureAwait(false), new { id = buildInformation.Id }).ConfigureAwait(false);
+            await repository.Client.Delete(await repository.Link("BuildInformation").ConfigureAwait(false), new { id = buildInformation.Id }, token: token).ConfigureAwait(false);
         }
 
-        public async Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource> builds)
+        public async Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource> builds, CancellationToken token = default)
         {
-            await repository.Client.Delete(await repository.Link("BuildInformationBulk").ConfigureAwait(false), new { ids = builds.Select(p => p.Id).ToArray() }).ConfigureAwait(false);
+            await repository.Client.Delete(await repository.Link("BuildInformationBulk").ConfigureAwait(false), new { ids = builds.Select(p => p.Id).ToArray() }, token: token).ConfigureAwait(false);
         }
     }
 
     public interface IBuildInformationRepository
     {
-        Task<OctopusPackageVersionBuildInformationMappedResource> Get(string id);
-        Task<OctopusPackageVersionBuildInformationMappedResource> Push(string packageId, string version, OctopusBuildInformation octopusMetadata, OverwriteMode overwriteMode);
+        Task<OctopusPackageVersionBuildInformationMappedResource> Get(string id, CancellationToken token = default);
+        Task<OctopusPackageVersionBuildInformationMappedResource> Push(string packageId, string version, OctopusBuildInformation octopusMetadata, OverwriteMode overwriteMode, CancellationToken token = default);
         [Obsolete]
-        Task<OctopusPackageVersionBuildInformationMappedResource> Push(string packageId, string version, OctopusBuildInformation octopusMetadata, bool replaceExisting);
+        Task<OctopusPackageVersionBuildInformationMappedResource> Push(string packageId, string version, OctopusBuildInformation octopusMetadata, bool replaceExisting, CancellationToken token = default);
 
-        Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(string packageId, int skip = 0, int take = 30);
-        Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(int skip = 0, int take = 30);
-        Task Delete(OctopusPackageVersionBuildInformationMappedResource buildInformation);
-        Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource> builds);
+        Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(string packageId, int skip = 0, int take = 30, CancellationToken token = default);
+        Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(int skip = 0, int take = 30, CancellationToken token = default);
+        Task Delete(OctopusPackageVersionBuildInformationMappedResource buildInformation, CancellationToken token = default);
+        Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource> builds, CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Repositories/Async/CertificateConfigurationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/CertificateConfigurationRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,8 +8,8 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ICertificateConfigurationRepository : IGet<CertificateConfigurationResource>, IFindByName<CertificateConfigurationResource>
     {
-        Task<CertificateConfigurationResource> GetOctopusCertificate();
-        Task<Stream> GetPublicCertificate(CertificateConfigurationResource certificateConfiguration);
+        Task<CertificateConfigurationResource> GetOctopusCertificate(CancellationToken token = default);
+        Task<Stream> GetPublicCertificate(CertificateConfigurationResource certificateConfiguration, CancellationToken token = default);
     }
 
     class CertificateConfigurationRepository : BasicRepository<CertificateConfigurationResource>, ICertificateConfigurationRepository
@@ -17,14 +18,14 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<CertificateConfigurationResource> GetOctopusCertificate()
+        public Task<CertificateConfigurationResource> GetOctopusCertificate(CancellationToken token = default)
         {
-            return Get("certificate-global");
+            return Get("certificate-global", token);
         }
 
-        public Task<Stream> GetPublicCertificate(CertificateConfigurationResource certificateConfiguration)
+        public Task<Stream> GetPublicCertificate(CertificateConfigurationResource certificateConfiguration, CancellationToken token = default)
         {
-            return Client.GetContent(certificateConfiguration.Links["PublicCer"]);
+            return Client.GetContent(certificateConfiguration.Links["PublicCer"], token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/CertificateRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/CertificateRepository.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -13,8 +14,9 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="format">The format of the exported certificate. If null, the certificate will be exported exactly as it was originally uploaded (including with original password).</param>
         /// <param name="password">Password for the exported file.  This value is only used if exporting to PCKS#12 or PEM formats.</param>
         /// <param name="includePrivateKey">Specifies whether the certificate private-key (if present) should be included in the exported file.  This value is only be used when exporting to PEM format.</param>
+        /// <param name="token"></param>
         /// <returns>The exported certificate data.</returns>
-        Task<Stream> Export(CertificateResource certificate, CertificateFormat? format = null, string password = null, bool includePrivateKey = false);
+        Task<Stream> Export(CertificateResource certificate, CertificateFormat? format = null, string password = null, bool includePrivateKey = false, CancellationToken token = default);
         
         /// <summary>
         /// Exports the certificate in PEM format 
@@ -22,8 +24,9 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="certificate">The certificate to export.</param>
         /// <param name="includePrivateKey">Specifies whether the certificate private-key (if present) should be included in the exported file.</param>
         /// <param name="pemOptions">Options specifying which certificates should be included when chain certificates are present</param>
+        /// <param name="token"></param>
         /// <returns>The exported certificate in PEM format</returns>
-        Task<Stream> ExportAsPem(CertificateResource certificate, bool includePrivateKey = false, CertificateExportPemOptions pemOptions = CertificateExportPemOptions.PrimaryOnly);
+        Task<Stream> ExportAsPem(CertificateResource certificate, bool includePrivateKey = false, CertificateExportPemOptions pemOptions = CertificateExportPemOptions.PrimaryOnly, CancellationToken token = default);
 
         /// <summary>
         /// Replace with a new certificate.  
@@ -33,19 +36,20 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="certificate">The certificate to be replaced</param>
         /// <param name="certificateData">The new base64-encoded certificate-data</param>
         /// <param name="password">The new password</param>
+        /// <param name="token"></param>
         /// <returns>The replaced certificate. The ReplacedBy property will contain the ID of the new certificate (which will be the previous ID of the replaced certificate).</returns>
-        Task<CertificateResource> Replace(CertificateResource certificate, string certificateData, string password);
+        Task<CertificateResource> Replace(CertificateResource certificate, string certificateData, string password, CancellationToken token = default);
 
         /// <summary>
         /// Archive a certificate. 
         /// Archiving makes a certificate unavailable for selection as the value of a variable. 
         /// </summary>
-        Task Archive(CertificateResource certificate);
+        Task Archive(CertificateResource certificate, CancellationToken token = default);
 
         /// <summary>
         /// Unarchive a certificate. This makes the certificate again available for selection as the value of a variable.
         /// </summary>
-        Task UnArchive(CertificateResource certificate);
+        Task UnArchive(CertificateResource certificate, CancellationToken token = default);
 
         // For backwards compatibility.  
         // The CertificateRepository was renamed to CertificateConfigurationRepository when the Certificates feature was 
@@ -53,7 +57,7 @@ namespace Octopus.Client.Repositories.Async
         /// <summary>
         /// Returns details of the certificate used by Octopus for communications.
         /// </summary>
-        Task<CertificateConfigurationResource> GetOctopusCertificate();
+        Task<CertificateConfigurationResource> GetOctopusCertificate(CancellationToken token = default);
     }
 
     class CertificateRepository : BasicRepository<CertificateResource>, ICertificateRepository
@@ -63,37 +67,37 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<Stream> Export(CertificateResource certificate, CertificateFormat? format = null, string password = null, bool includePrivateKey = false)
+        public Task<Stream> Export(CertificateResource certificate, CertificateFormat? format = null, string password = null, bool includePrivateKey = false, CancellationToken token = default)
         {
             var pathParameters = format.HasValue ? new { format= format.Value, password = password, includePrivateKey = includePrivateKey} : null; 
-            return Client.GetContent(certificate.Link("Export"), pathParameters);
+            return Client.GetContent(certificate.Link("Export"), pathParameters, token);
         }
 
         public Task<Stream> ExportAsPem(CertificateResource certificate, bool includePrivateKey = false,
-            CertificateExportPemOptions pemOptions = CertificateExportPemOptions.PrimaryOnly)
+            CertificateExportPemOptions pemOptions = CertificateExportPemOptions.PrimaryOnly, CancellationToken token = default)
         {
             var parameters = new { format = CertificateFormat.Pem, includePrivateKey, pemOptions };
-            return Client.GetContent(certificate.Link("Export"), parameters);
+            return Client.GetContent(certificate.Link("Export"), parameters, token);
         }
 
-        public Task<CertificateResource> Replace(CertificateResource certificate, string certificateData, string password)
+        public Task<CertificateResource> Replace(CertificateResource certificate, string certificateData, string password, CancellationToken token = default)
         {
-            return Client.Post<object, CertificateResource>(certificate.Link("Replace"), new {certificateData = certificateData, password = password});
+            return Client.Post<object, CertificateResource>(certificate.Link("Replace"), new {certificateData = certificateData, password = password}, token: token);
         }
 
-        public Task Archive(CertificateResource certificate)
+        public Task Archive(CertificateResource certificate, CancellationToken token = default)
         {
-            return Client.Post(certificate.Link("Archive"));
+            return Client.Post(certificate.Link("Archive"), token: token);
         }
 
-        public Task UnArchive(CertificateResource certificate)
+        public Task UnArchive(CertificateResource certificate, CancellationToken token = default)
         {
-            return Client.Post(certificate.Link("Unarchive"));
+            return Client.Post(certificate.Link("Unarchive"), token: token);
         }
 
-        public Task<CertificateConfigurationResource> GetOctopusCertificate()
+        public Task<CertificateConfigurationResource> GetOctopusCertificate(CancellationToken token = default)
         {
-            return Repository.CertificateConfiguration.GetOctopusCertificate();
+            return Repository.CertificateConfiguration.GetOctopusCertificate(token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ChannelRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ChannelRepository.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -7,13 +8,13 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IChannelRepository : ICreate<ChannelResource>, IModify<ChannelResource>, IGet<ChannelResource>, IDelete<ChannelResource>, IPaginate<ChannelResource>
     {
-        Task<ChannelResource> FindByName(ProjectResource project, string name);
-        Task<ChannelEditor> CreateOrModify(ProjectResource project, string name);
-        Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, string description);
+        Task<ChannelResource> FindByName(ProjectResource project, string name, CancellationToken token = default);
+        Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, CancellationToken token = default);
+        Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, string description, CancellationToken token = default);
         Task<ResourceCollection<ReleaseResource>> GetReleases(ChannelResource channel,
-            int skip = 0, int? take = null, string searchByVersion = null);
-        Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ChannelResource channel);
-        Task<ReleaseResource> GetReleaseByVersion(ChannelResource channel, string version);
+            int skip = 0, int? take = null, string searchByVersion = null, CancellationToken token = default);
+        Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ChannelResource channel, CancellationToken token = default);
+        Task<ReleaseResource> GetReleaseByVersion(ChannelResource channel, string version, CancellationToken token = default);
     }
 
     class ChannelRepository : BasicRepository<ChannelResource>, IChannelRepository
@@ -23,35 +24,35 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<ChannelResource> FindByName(ProjectResource project, string name)
+        public Task<ChannelResource> FindByName(ProjectResource project, string name, CancellationToken token = default)
         {
-            return FindByName(name, path: project.Link("Channels"));
+            return FindByName(name, path: project.Link("Channels"), token: token);
         }
 
-        public Task<ChannelEditor> CreateOrModify(ProjectResource project, string name)
+        public Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, CancellationToken token = default)
         {
-            return new ChannelEditor(this).CreateOrModify(project, name);
+            return new ChannelEditor(this).CreateOrModify(project, name, token);
         }
 
-        public Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, string description)
+        public Task<ChannelEditor> CreateOrModify(ProjectResource project, string name, string description, CancellationToken token = default)
         {
-            return new ChannelEditor(this).CreateOrModify(project, name, description);
+            return new ChannelEditor(this).CreateOrModify(project, name, description, token);
         }
 
         public Task<ResourceCollection<ReleaseResource>> GetReleases(ChannelResource channel,
-            int skip = 0, int? take = null, string searchByVersion = null)
+            int skip = 0, int? take = null, string searchByVersion = null, CancellationToken token = default)
         {
-            return Client.List<ReleaseResource>(channel.Link("Releases"), new { skip, take, searchByVersion });
+            return Client.List<ReleaseResource>(channel.Link("Releases"), new { skip, take, searchByVersion }, token);
         }
 
-        public Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ChannelResource channel)
+        public Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ChannelResource channel, CancellationToken token = default)
         {
-            return Client.ListAll<ReleaseResource>(channel.Link("Releases"));
+            return Client.ListAll<ReleaseResource>(channel.Link("Releases"), token: token);
         }
 
-        public Task<ReleaseResource> GetReleaseByVersion(ChannelResource channel, string version)
+        public Task<ReleaseResource> GetReleaseByVersion(ChannelResource channel, string version, CancellationToken token = default)
         {
-            return Client.Get<ReleaseResource>(channel.Link("Releases"), new { version });
+            return Client.Get<ReleaseResource>(channel.Link("Releases"), new { version }, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/CommunityActionTemplateRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/CommunityActionTemplateRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
@@ -9,9 +10,9 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ICommunityActionTemplateRepository : IGet<CommunityActionTemplateResource>
     {
-        Task<ActionTemplateResource> GetInstalledTemplate(CommunityActionTemplateResource resource);
-        Task Install(CommunityActionTemplateResource resource);
-        Task UpdateInstallation(CommunityActionTemplateResource resource);
+        Task<ActionTemplateResource> GetInstalledTemplate(CommunityActionTemplateResource resource, CancellationToken token = default);
+        Task Install(CommunityActionTemplateResource resource, CancellationToken token = default);
+        Task UpdateInstallation(CommunityActionTemplateResource resource, CancellationToken token = default);
     }
 
     class CommunityActionTemplateRepository : BasicRepository<CommunityActionTemplateResource>, ICommunityActionTemplateRepository
@@ -20,7 +21,7 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task Install(CommunityActionTemplateResource resource)
+        public Task Install(CommunityActionTemplateResource resource, CancellationToken token = default)
         {
             var baseLink = resource.Links["Installation"];
             var spaceResource = Repository.Scope.Apply(space => space,
@@ -29,13 +30,13 @@ namespace Octopus.Client.Repositories.Async
 
             if (spaceResource == null)
             {
-                return Client.Post(baseLink.ToString());
+                return Client.Post(baseLink.ToString(), token: token);
             }
 
-            return Client.Post<string>(baseLink.ToString(), null, new {spaceId = spaceResource.Id});
+            return Client.Post<string>(baseLink.ToString(), null, new {spaceId = spaceResource.Id}, token);
         }
 
-        public Task UpdateInstallation(CommunityActionTemplateResource resource)
+        public Task UpdateInstallation(CommunityActionTemplateResource resource, CancellationToken token = default)
         {
             var baseLink = resource.Links["Installation"];
             var spaceResource = Repository.Scope.Apply(space => space,
@@ -44,13 +45,13 @@ namespace Octopus.Client.Repositories.Async
 
             if (spaceResource == null)
             {
-                return Client.Put(baseLink.ToString());
+                return Client.Put(baseLink.ToString(), token);
             }
 
-            return Client.Put<string>(baseLink.ToString(), null, new {spaceId = spaceResource.Id});
+            return Client.Put<string>(baseLink.ToString(), null, new {spaceId = spaceResource.Id}, token);
         }
 
-        public Task<ActionTemplateResource> GetInstalledTemplate(CommunityActionTemplateResource resource)
+        public Task<ActionTemplateResource> GetInstalledTemplate(CommunityActionTemplateResource resource, CancellationToken token = default)
         {
             var baseLink = resource.Links["InstalledTemplate"];
             var spaceResource = Repository.Scope.Apply(space => space,
@@ -59,10 +60,10 @@ namespace Octopus.Client.Repositories.Async
 
             if (spaceResource == null)
             {
-                return Client.Get<ActionTemplateResource>(baseLink.ToString());
+                return Client.Get<ActionTemplateResource>(baseLink.ToString(), token: token);
             }
 
-            return Client.Get<ActionTemplateResource>(baseLink.ToString(), new {spaceId = spaceResource.Id});
+            return Client.Get<ActionTemplateResource>(baseLink.ToString(), new {spaceId = spaceResource.Id}, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/DashboardConfigurationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DashboardConfigurationRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,8 +7,8 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IDashboardConfigurationRepository
     {
-        Task<DashboardConfigurationResource> GetDashboardConfiguration();
-        Task<DashboardConfigurationResource> ModifyDashboardConfiguration(DashboardConfigurationResource resource);
+        Task<DashboardConfigurationResource> GetDashboardConfiguration(CancellationToken token = default);
+        Task<DashboardConfigurationResource> ModifyDashboardConfiguration(DashboardConfigurationResource resource, CancellationToken token = default);
     }
 
     class DashboardConfigurationRepository : IDashboardConfigurationRepository
@@ -19,14 +20,14 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<DashboardConfigurationResource> GetDashboardConfiguration()
+        public async Task<DashboardConfigurationResource> GetDashboardConfiguration(CancellationToken token = default)
         {
-            return await repository.Client.Get<DashboardConfigurationResource>(await repository.Link("DashboardConfiguration").ConfigureAwait(false)).ConfigureAwait(false);
+            return await repository.Client.Get<DashboardConfigurationResource>(await repository.Link("DashboardConfiguration").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
 
-        public async Task<DashboardConfigurationResource> ModifyDashboardConfiguration(DashboardConfigurationResource resource)
+        public async Task<DashboardConfigurationResource> ModifyDashboardConfiguration(DashboardConfigurationResource resource, CancellationToken token = default)
         {
-            return await repository.Client.Update(await repository.Link("DashboardConfiguration").ConfigureAwait(false), resource).ConfigureAwait(false);
+            return await repository.Client.Update(await repository.Link("DashboardConfiguration").ConfigureAwait(false), resource, token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/DashboardRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DashboardRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,12 +7,13 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IDashboardRepository
     {
-        Task<DashboardResource> GetDashboard();
+        Task<DashboardResource> GetDashboard(CancellationToken token = default);
 
         /// <param name="projects"></param>
         /// <param name="environments"></param>
         /// <param name="dashboardItemsOptions">options for DashboardResource Items property</param>
-        Task<DashboardResource> GetDynamicDashboard(string[] projects, string[] environments, DashboardItemsOptions dashboardItemsOptions = DashboardItemsOptions.IncludeCurrentDeploymentOnly);
+        /// <param name="token"></param>
+        Task<DashboardResource> GetDynamicDashboard(string[] projects, string[] environments, DashboardItemsOptions dashboardItemsOptions = DashboardItemsOptions.IncludeCurrentDeploymentOnly, CancellationToken token = default);
     }
 
     class DashboardRepository : IDashboardRepository
@@ -23,15 +25,15 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<DashboardResource> GetDashboard()
+        public async Task<DashboardResource> GetDashboard(CancellationToken token = default)
         {
-            return await repository.Client.Get<DashboardResource>(await repository.Link("Dashboard").ConfigureAwait(false)).ConfigureAwait(false);
+            return await repository.Client.Get<DashboardResource>(await repository.Link("Dashboard").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
 
-        public async Task<DashboardResource> GetDynamicDashboard(string[] projects, string[] environments, DashboardItemsOptions dashboardItemsOptions = DashboardItemsOptions.IncludeCurrentDeploymentOnly)
+        public async Task<DashboardResource> GetDynamicDashboard(string[] projects, string[] environments, DashboardItemsOptions dashboardItemsOptions = DashboardItemsOptions.IncludeCurrentDeploymentOnly, CancellationToken token = default)
         {
             var includePrevious = dashboardItemsOptions == DashboardItemsOptions.IncludeCurrentAndPreviousSuccessfulDeployment;
-            return await repository.Client.Get<DashboardResource>(await repository.Link("DashboardDynamic").ConfigureAwait(false), new { projects, environments, includePrevious }).ConfigureAwait(false);
+            return await repository.Client.Get<DashboardResource>(await repository.Link("DashboardDynamic").ConfigureAwait(false), new { projects, environments, includePrevious }, token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/DefectsRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DefectsRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,9 +7,9 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IDefectsRepository
     {
-        Task<ResourceCollection<DefectResource>> GetDefects(ReleaseResource release);
-        Task RaiseDefect(ReleaseResource release, string description);
-        Task ResolveDefect(ReleaseResource release);
+        Task<ResourceCollection<DefectResource>> GetDefects(ReleaseResource release, CancellationToken token = default);
+        Task RaiseDefect(ReleaseResource release, string description, CancellationToken token = default);
+        Task ResolveDefect(ReleaseResource release, CancellationToken token = default);
     }
 
     class DefectsRepository : BasicRepository<DefectResource>, IDefectsRepository
@@ -18,19 +19,19 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<ResourceCollection<DefectResource>> GetDefects(ReleaseResource release)
+        public Task<ResourceCollection<DefectResource>> GetDefects(ReleaseResource release, CancellationToken token = default)
         {
-            return Client.List<DefectResource>(release.Link("Defects"));
+            return Client.List<DefectResource>(release.Link("Defects"), token: token);
         }
 
-        public Task RaiseDefect(ReleaseResource release, string description)
+        public Task RaiseDefect(ReleaseResource release, string description, CancellationToken token = default)
         {
-            return Client.Post(release.Link("ReportDefect"), new DefectResource(description));
+            return Client.Post(release.Link("ReportDefect"), new DefectResource(description), token: token);
         }
 
-        public Task ResolveDefect(ReleaseResource release)
+        public Task ResolveDefect(ReleaseResource release, CancellationToken token = default)
         {
-            return Client.Post(release.Link("ResolveDefect"));
+            return Client.Post(release.Link("ResolveDefect"), token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/DeploymentRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DeploymentRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,7 +7,7 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IDeploymentRepository : IGet<DeploymentResource>, ICreate<DeploymentResource>, IPaginate<DeploymentResource>, IDelete<DeploymentResource>
     {
-        Task<TaskResource> GetTask(DeploymentResource resource);
+        Task<TaskResource> GetTask(DeploymentResource resource, CancellationToken token = default);
 
         /// <summary>
         /// 
@@ -15,13 +16,14 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="environments"></param>
         /// <param name="skip">Number of records to skip</param>
         /// <param name="take">Number of records to take (First supported in Server 3.14.15)</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<ResourceCollection<DeploymentResource>> FindBy(string[] projects, string[] environments, int skip = 0, int? take = null);
+        Task<ResourceCollection<DeploymentResource>> FindBy(string[] projects, string[] environments, int skip = 0, int? take = null, CancellationToken token = default);
 
         [Obsolete("This method is not a find all, it still requires paging. So it has been renamed to `FindBy`")]
-        Task<ResourceCollection<DeploymentResource>> FindAll(string[] projects, string[] environments, int skip = 0, int? take = null);
-        Task Paginate(string[] projects, string[] environments, Func<ResourceCollection<DeploymentResource>, bool> getNextPage);
-        Task Paginate(string[] projects, string[] environments, string[] tenants, Func<ResourceCollection<DeploymentResource>, bool> getNextPage);
+        Task<ResourceCollection<DeploymentResource>> FindAll(string[] projects, string[] environments, int skip = 0, int? take = null, CancellationToken token = default);
+        Task Paginate(string[] projects, string[] environments, Func<ResourceCollection<DeploymentResource>, bool> getNextPage, CancellationToken token = default);
+        Task Paginate(string[] projects, string[] environments, string[] tenants, Func<ResourceCollection<DeploymentResource>, bool> getNextPage, CancellationToken token = default);
     }
 
     class DeploymentRepository : BasicRepository<DeploymentResource>, IDeploymentRepository
@@ -31,30 +33,30 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<TaskResource> GetTask(DeploymentResource resource)
+        public Task<TaskResource> GetTask(DeploymentResource resource, CancellationToken token = default)
         {
-            return Client.Get<TaskResource>(resource.Link("Task"));
+            return Client.Get<TaskResource>(resource.Link("Task"), token: token);
         }
 
-        public async Task<ResourceCollection<DeploymentResource>> FindBy(string[] projects, string[] environments, int skip = 0, int? take = null)
+        public async Task<ResourceCollection<DeploymentResource>> FindBy(string[] projects, string[] environments, int skip = 0, int? take = null, CancellationToken token = default)
         {
-            return await Client.List<DeploymentResource>(await Repository.Link("Deployments").ConfigureAwait(false), new { skip, take, projects = projects ?? new string[0], environments = environments ?? new string[0] }).ConfigureAwait(false);
+            return await Client.List<DeploymentResource>(await Repository.Link("Deployments").ConfigureAwait(false), new { skip, take, projects = projects ?? new string[0], environments = environments ?? new string[0] }, token).ConfigureAwait(false);
         }
 
         [Obsolete("This method is not a find all, it still requires paging. So it has been renamed to `FindBy`")]
-        public Task<ResourceCollection<DeploymentResource>> FindAll(string[] projects, string[] environments, int skip = 0, int? take = null)
+        public Task<ResourceCollection<DeploymentResource>> FindAll(string[] projects, string[] environments, int skip = 0, int? take = null, CancellationToken token = default)
         {
-            return FindBy(projects, environments, skip, take);
+            return FindBy(projects, environments, skip, take, token);
         }
 
-        public Task Paginate(string[] projects, string[] environments, Func<ResourceCollection<DeploymentResource>, bool> getNextPage)
+        public Task Paginate(string[] projects, string[] environments, Func<ResourceCollection<DeploymentResource>, bool> getNextPage, CancellationToken token = default)
         {
-            return Paginate(projects, environments, new string[0], getNextPage);
+            return Paginate(projects, environments, new string[0], getNextPage, token);
         }
 
-        public async Task Paginate(string[] projects, string[] environments, string[] tenants, Func<ResourceCollection<DeploymentResource>, bool> getNextPage)
+        public async Task Paginate(string[] projects, string[] environments, string[] tenants, Func<ResourceCollection<DeploymentResource>, bool> getNextPage, CancellationToken token = default)
         {
-            await Client.Paginate(await Repository.Link("Deployments").ConfigureAwait(false), new { projects = projects ?? new string[0], environments = environments ?? new string[0], tenants = tenants ?? new string[0] }, getNextPage).ConfigureAwait(false);
+            await Client.Paginate(await Repository.Link("Deployments").ConfigureAwait(false), new { projects = projects ?? new string[0], environments = environments ?? new string[0], tenants = tenants ?? new string[0] }, getNextPage, token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/EnvironmentRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/EnvironmentRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -17,7 +18,8 @@ namespace Octopus.Client.Repositories.Async
             string healthStatuses = null,
             string commStyles = null,
             string tenantIds = null,
-            string tenantTags = null);
+            string tenantTags = null, 
+            CancellationToken token = default);
         Task<EnvironmentsSummaryResource> Summary(
             string ids = null,
             string partialName = null,
@@ -28,11 +30,12 @@ namespace Octopus.Client.Repositories.Async
             string commStyles = null,
             string tenantIds = null,
             string tenantTags = null,
-            bool? hideEmptyEnvironments = false);
-        Task Sort(string[] environmentIdsInOrder);
-        Task<EnvironmentEditor> CreateOrModify(string name);
-        Task<EnvironmentEditor> CreateOrModify(string name, string description);
-        Task<EnvironmentEditor> CreateOrModify(string name, string description, bool allowDynamicInfrastructure);
+            bool? hideEmptyEnvironments = false, 
+            CancellationToken token = default);
+        Task Sort(string[] environmentIdsInOrder, CancellationToken token = default);
+        Task<EnvironmentEditor> CreateOrModify(string name, CancellationToken token = default);
+        Task<EnvironmentEditor> CreateOrModify(string name, string description, CancellationToken token = default);
+        Task<EnvironmentEditor> CreateOrModify(string name, string description, bool allowDynamicInfrastructure, CancellationToken token = default);
     }
 
     class EnvironmentRepository : BasicRepository<EnvironmentResource>, IEnvironmentRepository
@@ -51,7 +54,8 @@ namespace Octopus.Client.Repositories.Async
             string healthStatuses = null,
             string commStyles = null,
             string tenantIds = null,
-            string tenantTags = null)
+            string tenantTags = null,
+            CancellationToken token = default)
         {
             var resources = new List<MachineResource>();
 
@@ -69,7 +73,7 @@ namespace Octopus.Client.Repositories.Async
             {
                 resources.AddRange(page.Items);
                 return true;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
 
             return resources;
         }
@@ -84,7 +88,8 @@ namespace Octopus.Client.Repositories.Async
             string commStyles = null,
             string tenantIds = null,
             string tenantTags = null,
-            bool? hideEmptyEnvironments = false)
+            bool? hideEmptyEnvironments = false,
+            CancellationToken token = default)
         {
             return await Client.Get<EnvironmentsSummaryResource>(await Repository.Link("EnvironmentsSummary").ConfigureAwait(false), new
             {
@@ -98,27 +103,27 @@ namespace Octopus.Client.Repositories.Async
                 tenantIds,
                 tenantTags,
                 hideEmptyEnvironments,
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
         }
 
-        public async Task Sort(string[] environmentIdsInOrder)
+        public async Task Sort(string[] environmentIdsInOrder, CancellationToken token = default)
         {
-            await Client.Put(await Repository.Link("EnvironmentSortOrder").ConfigureAwait(false), environmentIdsInOrder).ConfigureAwait(false);
+            await Client.Put(await Repository.Link("EnvironmentSortOrder").ConfigureAwait(false), environmentIdsInOrder, token: token).ConfigureAwait(false);
         }
 
-        public Task<EnvironmentEditor> CreateOrModify(string name)
+        public Task<EnvironmentEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            return new EnvironmentEditor(this).CreateOrModify(name);
+            return new EnvironmentEditor(this).CreateOrModify(name, token);
         }
 
-        public Task<EnvironmentEditor> CreateOrModify(string name, string description)
+        public Task<EnvironmentEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            return new EnvironmentEditor(this).CreateOrModify(name, description);
+            return new EnvironmentEditor(this).CreateOrModify(name, description, token: token);
         }
 
-        public Task<EnvironmentEditor> CreateOrModify(string name, string description, bool allowDynamicInfrastructure)
+        public Task<EnvironmentEditor> CreateOrModify(string name, string description, bool allowDynamicInfrastructure, CancellationToken token = default)
         {
-            return new EnvironmentEditor(this).CreateOrModify(name, description, allowDynamicInfrastructure);
+            return new EnvironmentEditor(this).CreateOrModify(name, description, allowDynamicInfrastructure, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/EventRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/EventRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Util;
@@ -13,7 +14,8 @@ namespace Octopus.Client.Repositories.Async
         Task<ResourceCollection<EventResource>> List(int skip = 0, 
             string filterByUserId = null,
             string regardingDocumentId = null,
-            bool includeInternalEvents = false);
+            bool includeInternalEvents = false,
+            CancellationToken token = default);
 
         /// <summary>
         /// 
@@ -38,6 +40,7 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="documentTypes"></param>
         /// <param name="eventAgents"></param>
         /// <param name="projectGroups"></param>
+        /// <param name="token"></param>
         /// <returns></returns>
         Task<ResourceCollection<EventResource>> List(int skip = 0,
             int? take = null,
@@ -58,12 +61,13 @@ namespace Octopus.Client.Repositories.Async
             long? toAutoId = null,
             string documentTypes = null,
             string eventAgents = null,
-            string projectGroups = null);
+            string projectGroups = null, 
+            CancellationToken token = default);
 
-        Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes();
-        Task<IReadOnlyList<EventAgentResource>> GetAgents();
-        Task<IReadOnlyList<EventCategoryResource>> GetCategories();
-        Task<IReadOnlyList<EventGroupResource>> GetGroups();
+        Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes(CancellationToken token = default);
+        Task<IReadOnlyList<EventAgentResource>> GetAgents(CancellationToken token = default);
+        Task<IReadOnlyList<EventCategoryResource>> GetCategories(CancellationToken token = default);
+        Task<IReadOnlyList<EventGroupResource>> GetGroups(CancellationToken token = default);
     }
 
     class EventRepository : MixedScopeBaseRepository<EventResource>, IEventRepository
@@ -82,7 +86,8 @@ namespace Octopus.Client.Repositories.Async
         public async Task<ResourceCollection<EventResource>> List(int skip = 0, 
                 string filterByUserId = null,
                 string regardingDocumentId = null,
-                bool includeInternalEvents = false)
+                bool includeInternalEvents = false,
+                CancellationToken token = default)
         {
             return await Client.List<EventResource>(await Repository.Link("Events").ConfigureAwait(false), ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new
             {
@@ -90,7 +95,7 @@ namespace Octopus.Client.Repositories.Async
                 user = filterByUserId,
                 regarding = regardingDocumentId,
                 @internal = includeInternalEvents.ToString()
-            })).ConfigureAwait(false);
+            }), token).ConfigureAwait(false);
         }
 
         public async Task<ResourceCollection<EventResource>> List(int skip = 0, 
@@ -112,7 +117,8 @@ namespace Octopus.Client.Repositories.Async
             long? toAutoId = null,
             string documentTypes = null,
             string eventAgents = null,
-            string projectGroups = null)
+            string projectGroups = null,
+            CancellationToken token = default)
         {
             var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new
             {
@@ -138,31 +144,31 @@ namespace Octopus.Client.Repositories.Async
                 projectGroups,
             });
 
-            return await Client.List<EventResource>(await Repository.Link("Events").ConfigureAwait(false), parameters).ConfigureAwait(false);
+            return await Client.List<EventResource>(await Repository.Link("Events").ConfigureAwait(false), parameters, token).ConfigureAwait(false);
         }
 
-        public async Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes()
+        public async Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes(CancellationToken token = default)
         {
             var link = await Repository.Link("EventDocumentTypes").ConfigureAwait(false);
-            return await Client.Get<List<DocumentTypeResource>>(link).ConfigureAwait(false);
+            return await Client.Get<List<DocumentTypeResource>>(link, token: token).ConfigureAwait(false);
         }
         
-        public async Task<IReadOnlyList<EventAgentResource>> GetAgents()
+        public async Task<IReadOnlyList<EventAgentResource>> GetAgents(CancellationToken token = default)
         {
             var link = await Repository.Link("EventAgents").ConfigureAwait(false);
-            return await Client.Get<List<EventAgentResource>>(link).ConfigureAwait(false);
+            return await Client.Get<List<EventAgentResource>>(link, token: token).ConfigureAwait(false);
         }
         
-        public async Task<IReadOnlyList<EventCategoryResource>> GetCategories()        
+        public async Task<IReadOnlyList<EventCategoryResource>> GetCategories(CancellationToken token = default)        
         {
             var link = await Repository.Link("EventCategories").ConfigureAwait(false);
-            return await Client.Get<List<EventCategoryResource>>(link).ConfigureAwait(false);
+            return await Client.Get<List<EventCategoryResource>>(link, token: token).ConfigureAwait(false);
         }
         
-        public async Task<IReadOnlyList<EventGroupResource>> GetGroups()
+        public async Task<IReadOnlyList<EventGroupResource>> GetGroups(CancellationToken token = default)
         {
             var link = await Repository.Link("EventGroups").ConfigureAwait(false);
-            return await Client.Get<List<EventGroupResource>>(link).ConfigureAwait(false);
+            return await Client.Get<List<EventGroupResource>>(link, token: token).ConfigureAwait(false);
         }
 
         public IEventRepository UsingContext(SpaceContext spaceContext)

--- a/source/Octopus.Client/Repositories/Async/FeaturesConfigurationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/FeaturesConfigurationRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,8 +7,8 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IFeaturesConfigurationRepository
     {
-        Task<FeaturesConfigurationResource> GetFeaturesConfiguration();
-        Task<FeaturesConfigurationResource> ModifyFeaturesConfiguration(FeaturesConfigurationResource resource);
+        Task<FeaturesConfigurationResource> GetFeaturesConfiguration(CancellationToken token = default);
+        Task<FeaturesConfigurationResource> ModifyFeaturesConfiguration(FeaturesConfigurationResource resource, CancellationToken token = default);
     }
 
     class FeaturesConfigurationRepository : IFeaturesConfigurationRepository
@@ -19,14 +20,14 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<FeaturesConfigurationResource> GetFeaturesConfiguration()
+        public async Task<FeaturesConfigurationResource> GetFeaturesConfiguration(CancellationToken token = default)
         {
-            return await repository.Client.Get<FeaturesConfigurationResource>(await repository.Link("FeaturesConfiguration").ConfigureAwait(false)).ConfigureAwait(false);
+            return await repository.Client.Get<FeaturesConfigurationResource>(await repository.Link("FeaturesConfiguration").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
 
-        public async Task<FeaturesConfigurationResource> ModifyFeaturesConfiguration(FeaturesConfigurationResource resource)
+        public async Task<FeaturesConfigurationResource> ModifyFeaturesConfiguration(FeaturesConfigurationResource resource, CancellationToken token = default)
         {
-            return await repository.Client.Update(await repository.Link("FeaturesConfiguration").ConfigureAwait(false), resource).ConfigureAwait(false);
+            return await repository.Client.Update(await repository.Link("FeaturesConfiguration").ConfigureAwait(false), resource, token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/FeedRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/FeedRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,7 +8,7 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IFeedRepository : ICreate<FeedResource>, IModify<FeedResource>, IDelete<FeedResource>, IGet<FeedResource>, IFindByName<FeedResource>
     {
-        Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds);
+        Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds, CancellationToken token = default);
     }
 
     class FeedRepository : BasicRepository<FeedResource>, IFeedRepository
@@ -16,9 +17,9 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds)
+        public Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds, CancellationToken token = default)
         {
-            return Client.Get<List<PackageResource>>(feed.Link("VersionsTemplate"), new { packageIds = packageIds });
+            return Client.Get<List<PackageResource>>(feed.Link("VersionsTemplate"), new { packageIds = packageIds }, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ICreate.cs
+++ b/source/Octopus.Client/Repositories/Async/ICreate.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface ICreate<TResource>
     {
-        Task<TResource> Create(TResource resource, object pathParameters = null);
+        Task<TResource> Create(TResource resource, object pathParameters = null, CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Repositories/Async/IDelete.cs
+++ b/source/Octopus.Client/Repositories/Async/IDelete.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IDelete<in TResource>
     {
-        Task Delete(TResource resource);
+        Task Delete(TResource resource, CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Repositories/Async/IFindByName.cs
+++ b/source/Octopus.Client/Repositories/Async/IFindByName.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IFindByName<TResource> : IPaginate<TResource>
     {
-        Task<TResource> FindByName(string name, string path = null, object pathParameters = null);
-        Task<List<TResource>> FindByNames(IEnumerable<string> names, string path = null, object pathParameters = null);
+        Task<TResource> FindByName(string name, string path = null, object pathParameters = null, CancellationToken token = default);
+        Task<List<TResource>> FindByNames(IEnumerable<string> names, string path = null, object pathParameters = null, CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Repositories/Async/IGet.cs
+++ b/source/Octopus.Client/Repositories/Async/IGet.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IGet<TResource>
     {
-        Task<TResource> Get(string idOrHref);
-        Task<List<TResource>> Get(params string[] ids);
-        Task<TResource> Refresh(TResource resource);
+        Task<TResource> Get(string idOrHref, CancellationToken token = default);
+        Task<List<TResource>> Get(CancellationToken token = default, params string[] ids);
+        Task<TResource> Refresh(TResource resource, CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Repositories/Async/IGetAll.cs
+++ b/source/Octopus.Client/Repositories/Async/IGetAll.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IGetAll<TResource>
     {
-        Task<List<TResource>> GetAll();
+        Task<List<TResource>> GetAll(CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Repositories/Async/IModify.cs
+++ b/source/Octopus.Client/Repositories/Async/IModify.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IModify<TResource>
     {
-        Task<TResource> Modify(TResource resource);
+        Task<TResource> Modify(TResource resource, CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Repositories/Async/IPaginate.cs
+++ b/source/Octopus.Client/Repositories/Async/IPaginate.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,9 +8,9 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IPaginate<TResource>
     {
-        Task Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path = null, object pathParameters = null);
-        Task<TResource> FindOne(Func<TResource, bool> search, string path = null, object pathParameters = null);
-        Task<List<TResource>> FindMany(Func<TResource, bool> search, string path = null, object pathParameters = null);
-        Task<List<TResource>> FindAll(string path = null, object pathParameters = null);
+        Task Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path = null, object pathParameters = null, CancellationToken token = default);
+        Task<TResource> FindOne(Func<TResource, bool> search, string path = null, object pathParameters = null, CancellationToken token = default);
+        Task<List<TResource>> FindMany(Func<TResource, bool> search, string path = null, object pathParameters = null, CancellationToken token = default);
+        Task<List<TResource>> FindAll(string path = null, object pathParameters = null, CancellationToken token = default);
     }
 }

--- a/source/Octopus.Client/Repositories/Async/InterruptionRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/InterruptionRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -13,11 +14,12 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="take">Number of records to take (First supported in Server 3.14.15)</param>
         /// <param name="pendingOnly"></param>
         /// <param name="regardingDocumentId"></param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<ResourceCollection<InterruptionResource>> List(int skip = 0, int? take = null, bool pendingOnly = false, string regardingDocumentId = null);
-        Task Submit(InterruptionResource interruption);
-        Task TakeResponsibility(InterruptionResource interruption);
-        Task<UserResource> GetResponsibleUser(InterruptionResource interruption);
+        Task<ResourceCollection<InterruptionResource>> List(int skip = 0, int? take = null, bool pendingOnly = false, string regardingDocumentId = null, CancellationToken token = default);
+        Task Submit(InterruptionResource interruption, CancellationToken token = default);
+        Task TakeResponsibility(InterruptionResource interruption, CancellationToken token = default);
+        Task<UserResource> GetResponsibleUser(InterruptionResource interruption, CancellationToken token = default);
     }
 
     class InterruptionRepository : BasicRepository<InterruptionResource>, IInterruptionRepository
@@ -27,24 +29,24 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<ResourceCollection<InterruptionResource>> List(int skip = 0, int? take = null, bool pendingOnly = false, string regardingDocumentId = null)
+        public async Task<ResourceCollection<InterruptionResource>> List(int skip = 0, int? take = null, bool pendingOnly = false, string regardingDocumentId = null, CancellationToken token = default)
         {
-            return await Client.List<InterruptionResource>(await Repository.Link("Interruptions").ConfigureAwait(false), new { skip, take, pendingOnly, regarding = regardingDocumentId }).ConfigureAwait(false);
+            return await Client.List<InterruptionResource>(await Repository.Link("Interruptions").ConfigureAwait(false), new { skip, take, pendingOnly, regarding = regardingDocumentId }, token).ConfigureAwait(false);
         }
 
-        public Task Submit(InterruptionResource interruption)
+        public Task Submit(InterruptionResource interruption, CancellationToken token = default)
         {
-            return Client.Post(interruption.Link("Submit"), interruption.Form.Values);
+            return Client.Post(interruption.Link("Submit"), interruption.Form.Values, token: token);
         }
 
-        public Task TakeResponsibility(InterruptionResource interruption)
+        public Task TakeResponsibility(InterruptionResource interruption, CancellationToken token = default)
         {
-            return Client.Put(interruption.Link("Responsible"), (InterruptionResource)null);
+            return Client.Put(interruption.Link("Responsible"), (InterruptionResource)null, token: token);
         }
 
-        public Task<UserResource> GetResponsibleUser(InterruptionResource interruption)
+        public Task<UserResource> GetResponsibleUser(InterruptionResource interruption, CancellationToken token = default)
         {
-            return Client.Get<UserResource>(interruption.Link("Responsible"));
+            return Client.Get<UserResource>(interruption.Link("Responsible"), token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/LibraryVariableSetRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/LibraryVariableSetRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -12,8 +13,8 @@ namespace Octopus.Client.Repositories.Async
         IDelete<LibraryVariableSetResource>,
         IFindByName<LibraryVariableSetResource>
     {
-        Task<LibraryVariableSetEditor> CreateOrModify(string name);
-        Task<LibraryVariableSetEditor> CreateOrModify(string name, string description);
+        Task<LibraryVariableSetEditor> CreateOrModify(string name, CancellationToken token = default);
+        Task<LibraryVariableSetEditor> CreateOrModify(string name, string description, CancellationToken token = default);
     }
 
     class LibraryVariableSetRepository : BasicRepository<LibraryVariableSetResource>, ILibraryVariableSetRepository
@@ -23,14 +24,14 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<LibraryVariableSetEditor> CreateOrModify(string name)
+        public Task<LibraryVariableSetEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            return new LibraryVariableSetEditor(this, new VariableSetRepository(Repository)).CreateOrModify(name);
+            return new LibraryVariableSetEditor(this, new VariableSetRepository(Repository)).CreateOrModify(name, token);
         }
 
-        public Task<LibraryVariableSetEditor> CreateOrModify(string name, string description)
+        public Task<LibraryVariableSetEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            return new LibraryVariableSetEditor(this, new VariableSetRepository(Repository)).CreateOrModify(name, description);
+            return new LibraryVariableSetEditor(this, new VariableSetRepository(Repository)).CreateOrModify(name, description, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/LicensesRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/LicensesRepository.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -5,9 +6,9 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ILicensesRepository
     {
-        Task<LicenseResource> GetCurrent();
-        Task<LicenseResource> UpdateCurrent(LicenseResource resource);
-        Task<LicenseStatusResource> GetStatus();
+        Task<LicenseResource> GetCurrent(CancellationToken token = default);
+        Task<LicenseResource> UpdateCurrent(LicenseResource resource, CancellationToken token = default);
+        Task<LicenseStatusResource> GetStatus(CancellationToken token = default);
     }
     
     class LicensesRepository : BasicRepository<LicenseResource>, ILicensesRepository
@@ -17,14 +18,14 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<LicenseResource> GetCurrent()
-            => await Client.Get<LicenseResource>(await Repository.Link(CollectionLinkName));
+        public async Task<LicenseResource> GetCurrent(CancellationToken token = default)
+            => await Client.Get<LicenseResource>(await Repository.Link(CollectionLinkName), token: token);
 
-        public async Task<LicenseResource> UpdateCurrent(LicenseResource resource)
-            => await Client.Update(await Repository.Link(CollectionLinkName), resource);
+        public async Task<LicenseResource> UpdateCurrent(LicenseResource resource, CancellationToken token = default)
+            => await Client.Update(await Repository.Link(CollectionLinkName), resource, token: token);
 
-        public async Task<LicenseStatusResource> GetStatus()
-            => await Client.Get<LicenseStatusResource>(await Repository.Link("CurrentLicenseStatus"));
+        public async Task<LicenseStatusResource> GetStatus(CancellationToken token = default)
+            => await Client.Get<LicenseStatusResource>(await Repository.Link("CurrentLicenseStatus"), token: token);
 
     }
 }

--- a/source/Octopus.Client/Repositories/Async/LifecyclesRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/LifecyclesRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -7,8 +8,8 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ILifecyclesRepository : IGet<LifecycleResource>, ICreate<LifecycleResource>, IModify<LifecycleResource>, IDelete<LifecycleResource>, IFindByName<LifecycleResource>
     {
-        Task<LifecycleEditor> CreateOrModify(string name);
-        Task<LifecycleEditor> CreateOrModify(string name, string description);
+        Task<LifecycleEditor> CreateOrModify(string name, CancellationToken token = default);
+        Task<LifecycleEditor> CreateOrModify(string name, string description, CancellationToken token = default);
     }
 
     class LifecyclesRepository : BasicRepository<LifecycleResource>, ILifecyclesRepository
@@ -18,14 +19,14 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<LifecycleEditor> CreateOrModify(string name)
+        public Task<LifecycleEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            return new LifecycleEditor(this).CreateOrModify(name);
+            return new LifecycleEditor(this).CreateOrModify(name, token);
         }
 
-        public Task<LifecycleEditor> CreateOrModify(string name, string description)
+        public Task<LifecycleEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            return new LifecycleEditor(this).CreateOrModify(name, description);
+            return new LifecycleEditor(this).CreateOrModify(name, description, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/MachinePolicyRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MachinePolicyRepository.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,8 +7,8 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IMachinePolicyRepository : IFindByName<MachinePolicyResource>, ICreate<MachinePolicyResource>, IModify<MachinePolicyResource>, IGet<MachinePolicyResource>, IDelete<MachinePolicyResource>
     {
-        Task<List<MachineResource>> GetMachines(MachinePolicyResource machinePolicy);
-        Task<MachinePolicyResource> GetTemplate();
+        Task<List<MachineResource>> GetMachines(MachinePolicyResource machinePolicy, CancellationToken token = default);
+        Task<MachinePolicyResource> GetTemplate(CancellationToken token = default);
 
     }
 
@@ -17,7 +18,7 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<List<MachineResource>> GetMachines(MachinePolicyResource machinePolicy)
+        public async Task<List<MachineResource>> GetMachines(MachinePolicyResource machinePolicy, CancellationToken token = default)
         {
             var resources = new List<MachineResource>();
 
@@ -25,15 +26,15 @@ namespace Octopus.Client.Repositories.Async
             {
                 resources.AddRange(page.Items);
                 return true;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
 
             return resources;
         }
 
-        public async Task<MachinePolicyResource> GetTemplate()
+        public async Task<MachinePolicyResource> GetTemplate(CancellationToken token = default)
         {
             var link = await Repository.Link("MachinePolicyTemplate").ConfigureAwait(false);
-            return await Client.Get<MachinePolicyResource>(link).ConfigureAwait(false);
+            return await Client.Get<MachinePolicyResource>(link, token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/MachineRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MachineRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -9,12 +10,12 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IMachineRepository : IFindByName<MachineResource>, IGet<MachineResource>, ICreate<MachineResource>, IModify<MachineResource>, IDelete<MachineResource>
     {
-        Task<MachineResource> Discover(string host, int port = 10933, DiscoverableEndpointType? discoverableEndpointType = null);
-        Task<MachineResource> Discover(DiscoverMachineOptions options);
-        Task<MachineConnectionStatus> GetConnectionStatus(MachineResource machine);
-        Task<List<MachineResource>> FindByThumbprint(string thumbprint);
-        Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine);
-        Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine, object pathParameters);
+        Task<MachineResource> Discover(string host, int port = 10933, DiscoverableEndpointType? discoverableEndpointType = null, CancellationToken token = default);
+        Task<MachineResource> Discover(DiscoverMachineOptions options, CancellationToken token = default);
+        Task<MachineConnectionStatus> GetConnectionStatus(MachineResource machine, CancellationToken token = default);
+        Task<List<MachineResource>> FindByThumbprint(string thumbprint, CancellationToken token = default);
+        Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine, CancellationToken token = default);
+        Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine, object pathParameters, CancellationToken token = default);
 
         Task<MachineEditor> CreateOrModify(
             string name,
@@ -23,13 +24,15 @@ namespace Octopus.Client.Repositories.Async
             string[] roles,
             TenantResource[] tenants,
             TagResource[] tenantTags,
-            TenantedDeploymentMode? tenantedDeploymentParticipation);
+            TenantedDeploymentMode? tenantedDeploymentParticipation, 
+            CancellationToken token = default);
 
         Task<MachineEditor> CreateOrModify(
             string name,
             EndpointResource endpoint,
             EnvironmentResource[] environments,
-            string[] roles);
+            string[] roles, 
+            CancellationToken token = default);
 
         Task<ResourceCollection<MachineResource>> List(int skip = 0,
             int? take = null,
@@ -42,7 +45,8 @@ namespace Octopus.Client.Repositories.Async
             string commStyles = null,
             string tenantIds = null,
             string tenantTags = null,
-            string environmentIds = null);
+            string environmentIds = null, 
+            CancellationToken token = default);
     }
 
     class MachineRepository : BasicRepository<MachineResource>, IMachineRepository
@@ -51,40 +55,41 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<MachineResource> Discover(string host, int port = 10933, DiscoverableEndpointType? type = null)
+        public Task<MachineResource> Discover(string host, int port = 10933, DiscoverableEndpointType? type = null, CancellationToken token = default)
             => Discover(new DiscoverMachineOptions(host)
             {
                 Port = port,
                 Type = type
-            });
+            }, token);
 
-        public async Task<MachineResource> Discover(DiscoverMachineOptions options)
+        public async Task<MachineResource> Discover(DiscoverMachineOptions options, CancellationToken token = default)
             => await Client.Get<MachineResource>(await Repository.Link("DiscoverMachine").ConfigureAwait(false), new
             {
                 host = options.Host,
                 port = options.Port,
                 type = options.Type,
                 proxyId = options.Proxy?.Id
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
 
-        public Task<MachineConnectionStatus> GetConnectionStatus(MachineResource machine)
+        public Task<MachineConnectionStatus> GetConnectionStatus(MachineResource machine, CancellationToken token = default)
         {
             if (machine == null) throw new ArgumentNullException("machine");
-            return Client.Get<MachineConnectionStatus>(machine.Link("Connection"));
+            return Client.Get<MachineConnectionStatus>(machine.Link("Connection"), token: token);
         }
 
-        public async Task<List<MachineResource>> FindByThumbprint(string thumbprint)
+        public async Task<List<MachineResource>> FindByThumbprint(string thumbprint, CancellationToken token = default)
         {
             if (thumbprint == null) throw new ArgumentNullException("thumbprint");
-            return await Client.Get<List<MachineResource>>(await Repository.Link("machines").ConfigureAwait(false), new { id = IdValueConstant.IdAll, thumbprint }).ConfigureAwait(false);
+            return await Client.Get<List<MachineResource>>(await Repository.Link("machines").ConfigureAwait(false), new { id = IdValueConstant.IdAll, thumbprint }, token).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Gets all tasks involving the specified machine
         /// </summary>
         /// <param name="machine"></param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        public Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine) => GetTasks(machine, new {  skip = 0 });
+        public Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine, CancellationToken token = default) => GetTasks(machine, new {  skip = 0 }, token);
 
         /// <summary>
         /// Gets all tasks associated with this machine
@@ -93,13 +98,14 @@ namespace Octopus.Client.Repositories.Async
         /// </summary>
         /// <param name="machine"></param>
         /// <param name="pathParameters"></param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine, object pathParameters)
+        public async Task<IReadOnlyList<TaskResource>> GetTasks(MachineResource machine, object pathParameters, CancellationToken token = default)
         {
             if (machine == null)
                 throw new ArgumentNullException(nameof(machine));
 
-            return await Client.ListAll<TaskResource>(machine.Link("TasksTemplate"), pathParameters).ConfigureAwait(false);
+            return await Client.ListAll<TaskResource>(machine.Link("TasksTemplate"), pathParameters, token).ConfigureAwait(false);
         }
 
         public Task<MachineEditor> CreateOrModify(
@@ -109,18 +115,20 @@ namespace Octopus.Client.Repositories.Async
             string[] roles,
             TenantResource[] tenants,
             TagResource[] tenantTags,
-            TenantedDeploymentMode? tenantedDeploymentParticipation)
+            TenantedDeploymentMode? tenantedDeploymentParticipation,
+            CancellationToken token = default)
         {
-            return new MachineEditor(this).CreateOrModify(name, endpoint, environments, roles, tenants, tenantTags, tenantedDeploymentParticipation);
+            return new MachineEditor(this).CreateOrModify(name, endpoint, environments, roles, tenants, tenantTags, tenantedDeploymentParticipation, token);
         }
 
         public Task<MachineEditor> CreateOrModify(
             string name,
             EndpointResource endpoint,
             EnvironmentResource[] environments,
-            string[] roles)
+            string[] roles,
+            CancellationToken token = default)
         {
-            return new MachineEditor(this).CreateOrModify(name, endpoint, environments, roles);
+            return new MachineEditor(this).CreateOrModify(name, endpoint, environments, roles, token);
         }
 
         public async Task<ResourceCollection<MachineResource>> List(int skip = 0,
@@ -134,7 +142,8 @@ namespace Octopus.Client.Repositories.Async
             string commStyles = null,
             string tenantIds = null,
             string tenantTags = null,
-            string environmentIds = null)
+            string environmentIds = null,
+            CancellationToken token = default)
         {
             return await Client.List<MachineResource>(await Repository.Link("Machines").ConfigureAwait(false), new
             {
@@ -150,7 +159,7 @@ namespace Octopus.Client.Repositories.Async
                 tenantIds,
                 tenantTags,
                 environmentIds,
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/MachineRoleRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MachineRoleRepository.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IMachineRoleRepository
     {
-        Task<List<string>> GetAllRoleNames();
+        Task<List<string>> GetAllRoleNames(CancellationToken token = default);
     }
 
     class MachineRoleRepository : IMachineRoleRepository
@@ -19,9 +20,9 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<List<string>> GetAllRoleNames()
+        public async Task<List<string>> GetAllRoleNames(CancellationToken token = default)
         {
-            var result = await repository.Client.Get<string[]>(await repository.Link("MachineRoles").ConfigureAwait(false)).ConfigureAwait(false);
+            var result = await repository.Client.Get<string[]>(await repository.Link("MachineRoles").ConfigureAwait(false), token: token).ConfigureAwait(false);
             return result.ToList();
         }
     }

--- a/source/Octopus.Client/Repositories/Async/MigrationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/MigrationRepository.cs
@@ -1,12 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Client.Model.Migrations;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IMigrationRepository
     {
-        Task<MigrationPartialExportResource> PartialExport(MigrationPartialExportResource resource);
-        Task<MigrationImportResource> Import(MigrationImportResource resource);
+        Task<MigrationPartialExportResource> PartialExport(MigrationPartialExportResource resource, CancellationToken token = default);
+        Task<MigrationImportResource> Import(MigrationImportResource resource, CancellationToken token = default);
     }
 
     class MigrationRepository : IMigrationRepository
@@ -18,14 +19,14 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<MigrationPartialExportResource> PartialExport(MigrationPartialExportResource resource)
+        public async Task<MigrationPartialExportResource> PartialExport(MigrationPartialExportResource resource, CancellationToken token = default)
         {
-            return await repository.Client.Post<MigrationPartialExportResource, MigrationPartialExportResource>(await repository.Link("MigrationsPartialExport").ConfigureAwait(false), resource).ConfigureAwait(false);
+            return await repository.Client.Post<MigrationPartialExportResource, MigrationPartialExportResource>(await repository.Link("MigrationsPartialExport").ConfigureAwait(false), resource, token: token).ConfigureAwait(false);
         }
 
-        public async Task<MigrationImportResource> Import(MigrationImportResource resource)
+        public async Task<MigrationImportResource> Import(MigrationImportResource resource, CancellationToken token = default)
         {
-            return await repository.Client.Post<MigrationImportResource, MigrationImportResource>(await repository.Link("MigrationsImport").ConfigureAwait(false), resource).ConfigureAwait(false);
+            return await repository.Client.Post<MigrationImportResource, MigrationImportResource>(await repository.Link("MigrationsImport").ConfigureAwait(false), resource, token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/OctopusServerNodeRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/OctopusServerNodeRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,8 +8,8 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IOctopusServerNodeRepository : IModify<OctopusServerNodeResource>, IDelete<OctopusServerNodeResource>, IGet<OctopusServerNodeResource>, IFindByName<OctopusServerNodeResource>
     {
-        Task<OctopusServerNodeDetailsResource> Details(OctopusServerNodeResource node);
-        Task<OctopusServerClusterSummaryResource> Summary();
+        Task<OctopusServerNodeDetailsResource> Details(OctopusServerNodeResource node, CancellationToken token = default);
+        Task<OctopusServerClusterSummaryResource> Summary(CancellationToken token = default);
     }
 
     class OctopusServerNodeRepository : BasicRepository<OctopusServerNodeResource>, IOctopusServerNodeRepository
@@ -21,14 +22,14 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<OctopusServerNodeDetailsResource> Details(OctopusServerNodeResource node)
+        public async Task<OctopusServerNodeDetailsResource> Details(OctopusServerNodeResource node, CancellationToken token = default)
         {
-            return await repository.Client.Get<OctopusServerNodeDetailsResource>(node.Link("Details"));
+            return await repository.Client.Get<OctopusServerNodeDetailsResource>(node.Link("Details"), token: token);
         }
 
-        public async Task<OctopusServerClusterSummaryResource> Summary()
+        public async Task<OctopusServerClusterSummaryResource> Summary(CancellationToken token = default)
         {
-            return await repository.Client.Get<OctopusServerClusterSummaryResource>(await repository.Link("OctopusServerClusterSummary").ConfigureAwait(false)).ConfigureAwait(false);
+            return await repository.Client.Get<OctopusServerClusterSummaryResource>(await repository.Link("OctopusServerClusterSummary").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/PerformanceConfigurationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/PerformanceConfigurationRepository.cs
@@ -1,12 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IPerformanceConfigurationRepository
     {
-        Task<PerformanceConfigurationResource> Get();
-        Task<PerformanceConfigurationResource> Modify(PerformanceConfigurationResource resource);
+        Task<PerformanceConfigurationResource> Get(CancellationToken token = default);
+        Task<PerformanceConfigurationResource> Modify(PerformanceConfigurationResource resource, CancellationToken token = default);
     }
 
     class PerformanceConfigurationRepository : IPerformanceConfigurationRepository
@@ -18,14 +19,14 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public async Task<PerformanceConfigurationResource> Get()
+        public async Task<PerformanceConfigurationResource> Get(CancellationToken token = default)
         {
-            return await repository.Client.Get<PerformanceConfigurationResource>(await repository.Link("PerformanceConfiguration").ConfigureAwait(false)).ConfigureAwait(false);
+            return await repository.Client.Get<PerformanceConfigurationResource>(await repository.Link("PerformanceConfiguration").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
 
-        public async Task<PerformanceConfigurationResource> Modify(PerformanceConfigurationResource resource)
+        public async Task<PerformanceConfigurationResource> Modify(PerformanceConfigurationResource resource, CancellationToken token = default)
         {
-            return await repository.Client.Update(await repository.Link("PerformanceConfiguration").ConfigureAwait(false), resource).ConfigureAwait(false);
+            return await repository.Client.Update(await repository.Link("PerformanceConfiguration").ConfigureAwait(false), resource, token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ProjectGroupRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectGroupRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -8,9 +9,9 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IProjectGroupRepository : IFindByName<ProjectGroupResource>, IGet<ProjectGroupResource>, ICreate<ProjectGroupResource>, IModify<ProjectGroupResource>, IDelete<ProjectGroupResource>, IGetAll<ProjectGroupResource>
     {
-        Task<List<ProjectResource>> GetProjects(ProjectGroupResource projectGroup);
-        Task<ProjectGroupEditor> CreateOrModify(string name);
-        Task<ProjectGroupEditor> CreateOrModify(string name, string description);
+        Task<List<ProjectResource>> GetProjects(ProjectGroupResource projectGroup, CancellationToken token = default);
+        Task<ProjectGroupEditor> CreateOrModify(string name, CancellationToken token = default);
+        Task<ProjectGroupEditor> CreateOrModify(string name, string description, CancellationToken token = default);
     }
 
     class ProjectGroupRepository : BasicRepository<ProjectGroupResource>, IProjectGroupRepository
@@ -20,7 +21,7 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<List<ProjectResource>> GetProjects(ProjectGroupResource projectGroup)
+        public async Task<List<ProjectResource>> GetProjects(ProjectGroupResource projectGroup, CancellationToken token = default)
         {
             var resources = new List<ProjectResource>();
 
@@ -28,19 +29,19 @@ namespace Octopus.Client.Repositories.Async
             {
                 resources.AddRange(page.Items);
                 return true;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
 
             return resources;
         }
 
-        public Task<ProjectGroupEditor> CreateOrModify(string name)
+        public Task<ProjectGroupEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            return new ProjectGroupEditor(this).CreateOrModify(name);
+            return new ProjectGroupEditor(this).CreateOrModify(name, token);
         }
 
-        public Task<ProjectGroupEditor> CreateOrModify(string name, string description)
+        public Task<ProjectGroupEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            return new ProjectGroupEditor(this).CreateOrModify(name, description);
+            return new ProjectGroupEditor(this).CreateOrModify(name, description, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -4,28 +4,29 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
+using System.Threading;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IProjectRepository : IFindByName<ProjectResource>, IGet<ProjectResource>, ICreate<ProjectResource>, IModify<ProjectResource>, IDelete<ProjectResource>, IGetAll<ProjectResource>
     {
         IProjectBetaRepository Beta();
-        Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null);
-        Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project);
-        Task<ReleaseResource> GetReleaseByVersion(ProjectResource project, string version);
-        Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource project);
-        Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource project);
-        Task<ProgressionResource> GetProgression(ProjectResource project);
-        Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(ProjectResource project);
-        Task<IReadOnlyList<ProjectTriggerResource>> GetAllTriggers(ProjectResource project);
-        Task SetLogo(ProjectResource project, string fileName, Stream contents);
-        Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle);
-        Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null);
-        Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(ProjectResource project, int skip = 0, int? take = null, string searchByName = null);
-        Task<IReadOnlyList<RunbookSnapshotResource>> GetAllRunbookSnapshots(ProjectResource project);
-        Task<RunbookSnapshotResource> GetRunbookSnapshotByName(ProjectResource project, string name);
-        Task<ResourceCollection<RunbookResource>> GetRunbooks(ProjectResource project, int skip = 0, int? take = null, string searchByName = null);
-        Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(ProjectResource project);
+        Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null, CancellationToken token = default);
+        Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project, CancellationToken token = default);
+        Task<ReleaseResource> GetReleaseByVersion(ProjectResource project, string version, CancellationToken token = default);
+        Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource project, CancellationToken token = default);
+        Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource project, CancellationToken token = default);
+        Task<ProgressionResource> GetProgression(ProjectResource project, CancellationToken token = default);
+        Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(ProjectResource project, CancellationToken token = default);
+        Task<IReadOnlyList<ProjectTriggerResource>> GetAllTriggers(ProjectResource project, CancellationToken token = default);
+        Task SetLogo(ProjectResource project, string fileName, Stream contents, CancellationToken token = default);
+        Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, CancellationToken token = default);
+        Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null, CancellationToken token = default);
+        Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(ProjectResource project, int skip = 0, int? take = null, string searchByName = null, CancellationToken token = default);
+        Task<IReadOnlyList<RunbookSnapshotResource>> GetAllRunbookSnapshots(ProjectResource project, CancellationToken token = default);
+        Task<RunbookSnapshotResource> GetRunbookSnapshotByName(ProjectResource project, string name, CancellationToken token = default);
+        Task<ResourceCollection<RunbookResource>> GetRunbooks(ProjectResource project, int skip = 0, int? take = null, string searchByName = null, CancellationToken token = default);
+        Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(ProjectResource project, CancellationToken token = default);
     }
 
     class ProjectRepository : BasicRepository<ProjectResource>, IProjectRepository
@@ -43,91 +44,91 @@ namespace Octopus.Client.Repositories.Async
             return beta;
         }
 
-        public Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null)
+        public Task<ResourceCollection<ReleaseResource>> GetReleases(ProjectResource project, int skip = 0, int? take = null, string searchByVersion = null, CancellationToken token = default)
         {
-            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, searchByVersion });
+            return Client.List<ReleaseResource>(project.Link("Releases"), new { skip, take, searchByVersion }, token);
         }
 
-        public Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project)
+        public Task<IReadOnlyList<ReleaseResource>> GetAllReleases(ProjectResource project, CancellationToken token = default)
         {
-            return Client.ListAll<ReleaseResource>(project.Link("Releases"));
+            return Client.ListAll<ReleaseResource>(project.Link("Releases"), token: token);
         }
 
-        public Task<ReleaseResource> GetReleaseByVersion(ProjectResource project, string version)
+        public Task<ReleaseResource> GetReleaseByVersion(ProjectResource project, string version, CancellationToken token = default)
         {
-            return Client.Get<ReleaseResource>(project.Link("Releases"), new { version });
+            return Client.Get<ReleaseResource>(project.Link("Releases"), new { version }, token);
         }
 
-        public Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource project)
+        public Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource project, CancellationToken token = default)
         {
-            return Client.List<ChannelResource>(project.Link("Channels"));
+            return Client.List<ChannelResource>(project.Link("Channels"), token: token);
         }
 
-        public Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource project)
+        public Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource project, CancellationToken token = default)
         {
-            return Client.ListAll<ChannelResource>(project.Link("Channels"));
+            return Client.ListAll<ChannelResource>(project.Link("Channels"), token: token);
         }
 
-        public Task<ProgressionResource> GetProgression(ProjectResource project)
+        public Task<ProgressionResource> GetProgression(ProjectResource project, CancellationToken token = default)
         {
-            return Client.Get<ProgressionResource>(project.Link("Progression"));
+            return Client.Get<ProgressionResource>(project.Link("Progression"), token: token);
         }
 
-        public Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(ProjectResource project)
+        public Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(ProjectResource project, CancellationToken token = default)
         {
-            return Client.List<ProjectTriggerResource>(project.Link("Triggers"));
+            return Client.List<ProjectTriggerResource>(project.Link("Triggers"), token: token);
         }
 
-        public Task<IReadOnlyList<ProjectTriggerResource>> GetAllTriggers(ProjectResource project)
+        public Task<IReadOnlyList<ProjectTriggerResource>> GetAllTriggers(ProjectResource project, CancellationToken token = default)
         {
-            return Client.ListAll<ProjectTriggerResource>(project.Link("Triggers"));
+            return Client.ListAll<ProjectTriggerResource>(project.Link("Triggers"), token: token);
         }
 
-        public Task SetLogo(ProjectResource project, string fileName, Stream contents)
+        public Task SetLogo(ProjectResource project, string fileName, Stream contents, CancellationToken token = default)
         {
-            return Client.Post(project.Link("Logo"), new FileUpload { Contents = contents, FileName = fileName }, false);
+            return Client.Post(project.Link("Logo"), new FileUpload { Contents = contents, FileName = fileName }, false, token);
         }
 
-        public Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle)
+        public Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, CancellationToken token = default)
         {
-            return new ProjectEditor(this, new ChannelRepository(Repository), new DeploymentProcessRepository(Repository), new ProjectTriggerRepository(Repository), new VariableSetRepository(Repository)).CreateOrModify(name, projectGroup, lifecycle);
+            return new ProjectEditor(this, new ChannelRepository(Repository), new DeploymentProcessRepository(Repository), new ProjectTriggerRepository(Repository), new VariableSetRepository(Repository)).CreateOrModify(name, projectGroup, lifecycle, token);
         }
 
-        public Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null)
+        public Task<ProjectEditor> CreateOrModify(string name, ProjectGroupResource projectGroup, LifecycleResource lifecycle, string description, string cloneId = null, CancellationToken token = default)
         {
-            return new ProjectEditor(this, new ChannelRepository(Repository), new DeploymentProcessRepository(Repository), new ProjectTriggerRepository(Repository), new VariableSetRepository(Repository)).CreateOrModify(name, projectGroup, lifecycle, description, cloneId);
+            return new ProjectEditor(this, new ChannelRepository(Repository), new DeploymentProcessRepository(Repository), new ProjectTriggerRepository(Repository), new VariableSetRepository(Repository)).CreateOrModify(name, projectGroup, lifecycle, description, cloneId, token);
         }
 
-        public Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(ProjectResource project, int skip = 0, int? take = null, string searchByName = null)
+        public Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(ProjectResource project, int skip = 0, int? take = null, string searchByName = null, CancellationToken token = default)
         {
-            return Client.List<RunbookSnapshotResource>(project.Link("RunbookSnapshots"), new { skip, take, searchByName });
+            return Client.List<RunbookSnapshotResource>(project.Link("RunbookSnapshots"), new { skip, take, searchByName }, token);
         }
 
-        public Task<IReadOnlyList<RunbookSnapshotResource>> GetAllRunbookSnapshots(ProjectResource project)
+        public Task<IReadOnlyList<RunbookSnapshotResource>> GetAllRunbookSnapshots(ProjectResource project, CancellationToken token = default)
         {
-            return Client.ListAll<RunbookSnapshotResource>(project.Link("RunbookSnapshots"));
+            return Client.ListAll<RunbookSnapshotResource>(project.Link("RunbookSnapshots"), token: token);
         }
 
-        public Task<RunbookSnapshotResource> GetRunbookSnapshotByName(ProjectResource project, string name)
+        public Task<RunbookSnapshotResource> GetRunbookSnapshotByName(ProjectResource project, string name, CancellationToken token = default)
         {
-            return Client.Get<RunbookSnapshotResource>(project.Link("RunbookSnapshots"), new { name });
+            return Client.Get<RunbookSnapshotResource>(project.Link("RunbookSnapshots"), new { name }, token);
         }
 
-        public Task<ResourceCollection<RunbookResource>> GetRunbooks(ProjectResource project, int skip = 0, int? take = null, string searchByName = null)
+        public Task<ResourceCollection<RunbookResource>> GetRunbooks(ProjectResource project, int skip = 0, int? take = null, string searchByName = null, CancellationToken token = default)
         {
-            return Client.List<RunbookResource>(project.Link("Runbooks"), new { skip, take, searchByName });
+            return Client.List<RunbookResource>(project.Link("Runbooks"), new { skip, take, searchByName }, token);
         }
 
-        public Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(ProjectResource project)
+        public Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(ProjectResource project, CancellationToken token = default)
         {
-            return Client.ListAll<RunbookResource>(project.Link("Runbooks"));
+            return Client.ListAll<RunbookResource>(project.Link("Runbooks"), token: token);
         }
     }
 
     public interface IProjectBetaRepository
     {
-        Task<VersionControlBranchResource[]> GetVersionControlledBranches(ProjectResource projectResource);
-        Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch);
+        Task<VersionControlBranchResource[]> GetVersionControlledBranches(ProjectResource projectResource, CancellationToken token = default);
+        Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch, CancellationToken token = default);
     }
 
     class ProjectBetaRepository : IProjectBetaRepository
@@ -139,14 +140,14 @@ namespace Octopus.Client.Repositories.Async
             this.client = repository.Client;
         }
 
-        public Task<VersionControlBranchResource[]> GetVersionControlledBranches(ProjectResource projectResource)
+        public Task<VersionControlBranchResource[]> GetVersionControlledBranches(ProjectResource projectResource, CancellationToken token = default)
         {
-            return client.Get<VersionControlBranchResource[]>(projectResource.Link("Branches"));
+            return client.Get<VersionControlBranchResource[]>(projectResource.Link("Branches"), token: token);
         }
 
-        public Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch)
+        public Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch, CancellationToken token = default)
         {
-            return client.Get<VersionControlBranchResource>(projectResource.Link("Branches"), new { name = branch });
+            return client.Get<VersionControlBranchResource>(projectResource.Link("Branches"), new { name = branch }, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ProjectTriggerRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectTriggerRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -9,10 +10,10 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IProjectTriggerRepository : ICreate<ProjectTriggerResource>, IModify<ProjectTriggerResource>, IGet<ProjectTriggerResource>, IDelete<ProjectTriggerResource>
     {
-        Task<ProjectTriggerResource> FindByName(ProjectResource project, string name);
+        Task<ProjectTriggerResource> FindByName(ProjectResource project, string name, CancellationToken token = default);
 
-        Task<ProjectTriggerEditor> CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action);
-        Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(params string[] runbookIds);
+        Task<ProjectTriggerEditor> CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action, CancellationToken token = default);
+        Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(CancellationToken token = default, params string[] runbookIds);
     }
 
     class ProjectTriggerRepository : BasicRepository<ProjectTriggerResource>, IProjectTriggerRepository
@@ -23,23 +24,23 @@ namespace Octopus.Client.Repositories.Async
             MinimumCompatibleVersion("2019.11.0");
         }
 
-        public Task<ProjectTriggerResource> FindByName(ProjectResource project, string name)
+        public Task<ProjectTriggerResource> FindByName(ProjectResource project, string name, CancellationToken token = default)
         {
-            return FindByName(name, path: project.Link("Triggers"));
+            return FindByName(name, path: project.Link("Triggers"), token: token);
         }
 
-        public Task<ProjectTriggerEditor> CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action)
+        public Task<ProjectTriggerEditor> CreateOrModify(ProjectResource project, string name, TriggerFilterResource filter, TriggerActionResource action, CancellationToken token = default)
         {
             ThrowIfServerVersionIsNotCompatible().ConfigureAwait(false);
             
-            return new ProjectTriggerEditor(this).CreateOrModify(project, name, filter, action);
+            return new ProjectTriggerEditor(this).CreateOrModify(project, name, filter, action, token);
         }
 
-        public async Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(params string[] runbookIds)
+        public async Task<ResourceCollection<ProjectTriggerResource>> FindByRunbook(CancellationToken token = default, params string[] runbookIds)
         {
             await ThrowIfServerVersionIsNotCompatible();
             
-            return await Client.List<ProjectTriggerResource>(await Repository.Link("Triggers"), new { runbooks = runbookIds });
+            return await Client.List<ProjectTriggerResource>(await Repository.Link("Triggers"), new { runbooks = runbookIds }, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ReleaseRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ReleaseRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -12,21 +13,23 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="release"></param>
         /// <param name="skip">Number of records to skip</param>
         /// <param name="take">Number of records to take (First supported in Server 3.14.15)</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<ResourceCollection<DeploymentResource>> GetDeployments(ReleaseResource release, int skip = 0, int? take = null);
+        Task<ResourceCollection<DeploymentResource>> GetDeployments(ReleaseResource release, int skip = 0, int? take = null, CancellationToken token = default);
         /// <summary>
         /// 
         /// </summary>
         /// <param name="release"></param>
         /// <param name="skip">Number of records to skip</param>
         /// <param name="take">Number of records to take (First supported in Server 3.14.15)</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<ResourceCollection<ArtifactResource>> GetArtifacts(ReleaseResource release, int skip = 0, int? take = null);
-        Task<DeploymentTemplateResource> GetTemplate(ReleaseResource release);
-        Task<DeploymentPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget);
-        Task<ReleaseResource> SnapshotVariables(ReleaseResource release);    
-        Task<ReleaseResource> Create(ReleaseResource release, bool ignoreChannelRules = false);
-        Task<LifecycleProgressionResource> GetProgression(ReleaseResource release);
+        Task<ResourceCollection<ArtifactResource>> GetArtifacts(ReleaseResource release, int skip = 0, int? take = null, CancellationToken token = default);
+        Task<DeploymentTemplateResource> GetTemplate(ReleaseResource release, CancellationToken token = default);
+        Task<DeploymentPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget, CancellationToken token = default);
+        Task<ReleaseResource> SnapshotVariables(ReleaseResource release, CancellationToken token = default);    
+        Task<ReleaseResource> Create(ReleaseResource release, bool ignoreChannelRules = false, CancellationToken token = default);
+        Task<LifecycleProgressionResource> GetProgression(ReleaseResource release, CancellationToken token = default);
     }
 
     class ReleaseRepository : BasicRepository<ReleaseResource>, IReleaseRepository
@@ -36,40 +39,40 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<ResourceCollection<DeploymentResource>> GetDeployments(ReleaseResource release, int skip = 0, int? take = null)
+        public Task<ResourceCollection<DeploymentResource>> GetDeployments(ReleaseResource release, int skip = 0, int? take = null, CancellationToken token = default)
         {
-            return Client.List<DeploymentResource>(release.Link("Deployments"), new { skip, take });
+            return Client.List<DeploymentResource>(release.Link("Deployments"), new { skip, take }, token);
         }
 
-        public Task<ResourceCollection<ArtifactResource>> GetArtifacts(ReleaseResource release, int skip = 0, int? take = null)
+        public Task<ResourceCollection<ArtifactResource>> GetArtifacts(ReleaseResource release, int skip = 0, int? take = null, CancellationToken token = default)
         {
-            return Client.List<ArtifactResource>(release.Link("Artifacts"), new { skip, take });
+            return Client.List<ArtifactResource>(release.Link("Artifacts"), new { skip, take }, token);
         }
 
-        public Task<DeploymentTemplateResource> GetTemplate(ReleaseResource release)
+        public Task<DeploymentTemplateResource> GetTemplate(ReleaseResource release, CancellationToken token = default)
         {
-            return Client.Get<DeploymentTemplateResource>(release.Link("DeploymentTemplate"));
+            return Client.Get<DeploymentTemplateResource>(release.Link("DeploymentTemplate"), token: token);
         }
 
-        public Task<DeploymentPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget)
+        public Task<DeploymentPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget, CancellationToken token = default)
         {
-            return Client.Get<DeploymentPreviewResource>(promotionTarget.Link("Preview"));
+            return Client.Get<DeploymentPreviewResource>(promotionTarget.Link("Preview"), token: token);
         }
 
-        public async Task<ReleaseResource> SnapshotVariables(ReleaseResource release)
+        public async Task<ReleaseResource> SnapshotVariables(ReleaseResource release, CancellationToken token = default)
         {
-            await Client.Post(release.Link("SnapshotVariables")).ConfigureAwait(false);
-            return await Get(release.Id).ConfigureAwait(false);
+            await Client.Post(release.Link("SnapshotVariables"), token: token).ConfigureAwait(false);
+            return await Get(release.Id, token).ConfigureAwait(false);
         }
 
-        public async Task<ReleaseResource> Create(ReleaseResource release, bool ignoreChannelRules = false)
+        public async Task<ReleaseResource> Create(ReleaseResource release, bool ignoreChannelRules = false, CancellationToken token = default)
         {
-            return await Client.Create(await Repository.Link(CollectionLinkName).ConfigureAwait(false), release, new { ignoreChannelRules }).ConfigureAwait(false);
+            return await Client.Create(await Repository.Link(CollectionLinkName).ConfigureAwait(false), release, new { ignoreChannelRules }, token).ConfigureAwait(false);
         }
         
-        public Task<LifecycleProgressionResource> GetProgression(ReleaseResource release)
+        public Task<LifecycleProgressionResource> GetProgression(ReleaseResource release, CancellationToken token = default)
         {
-            return Client.Get<LifecycleProgressionResource>(release.Links["Progression"]);
+            return Client.Get<LifecycleProgressionResource>(release.Links["Progression"], token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/RetentionPolicyRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/RetentionPolicyRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Util;
@@ -7,7 +8,7 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IRetentionPolicyRepository
     {
-        Task<TaskResource> ApplyNow(string spaceId = null);
+        Task<TaskResource> ApplyNow(string spaceId = null, CancellationToken token = default);
     }
 
     class RetentionPolicyRepository : BasicRepository<RetentionPolicyResource>, IRetentionPolicyRepository
@@ -17,11 +18,11 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<TaskResource> ApplyNow(string spaceId = null)
+        public Task<TaskResource> ApplyNow(string spaceId = null, CancellationToken token = default)
         {
             var tasks = new TaskRepository(Repository);
             var task = new TaskResource { Name = "Retention", Description = "Request to apply retention policies via the API", SpaceId = spaceId};
-            return tasks.Create(task);
+            return tasks.Create(task, token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/RunbookProcessRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/RunbookProcessRepository.cs
@@ -1,11 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IRunbookProcessRepository : IGet<RunbookProcessResource>, IModify<RunbookProcessResource>
     {
-        Task<RunbookSnapshotTemplateResource> GetTemplate(RunbookProcessResource runbookProcess);
+        Task<RunbookSnapshotTemplateResource> GetTemplate(RunbookProcessResource runbookProcess, CancellationToken token = default);
     }
 
     class RunbookProcessRepository : BasicRepository<RunbookProcessResource>, IRunbookProcessRepository
@@ -15,9 +16,9 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<RunbookSnapshotTemplateResource> GetTemplate(RunbookProcessResource runbookProcess)
+        public Task<RunbookSnapshotTemplateResource> GetTemplate(RunbookProcessResource runbookProcess, CancellationToken token = default)
         {
-            return Client.Get<RunbookSnapshotTemplateResource>(runbookProcess.Link("RunbookSnapshotTemplate"));
+            return Client.Get<RunbookSnapshotTemplateResource>(runbookProcess.Link("RunbookSnapshotTemplate"), token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/RunbookRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/RunbookRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Exceptions;
@@ -8,13 +9,13 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IRunbookRepository : IFindByName<RunbookResource>, IGet<RunbookResource>, ICreate<RunbookResource>, IModify<RunbookResource>, IDelete<RunbookResource>
     {
-        Task<RunbookResource> FindByName(ProjectResource project, string name);
-        Task<RunbookEditor> CreateOrModify(ProjectResource project, string name, string description);
-        Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(RunbookResource runbook);
-        Task<RunbookRunTemplateResource> GetRunbookRunTemplate(RunbookResource runbook);
-        Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget);
-        Task<RunbookRunResource> Run(RunbookResource runbook, RunbookRunResource runbookRun);
-        Task<RunbookRunResource[]> Run(RunbookResource runbook, RunbookRunParameters runbookRunParameters);
+        Task<RunbookResource> FindByName(ProjectResource project, string name, CancellationToken token = default);
+        Task<RunbookEditor> CreateOrModify(ProjectResource project, string name, string description, CancellationToken token = default);
+        Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(RunbookResource runbook, CancellationToken token = default);
+        Task<RunbookRunTemplateResource> GetRunbookRunTemplate(RunbookResource runbook, CancellationToken token = default);
+        Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget, CancellationToken token = default);
+        Task<RunbookRunResource> Run(RunbookResource runbook, RunbookRunResource runbookRun, CancellationToken token = default);
+        Task<RunbookRunResource[]> Run(RunbookResource runbook, RunbookRunParameters runbookRunParameters, CancellationToken token = default);
     }
 
     class RunbookRepository : BasicRepository<RunbookResource>, IRunbookRepository
@@ -29,29 +30,29 @@ namespace Octopus.Client.Repositories.Async
             versionAfterWhichRunbookRunParametersAreAvailable = SemanticVersion.Parse("2020.3.1");
         }
 
-        public Task<RunbookResource> FindByName(ProjectResource project, string name)
+        public Task<RunbookResource> FindByName(ProjectResource project, string name, CancellationToken token = default)
         {
-            return FindByName(name, path: project.Link("Runbooks"));
+            return FindByName(name, path: project.Link("Runbooks"), token: token);
         }
 
-        public Task<RunbookEditor> CreateOrModify(ProjectResource project, string name, string description)
+        public Task<RunbookEditor> CreateOrModify(ProjectResource project, string name, string description, CancellationToken token = default)
         {
-            return new RunbookEditor(this, new RunbookProcessRepository(Repository)).CreateOrModify(project, name, description);
+            return new RunbookEditor(this, new RunbookProcessRepository(Repository)).CreateOrModify(project, name, description, token);
         }
 
-        public Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(RunbookResource runbook)
+        public Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(RunbookResource runbook, CancellationToken token = default)
         {
-            return Client.Get<RunbookSnapshotTemplateResource>(runbook.Link("RunbookSnapshotTemplate"));
+            return Client.Get<RunbookSnapshotTemplateResource>(runbook.Link("RunbookSnapshotTemplate"), token: token);
         }
 
-        public Task<RunbookRunTemplateResource> GetRunbookRunTemplate(RunbookResource runbook)
+        public Task<RunbookRunTemplateResource> GetRunbookRunTemplate(RunbookResource runbook, CancellationToken token = default)
         {
-            return Client.Get<RunbookRunTemplateResource>(runbook.Link("RunbookRunTemplate"));
+            return Client.Get<RunbookRunTemplateResource>(runbook.Link("RunbookRunTemplate"), token: token);
         }
 
-        public Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget)
+        public Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget, CancellationToken token = default)
         {
-            return Client.Get<RunbookRunPreviewResource>(promotionTarget.Link("RunbookRunPreview"));
+            return Client.Get<RunbookRunPreviewResource>(promotionTarget.Link("RunbookRunPreview"), token: token);
         }
 
         private bool ServerSupportsRunbookRunParameters(string version)
@@ -66,16 +67,16 @@ namespace Octopus.Client.Repositories.Async
                    serverVersion == integrationTestVersion;
         }
 
-        public async Task<RunbookRunResource> Run(RunbookResource runbook, RunbookRunResource runbookRun)
+        public async Task<RunbookRunResource> Run(RunbookResource runbook, RunbookRunResource runbookRun, CancellationToken token = default)
         {
             var serverSupportsRunbookRunParameters = ServerSupportsRunbookRunParameters((await Repository.LoadRootDocument()).Version);
 
             return serverSupportsRunbookRunParameters
                 ? (await Run(runbook, RunbookRunParameters.MapFrom(runbookRun))).FirstOrDefault()
-                : await Client.Post<object, RunbookRunResource>(runbook.Link("CreateRunbookRun"), runbookRun);
+                : await Client.Post<object, RunbookRunResource>(runbook.Link("CreateRunbookRun"), runbookRun, token: token);
         }
 
-        public async Task<RunbookRunResource[]> Run(RunbookResource runbook, RunbookRunParameters runbookRunParameters)
+        public async Task<RunbookRunResource[]> Run(RunbookResource runbook, RunbookRunParameters runbookRunParameters, CancellationToken token = default)
         {
             var serverVersion = (await Repository.LoadRootDocument()).Version;
             var serverSupportsRunbookRunParameters = ServerSupportsRunbookRunParameters(serverVersion);
@@ -84,7 +85,7 @@ namespace Octopus.Client.Repositories.Async
                 throw new UnsupportedApiVersionException($"This Octopus Deploy server is an older version ({serverVersion}) that does not yet support RunbookRunParameters. " +
                                                          $"Please update your Octopus Deploy server to 2020.3.* or newer to access this feature.");
 
-            return await Client.Post<object, RunbookRunResource[]>(runbook.Link("CreateRunbookRun"), runbookRunParameters);
+            return await Client.Post<object, RunbookRunResource[]>(runbook.Link("CreateRunbookRun"), runbookRunParameters, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/RunbookRunRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/RunbookRunRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,7 +7,7 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IRunbookRunRepository : IGet<RunbookRunResource>, ICreate<RunbookRunResource>, IPaginate<RunbookRunResource>, IDelete<RunbookRunResource>
     {
-        Task<TaskResource> GetTask(RunbookRunResource resource);
+        Task<TaskResource> GetTask(RunbookRunResource resource, CancellationToken token = default);
 
         /// <summary>
         /// 
@@ -16,10 +17,11 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="environments"></param>
         /// <param name="skip">Number of records to skip</param>
         /// <param name="take">Number of records to take (First supported in Server 3.14.15)</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<ResourceCollection<RunbookRunResource>> FindBy(string[] projects, string[] runbooks, string[] environments, int skip = 0, int? take = null);
-        Task Paginate(string[] projects, string[] runbooks, string[] environments, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage);
-        Task Paginate(string[] projects, string[] runbooks, string[] environments, string[] tenants, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage);
+        Task<ResourceCollection<RunbookRunResource>> FindBy(string[] projects, string[] runbooks, string[] environments, int skip = 0, int? take = null, CancellationToken token = default);
+        Task Paginate(string[] projects, string[] runbooks, string[] environments, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage, CancellationToken token = default);
+        Task Paginate(string[] projects, string[] runbooks, string[] environments, string[] tenants, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage, CancellationToken token = default);
     }
 
     class RunbookRunRepository : BasicRepository<RunbookRunResource>, IRunbookRunRepository
@@ -29,24 +31,24 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<TaskResource> GetTask(RunbookRunResource resource)
+        public Task<TaskResource> GetTask(RunbookRunResource resource, CancellationToken token = default)
         {
-            return Client.Get<TaskResource>(resource.Link("Task"));
+            return Client.Get<TaskResource>(resource.Link("Task"), token: token);
         }
 
-        public async Task<ResourceCollection<RunbookRunResource>> FindBy(string[] projects, string[] runbooks, string[] environments, int skip = 0, int? take = null)
+        public async Task<ResourceCollection<RunbookRunResource>> FindBy(string[] projects, string[] runbooks, string[] environments, int skip = 0, int? take = null, CancellationToken token = default)
         {
-            return await Client.List<RunbookRunResource>(await Repository.Link("RunbookRuns").ConfigureAwait(false), new { skip, take, projects = projects ?? new string[0], runbooks = runbooks ?? new string[0], environments = environments ?? new string[0] }).ConfigureAwait(false);
+            return await Client.List<RunbookRunResource>(await Repository.Link("RunbookRuns").ConfigureAwait(false), new { skip, take, projects = projects ?? new string[0], runbooks = runbooks ?? new string[0], environments = environments ?? new string[0] }, token).ConfigureAwait(false);
         }
 
-        public Task Paginate(string[] projects, string[] runbooks, string[] environments, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage)
+        public Task Paginate(string[] projects, string[] runbooks, string[] environments, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage, CancellationToken token = default)
         {
-            return Paginate(projects, runbooks, environments, new string[0], getNextPage);
+            return Paginate(projects, runbooks, environments, new string[0], getNextPage, token);
         }
 
-        public async Task Paginate(string[] projects, string[] runbooks, string[] environments, string[] tenants, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage)
+        public async Task Paginate(string[] projects, string[] runbooks, string[] environments, string[] tenants, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage, CancellationToken token = default)
         {
-            await Client.Paginate(await Repository.Link("RunbookRuns").ConfigureAwait(false), new { projects = projects ?? new string[0], runbooks = runbooks ?? new string[0], environments = environments ?? new string[0], tenants = tenants ?? new string[0] }, getNextPage).ConfigureAwait(false);
+            await Client.Paginate(await Repository.Link("RunbookRuns").ConfigureAwait(false), new { projects = projects ?? new string[0], runbooks = runbooks ?? new string[0], environments = environments ?? new string[0], tenants = tenants ?? new string[0] }, getNextPage, token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/RunbookSnapshotRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/RunbookSnapshotRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -12,20 +13,22 @@ namespace Octopus.Client.Repositories.Async
         /// <param name="runbookSnapshot"></param>
         /// <param name="skip">Number of records to skip</param>
         /// <param name="take">Number of records to take (First supported in Server 3.14.15)</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(RunbookSnapshotResource runbookSnapshot, int skip = 0, int? take = null);
+        Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(RunbookSnapshotResource runbookSnapshot, int skip = 0, int? take = null, CancellationToken token = default);
         /// <summary>
         /// 
         /// </summary>
         /// <param name="runbookSnapshot"></param>
         /// <param name="skip">Number of records to skip</param>
         /// <param name="take">Number of records to take (First supported in Server 3.14.15)</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<ResourceCollection<ArtifactResource>> GetArtifacts(RunbookSnapshotResource runbookSnapshot, int skip = 0, int? take = null);
-        Task<RunbookRunTemplateResource> GetTemplate(RunbookSnapshotResource runbookSnapshot);
-        Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget);
-        Task<RunbookSnapshotResource> SnapshotVariables(RunbookSnapshotResource runbookSnapshot);    
-        Task<RunbookSnapshotResource> Create(RunbookSnapshotResource runbookSnapshot);
+        Task<ResourceCollection<ArtifactResource>> GetArtifacts(RunbookSnapshotResource runbookSnapshot, int skip = 0, int? take = null, CancellationToken token = default);
+        Task<RunbookRunTemplateResource> GetTemplate(RunbookSnapshotResource runbookSnapshot, CancellationToken token = default);
+        Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget, CancellationToken token = default);
+        Task<RunbookSnapshotResource> SnapshotVariables(RunbookSnapshotResource runbookSnapshot, CancellationToken token = default);
+        Task<RunbookSnapshotResource> Create(RunbookSnapshotResource runbookSnapshot, CancellationToken token = default);
     }
 
     class RunbookSnapshotRepository : BasicRepository<RunbookSnapshotResource>, IRunbookSnapshotRepository
@@ -35,35 +38,35 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(RunbookSnapshotResource runbookSnapshot, int skip = 0, int? take = null)
+        public Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(RunbookSnapshotResource runbookSnapshot, int skip = 0, int? take = null, CancellationToken token = default)
         {
-            return Client.List<RunbookRunResource>(runbookSnapshot.Link("RunbookRuns"), new { skip, take });
+            return Client.List<RunbookRunResource>(runbookSnapshot.Link("RunbookRuns"), new { skip, take }, token);
         }
 
-        public Task<ResourceCollection<ArtifactResource>> GetArtifacts(RunbookSnapshotResource runbookSnapshot, int skip = 0, int? take = null)
+        public Task<ResourceCollection<ArtifactResource>> GetArtifacts(RunbookSnapshotResource runbookSnapshot, int skip = 0, int? take = null, CancellationToken token = default)
         {
-            return Client.List<ArtifactResource>(runbookSnapshot.Link("Artifacts"), new { skip, take });
+            return Client.List<ArtifactResource>(runbookSnapshot.Link("Artifacts"), new { skip, take }, token);
         }
 
-        public Task<RunbookRunTemplateResource> GetTemplate(RunbookSnapshotResource runbookSnapshot)
+        public Task<RunbookRunTemplateResource> GetTemplate(RunbookSnapshotResource runbookSnapshot, CancellationToken token = default)
         {
-            return Client.Get<RunbookRunTemplateResource>(runbookSnapshot.Link("RunbookRunTemplate"));
+            return Client.Get<RunbookRunTemplateResource>(runbookSnapshot.Link("RunbookRunTemplate"), token: token);
         }
 
-        public Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget)
+        public Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget, CancellationToken token = default)
         {
-            return Client.Get<RunbookRunPreviewResource>(promotionTarget.Link("RunbookRunPreview"));
+            return Client.Get<RunbookRunPreviewResource>(promotionTarget.Link("RunbookRunPreview"), token: token);
         }
 
-        public async Task<RunbookSnapshotResource> SnapshotVariables(RunbookSnapshotResource runbookSnapshot)
+        public async Task<RunbookSnapshotResource> SnapshotVariables(RunbookSnapshotResource runbookSnapshot, CancellationToken token = default)
         {
-            await Client.Post(runbookSnapshot.Link("SnapshotVariables")).ConfigureAwait(false);
-            return await Get(runbookSnapshot.Id).ConfigureAwait(false);
+            await Client.Post(runbookSnapshot.Link("SnapshotVariables"), token: token).ConfigureAwait(false);
+            return await Get(runbookSnapshot.Id, token).ConfigureAwait(false);
         }
 
-        public async Task<RunbookSnapshotResource> Create(RunbookSnapshotResource runbookSnapshot)
+        public async Task<RunbookSnapshotResource> Create(RunbookSnapshotResource runbookSnapshot, CancellationToken token = default)
         {
-            return await Client.Create(await Repository.Link(CollectionLinkName).ConfigureAwait(false), runbookSnapshot).ConfigureAwait(false);
+            return await Client.Create(await Repository.Link(CollectionLinkName).ConfigureAwait(false), runbookSnapshot, token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/SchedulerRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/SchedulerRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,14 +8,14 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ISchedulerRepository
     {
-        Task Start();
-        Task Start(string taskName);
-        Task Stop();
-        Task Stop(string taskName);
-        Task Trigger(string taskName);
-        Task<ScheduledTaskDetailsResource> GetLogs(string taskName);
-        Task<Stream> GetRawLogs(string taskName);
-        Task<SchedulerStatusResource> Status();
+        Task Start(CancellationToken token = default);
+        Task Start(string taskName, CancellationToken token = default);
+        Task Stop(CancellationToken token = default);
+        Task Stop(string taskName, CancellationToken token = default);
+        Task Trigger(string taskName, CancellationToken token = default);
+        Task<ScheduledTaskDetailsResource> GetLogs(string taskName, CancellationToken token = default);
+        Task<Stream> GetRawLogs(string taskName, CancellationToken token = default);
+        Task<SchedulerStatusResource> Status(CancellationToken token = default);
     }
 
     class SchedulerRepository : ISchedulerRepository
@@ -26,44 +27,44 @@ namespace Octopus.Client.Repositories.Async
             this.repository = repository;
         }
 
-        public Task Start()
+        public Task Start(CancellationToken token = default)
         {
-            return repository.Client.GetContent("~/api/scheduler/start");
+            return repository.Client.GetContent("~/api/scheduler/start", token: token);
         }
 
-        public Task Start(string taskName)
+        public Task Start(string taskName, CancellationToken token = default)
         {
-            return repository.Client.GetContent($"~/api/scheduler/start?task={taskName}");
+            return repository.Client.GetContent($"~/api/scheduler/start?task={taskName}", token: token);
         }
 
-        public Task Trigger(string taskName)
+        public Task Trigger(string taskName, CancellationToken token = default)
         {
-            return repository.Client.GetContent($"~/api/scheduler/trigger?task={taskName}");
+            return repository.Client.GetContent($"~/api/scheduler/trigger?task={taskName}", token: token);
         }
 
-        public Task Stop()
+        public Task Stop(CancellationToken token = default)
         {
-            return repository.Client.GetContent("~/api/scheduler/stop");
+            return repository.Client.GetContent("~/api/scheduler/stop", token: token);
         }
 
-        public Task Stop(string taskName)
+        public Task Stop(string taskName, CancellationToken token = default)
         {
-            return repository.Client.GetContent($"~/api/scheduler/stop?task={taskName}");
+            return repository.Client.GetContent($"~/api/scheduler/stop?task={taskName}", token: token);
         }
 
-        public Task<ScheduledTaskDetailsResource> GetLogs(string taskName)
+        public Task<ScheduledTaskDetailsResource> GetLogs(string taskName, CancellationToken token = default)
         {
-            return repository.Client.Get<ScheduledTaskDetailsResource>($"~/api/scheduler/{taskName}/logs");
+            return repository.Client.Get<ScheduledTaskDetailsResource>($"~/api/scheduler/{taskName}/logs", token: token);
         }
 
-        public Task<Stream> GetRawLogs(string taskName)
+        public Task<Stream> GetRawLogs(string taskName, CancellationToken token = default)
         {
-            return repository.Client.GetContent($"~/api/scheduler/{taskName}/logs/raw");
+            return repository.Client.GetContent($"~/api/scheduler/{taskName}/logs/raw", token: token);
         }
 
-        public Task<SchedulerStatusResource> Status()
+        public Task<SchedulerStatusResource> Status(CancellationToken token = default)
         {
-            return repository.Client.Get<SchedulerStatusResource>("~/api/scheduler");
+            return repository.Client.Get<SchedulerStatusResource>("~/api/scheduler", token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ServerStatusRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ServerStatusRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,9 +7,9 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IServerStatusRepository
     {
-        Task<ServerStatusResource> GetServerStatus();
-        Task<SystemInfoResource> GetSystemInfo(ServerStatusResource status);
-        Task<ServerStatusHealthResource> GetServerHealth();
+        Task<ServerStatusResource> GetServerStatus(CancellationToken token = default);
+        Task<SystemInfoResource> GetSystemInfo(ServerStatusResource status, CancellationToken token = default);
+        Task<ServerStatusHealthResource> GetServerHealth(CancellationToken token = default);
     }
 
     class ServerStatusRepository : BasicRepository<ServerStatusResource>, IServerStatusRepository
@@ -18,20 +19,20 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<ServerStatusResource> GetServerStatus()
+        public async Task<ServerStatusResource> GetServerStatus(CancellationToken token = default)
         {
-            return await Client.Get<ServerStatusResource>(await Repository.Link("ServerStatus").ConfigureAwait(false)).ConfigureAwait(false);
+            return await Client.Get<ServerStatusResource>(await Repository.Link("ServerStatus").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
 
-        public Task<SystemInfoResource> GetSystemInfo(ServerStatusResource status)
+        public Task<SystemInfoResource> GetSystemInfo(ServerStatusResource status, CancellationToken token = default)
         {
             if (status == null) throw new ArgumentNullException("status");
-            return Client.Get<SystemInfoResource>(status.Link("SystemInfo"));
+            return Client.Get<SystemInfoResource>(status.Link("SystemInfo"), token: token);
         }
 
-        public async Task<ServerStatusHealthResource> GetServerHealth()
+        public async Task<ServerStatusHealthResource> GetServerHealth(CancellationToken token = default)
         {
-            return await Client.Get<ServerStatusHealthResource>(await Repository.Link("ServerHealthStatus").ConfigureAwait(false)).ConfigureAwait(false);
+            return await Client.Get<ServerStatusHealthResource>(await Repository.Link("ServerHealthStatus").ConfigureAwait(false), token: token).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/SpaceRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/SpaceRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Octopus.Client.Model;
@@ -12,7 +13,7 @@ namespace Octopus.Client.Repositories.Async
         IFindByName<SpaceResource>,
         IGet<SpaceResource>
     {
-        Task SetLogo(SpaceResource space, string fileName, Stream contents);
+        Task SetLogo(SpaceResource space, string fileName, Stream contents, CancellationToken token = default);
     }
 
     class SpaceRepository : BasicRepository<SpaceResource>, ISpaceRepository
@@ -21,9 +22,9 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task SetLogo(SpaceResource space, string fileName, Stream contents)
+        public Task SetLogo(SpaceResource space, string fileName, Stream contents, CancellationToken token = default)
         {
-            return Client.Post(space.Link("Logo"), new FileUpload { Contents = contents, FileName = fileName }, false);
+            return Client.Post(space.Link("Logo"), new FileUpload { Contents = contents, FileName = fileName }, false, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/SubscriptionRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/SubscriptionRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
 
@@ -11,7 +12,7 @@ namespace Octopus.Client.Repositories.Async
         IGet<SubscriptionResource>, 
         IDelete<SubscriptionResource>
     {
-        Task<SubscriptionEditor> CreateOrModify(string name, EventNotificationSubscription eventNotificationSubscription, bool isDisabled);
+        Task<SubscriptionEditor> CreateOrModify(string name, EventNotificationSubscription eventNotificationSubscription, bool isDisabled, CancellationToken token = default);
     }
 
     class SubscriptionRepository : BasicRepository<SubscriptionResource>, ISubscriptionRepository
@@ -20,9 +21,9 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<SubscriptionEditor> CreateOrModify(string name, EventNotificationSubscription eventNotificationSubscription, bool isDisabled)
+        public Task<SubscriptionEditor> CreateOrModify(string name, EventNotificationSubscription eventNotificationSubscription, bool isDisabled, CancellationToken token = default)
         {
-            return new SubscriptionEditor(this).CreateOrModify(name, eventNotificationSubscription, isDisabled);
+            return new SubscriptionEditor(this).CreateOrModify(name, eventNotificationSubscription, isDisabled, token);
         }
 
     }

--- a/source/Octopus.Client/Repositories/Async/TagSetRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/TagSetRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -7,9 +8,9 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ITagSetRepository : ICreate<TagSetResource>, IModify<TagSetResource>, IGet<TagSetResource>, IDelete<TagSetResource>, IFindByName<TagSetResource>, IGetAll<TagSetResource>
     {
-        Task Sort(string[] tagSetIdsInOrder);
-        Task<TagSetEditor> CreateOrModify(string name);
-        Task<TagSetEditor> CreateOrModify(string name, string description);
+        Task Sort(string[] tagSetIdsInOrder, CancellationToken token = default);
+        Task<TagSetEditor> CreateOrModify(string name, CancellationToken token = default);
+        Task<TagSetEditor> CreateOrModify(string name, string description, CancellationToken token = default);
     }
 
     class TagSetRepository : BasicRepository<TagSetResource>, ITagSetRepository
@@ -18,19 +19,19 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task Sort(string[] tagSetIdsInOrder)
+        public async Task Sort(string[] tagSetIdsInOrder, CancellationToken token = default)
         {
-            await Client.Put(await Repository.Link("TagSetSortOrder").ConfigureAwait(false), tagSetIdsInOrder).ConfigureAwait(false);
+            await Client.Put(await Repository.Link("TagSetSortOrder").ConfigureAwait(false), tagSetIdsInOrder, token: token).ConfigureAwait(false);
         }
 
-        public Task<TagSetEditor> CreateOrModify(string name)
+        public Task<TagSetEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            return new TagSetEditor(this).CreateOrModify(name);
+            return new TagSetEditor(this).CreateOrModify(name, token);
         }
 
-        public Task<TagSetEditor> CreateOrModify(string name, string description)
+        public Task<TagSetEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            return new TagSetEditor(this).CreateOrModify(name, description);
+            return new TagSetEditor(this).CreateOrModify(name, description, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/TaskRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/TaskRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Util;
@@ -11,48 +12,51 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ITaskRepository : IPaginate<TaskResource>, IGet<TaskResource>, ICreate<TaskResource>, ICanExtendSpaceContext<ITaskRepository>
     {
-        Task<TaskResource> ExecuteHealthCheck(string description = null, int timeoutAfterMinutes = 5, int machineTimeoutAfterMinutes = 1, string environmentId = null, string[] machineIds = null, string restrictTo = null, string workerpoolId = null, string[] workerIds = null);
-        Task<TaskResource> ExecuteCalamariUpdate(string description = null, string[] machineIds = null);
-        Task<TaskResource> ExecuteBackup(string description = null);
-        Task<TaskResource> ExecuteTentacleUpgrade(string description = null, string environmentId = null, string[] machineIds = null, string restrictTo = null, string workerpooltId = null, string[] workerIds = null);
-        Task<TaskResource> ExecuteAdHocScript(string scriptBody, string[] machineIds = null, string[] environmentIds = null, string[] targetRoles = null, string description = null, string syntax = "PowerShell", BuiltInTasks.AdHocScript.TargetType? targetType = null);
-        Task<TaskDetailsResource> GetDetails(TaskResource resource, bool? includeVerboseOutput = null, int? tail = null);
-        Task<TaskResource> ExecuteActionTemplate(ActionTemplateResource resource, Dictionary<string, PropertyValueResource> properties, string[] machineIds = null, string[] environmentIds = null, string[] targetRoles = null, string description = null, BuiltInTasks.AdHocScript.TargetType? targetType = null);
-        Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(string description = null);
+        Task<TaskResource> ExecuteHealthCheck(string description = null, int timeoutAfterMinutes = 5, int machineTimeoutAfterMinutes = 1, string environmentId = null, string[] machineIds = null, string restrictTo = null, string workerpoolId = null, string[] workerIds = null, CancellationToken token = default);
+        Task<TaskResource> ExecuteCalamariUpdate(string description = null, string[] machineIds = null, CancellationToken token = default);
+        Task<TaskResource> ExecuteBackup(string description = null, CancellationToken token = default);
+        Task<TaskResource> ExecuteTentacleUpgrade(string description = null, string environmentId = null, string[] machineIds = null, string restrictTo = null, string workerpooltId = null, string[] workerIds = null, CancellationToken token = default);
+        Task<TaskResource> ExecuteAdHocScript(string scriptBody, string[] machineIds = null, string[] environmentIds = null, string[] targetRoles = null, string description = null, string syntax = "PowerShell", BuiltInTasks.AdHocScript.TargetType? targetType = null, CancellationToken token = default);
+        Task<TaskDetailsResource> GetDetails(TaskResource resource, bool? includeVerboseOutput = null, int? tail = null, CancellationToken token = default);
+        Task<TaskResource> ExecuteActionTemplate(ActionTemplateResource resource, Dictionary<string, PropertyValueResource> properties, string[] machineIds = null, string[] environmentIds = null, string[] targetRoles = null, string description = null, BuiltInTasks.AdHocScript.TargetType? targetType = null, CancellationToken token = default);
+        Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(string description = null, CancellationToken token = default);
         
         /// <summary>
         /// Gets all the active tasks (optionally limited to pageSize)
         /// </summary>
         /// <param name="pageSize">Number of items per page, setting to less than the total items still retreives all items, but uses multiple requests reducing memory load on the server</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<List<TaskResource>> GetAllActive(int pageSize = int.MaxValue);
+        Task<List<TaskResource>> GetAllActive(int pageSize = int.MaxValue, CancellationToken token = default);
         
         /// <summary>
         /// Returns all active tasks (optionally limited to pageSize) along with a count of all tasks in each status
         /// </summary>
         /// <param name="pageSize"></param>
         /// <param name="skip"></param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<TaskResourceCollection> GetActiveWithSummary(int pageSize = int.MaxValue, int skip = 0);
+        Task<TaskResourceCollection> GetActiveWithSummary(int pageSize = int.MaxValue, int skip = 0, CancellationToken token = default);
 
         /// <summary>
         /// Returns all tasks (optionally limited to pageSize) along with a count of all tasks in each status
         /// </summary>
         /// <param name="pageSize"></param>
         /// <param name="skip"></param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        Task<TaskResourceCollection> GetAllWithSummary(int pageSize = int.MaxValue, int skip = 0);
+        Task<TaskResourceCollection> GetAllWithSummary(int pageSize = int.MaxValue, int skip = 0, CancellationToken token = default);
         
-        Task<string> GetRawOutputLog(TaskResource resource);
-        Task<TaskTypeResource[]> GetTaskTypes();
-        Task Rerun(TaskResource resource);
-        Task Cancel(TaskResource resource);
-        Task ModifyState(TaskResource resource, TaskState newState, string reason);
-        Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(TaskResource resource);
-        Task WaitForCompletion(TaskResource task, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Action<TaskResource[]> interval = null);
-        Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Action<TaskResource[]> interval = null);
-        Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Func<TaskResource[], Task> interval = null);
-        Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, TimeSpan? timeoutAfter = null, Func<TaskResource[], Task> interval = null);
+        Task<string> GetRawOutputLog(TaskResource resource, CancellationToken token = default);
+        Task<TaskTypeResource[]> GetTaskTypes(CancellationToken token = default);
+        Task Rerun(TaskResource resource, CancellationToken token = default);
+        Task Cancel(TaskResource resource, CancellationToken token = default);
+        Task ModifyState(TaskResource resource, TaskState newState, string reason, CancellationToken token = default);
+        Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(TaskResource resource, CancellationToken token = default);
+        Task WaitForCompletion(TaskResource task, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Action<TaskResource[]> interval = null, CancellationToken token = default);
+        Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Action<TaskResource[]> interval = null, CancellationToken token = default);
+        Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Func<TaskResource[], Task> interval = null, CancellationToken token = default);
+        Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, TimeSpan? timeoutAfter = null, Func<TaskResource[], Task> interval = null, CancellationToken token = default);
     }
 
     class TaskRepository : MixedScopeBaseRepository<TaskResource>, ITaskRepository
@@ -69,7 +73,7 @@ namespace Octopus.Client.Repositories.Async
 
         public Task<TaskResource> ExecuteHealthCheck(
             string description = null, int timeoutAfterMinutes = 5, int machineTimeoutAfterMinutes = 1, string environmentId = null, string[] machineIds = null,
-            string restrictTo = null, string workerpoolId = null, string[] workerIds = null)
+            string restrictTo = null, string workerpoolId = null, string[] workerIds = null, CancellationToken token = default)
         {
             // Default space enabled -> Creates it in the default space
             // Default space disabled -> Fails
@@ -91,10 +95,10 @@ namespace Octopus.Client.Repositories.Async
                     }
                 }
             };
-            return Create(resource);
+            return Create(resource, token: token);
         }
 
-        public Task<TaskResource> ExecuteCalamariUpdate(string description = null, string[] machineIds = null)
+        public Task<TaskResource> ExecuteCalamariUpdate(string description = null, string[] machineIds = null, CancellationToken token = default)
         {
             EnsureSingleSpaceContext();
             var resource = new TaskResource
@@ -106,10 +110,10 @@ namespace Octopus.Client.Repositories.Async
                     {BuiltInTasks.UpdateCalamari.Arguments.MachineIds, machineIds}
                 }
             };
-            return Create(resource);
+            return Create(resource, token: token);
         }
 
-        public Task<TaskResource> ExecuteBackup(string description = null)
+        public Task<TaskResource> ExecuteBackup(string description = null, CancellationToken token = default)
         {
             EnsureSystemContext();
             var resource = new TaskResource
@@ -117,10 +121,10 @@ namespace Octopus.Client.Repositories.Async
                 Name = BuiltInTasks.Backup.Name,
                 Description = string.IsNullOrWhiteSpace(description) ? "Manual backup" : description
             };
-            return CreateSystemTask(resource);
+            return CreateSystemTask(resource, token);
         }
 
-        public async Task<TaskResource> ExecuteTentacleUpgrade(string description = null, string environmentId = null, string[] machineIds = null, string restrictTo = null, string workerpoolId = null, string[] workerIds = null)
+        public async Task<TaskResource> ExecuteTentacleUpgrade(string description = null, string environmentId = null, string[] machineIds = null, string restrictTo = null, string workerpoolId = null, string[] workerIds = null, CancellationToken token = default)
         {
             EnsureSingleSpaceContext();
             var resource = new TaskResource
@@ -138,13 +142,13 @@ namespace Octopus.Client.Repositories.Async
                     }
                 }
             };
-            return await Create(resource).ConfigureAwait(false);
+            return await Create(resource, token: token).ConfigureAwait(false);
         }
 
-        public async Task<TaskResource> ExecuteAdHocScript(string scriptBody, string[] machineIds = null, string[] environmentIds = null, string[] targetRoles = null, string description = null, string syntax = "PowerShell", BuiltInTasks.AdHocScript.TargetType? targetType = null)
+        public async Task<TaskResource> ExecuteAdHocScript(string scriptBody, string[] machineIds = null, string[] environmentIds = null, string[] targetRoles = null, string description = null, string syntax = "PowerShell", BuiltInTasks.AdHocScript.TargetType? targetType = null, CancellationToken token = default)
         {
             EnsureSingleSpaceContext();
-            await EnsureValidTargetType(targetType);
+            await EnsureValidTargetType(targetType, token);
             var resource = new TaskResource
             {
                 Name = BuiltInTasks.AdHocScript.Name,
@@ -159,7 +163,7 @@ namespace Octopus.Client.Repositories.Async
                     {BuiltInTasks.AdHocScript.Arguments.TargetType, targetType},
                 }
             };
-            return await Create(resource).ConfigureAwait(false);
+            return await Create(resource, token: token).ConfigureAwait(false);
         }
 
         public async Task<TaskResource> ExecuteActionTemplate(
@@ -169,10 +173,11 @@ namespace Octopus.Client.Repositories.Async
             string[] environmentIds = null,
             string[] targetRoles = null,
             string description = null,
-            BuiltInTasks.AdHocScript.TargetType? targetType = null)
+            BuiltInTasks.AdHocScript.TargetType? targetType = null, 
+            CancellationToken token = default)
         {
             if (string.IsNullOrEmpty(template?.Id)) throw new ArgumentException("The step template was either null, or has no ID");
-            await EnsureValidTargetType(targetType);
+            await EnsureValidTargetType(targetType, token);
             
             var resource = new TaskResource(){SpaceId = template.SpaceId};
             resource.Name = BuiltInTasks.AdHocScript.Name;
@@ -186,10 +191,10 @@ namespace Octopus.Client.Repositories.Async
                     {BuiltInTasks.AdHocScript.Arguments.Properties, properties},
                     {BuiltInTasks.AdHocScript.Arguments.TargetType, targetType},
                 };
-            return await Create(resource);
+            return await Create(resource, token: token);
         }
 
-        private async Task EnsureValidTargetType(BuiltInTasks.AdHocScript.TargetType? targetType)
+        private async Task EnsureValidTargetType(BuiltInTasks.AdHocScript.TargetType? targetType, CancellationToken token)
         {
             if (targetType == BuiltInTasks.AdHocScript.TargetType.OctopusServer)
             {
@@ -199,7 +204,7 @@ namespace Octopus.Client.Repositories.Async
             }
         }
 
-        public Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(string description = null)
+        public Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(string description = null, CancellationToken token = default)
         {
             EnsureSystemContext();
 
@@ -210,10 +215,10 @@ namespace Octopus.Client.Repositories.Async
                 Description = description ?? "Run " + BuiltInTasks.SyncCommunityActionTemplates.Name
             };
 
-            return CreateSystemTask(resource);
+            return CreateSystemTask(resource, token);
         }
 
-        public async Task<TaskDetailsResource> GetDetails(TaskResource resource, bool? includeVerboseOutput = null, int? tail = null)
+        public async Task<TaskDetailsResource> GetDetails(TaskResource resource, bool? includeVerboseOutput = null, int? tail = null, CancellationToken token = default)
         {
             var args = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             if (includeVerboseOutput.HasValue)
@@ -222,60 +227,60 @@ namespace Octopus.Client.Repositories.Async
             if (tail.HasValue)
                 args.Add("tail", tail.Value);
             var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), args);
-            return await Client.Get<TaskDetailsResource>(resource.Link("Details"), parameters).ConfigureAwait(false);
+            return await Client.Get<TaskDetailsResource>(resource.Link("Details"), parameters, token).ConfigureAwait(false);
         }
 
-        public async Task<string> GetRawOutputLog(TaskResource resource)
+        public async Task<string> GetRawOutputLog(TaskResource resource, CancellationToken token = default)
         {
-            return await Client.Get<string>(resource.Link("Raw"), GetAdditionalQueryParameters()).ConfigureAwait(false);
+            return await Client.Get<string>(resource.Link("Raw"), GetAdditionalQueryParameters(), token).ConfigureAwait(false);
         }
 
-        public async Task<TaskTypeResource[]> GetTaskTypes()
+        public async Task<TaskTypeResource[]> GetTaskTypes(CancellationToken token = default)
         {
-            return await Client.Get<TaskTypeResource[]>((await Client.Repository.LoadRootDocument()).Links["TaskTypes"]);
+            return await Client.Get<TaskTypeResource[]>((await Client.Repository.LoadRootDocument()).Links["TaskTypes"], token: token);
         }
 
-        public async Task Rerun(TaskResource resource)
-        {
-            EnsureTaskCanRunInTheCurrentContext(resource);
-            await Client.Post(resource.Link("Rerun"), (TaskResource)null).ConfigureAwait(false);
-        }
-
-        public async Task Cancel(TaskResource resource)
+        public async Task Rerun(TaskResource resource, CancellationToken token = default)
         {
             EnsureTaskCanRunInTheCurrentContext(resource);
-            await Client.Post(resource.Link("Cancel"), (TaskResource)null).ConfigureAwait(false);
+            await Client.Post(resource.Link("Rerun"), (TaskResource)null, token: token).ConfigureAwait(false);
         }
 
-        public async Task ModifyState(TaskResource resource, TaskState newState, string reason)
+        public async Task Cancel(TaskResource resource, CancellationToken token = default)
         {
             EnsureTaskCanRunInTheCurrentContext(resource);
-            await Client.Post(resource.Link("State"), new { state = newState, reason = reason }).ConfigureAwait(false);
+            await Client.Post(resource.Link("Cancel"), (TaskResource)null, token: token).ConfigureAwait(false);
         }
 
-        public async Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(TaskResource resource)
+        public async Task ModifyState(TaskResource resource, TaskState newState, string reason, CancellationToken token = default)
         {
-            return await Client.ListAll<TaskResource>(resource.Link("QueuedBehind"), GetAdditionalQueryParameters()).ConfigureAwait(false);
+            EnsureTaskCanRunInTheCurrentContext(resource);
+            await Client.Post(resource.Link("State"), new { state = newState, reason = reason }, token: token).ConfigureAwait(false);
         }
 
-        public Task WaitForCompletion(TaskResource task, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Action<TaskResource[]> interval = null)
+        public async Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(TaskResource resource, CancellationToken token = default)
         {
-            return WaitForCompletion(new[] { task }, pollIntervalSeconds, timeoutAfterMinutes, interval);
+            return await Client.ListAll<TaskResource>(resource.Link("QueuedBehind"), GetAdditionalQueryParameters(), token).ConfigureAwait(false);
         }
 
-        public Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Action<TaskResource[]> interval = null)
+        public Task WaitForCompletion(TaskResource task, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Action<TaskResource[]> interval = null, CancellationToken token = default)
+        {
+            return WaitForCompletion(new[] { task }, pollIntervalSeconds, timeoutAfterMinutes, interval, token);
+        }
+
+        public Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Action<TaskResource[]> interval = null, CancellationToken token = default)
         {
             Func<TaskResource[], Task> taskInterval = null;
             if (interval != null)
                 taskInterval = tr => Task.Run(() => interval(tr));
 
-            return WaitForCompletion(tasks, pollIntervalSeconds, timeoutAfterMinutes, taskInterval);
+            return WaitForCompletion(tasks, pollIntervalSeconds, timeoutAfterMinutes, taskInterval, token);
         }
 
-        public Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Func<TaskResource[], Task> interval = null)
-            => WaitForCompletion(tasks, pollIntervalSeconds, TimeSpan.FromMinutes(timeoutAfterMinutes), interval);
+        public Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, int timeoutAfterMinutes = 0, Func<TaskResource[], Task> interval = null, CancellationToken token = default)
+            => WaitForCompletion(tasks, pollIntervalSeconds, TimeSpan.FromMinutes(timeoutAfterMinutes), interval, token);
 
-        public async Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, TimeSpan? timeoutAfter = null, Func<TaskResource[], Task> interval = null)
+        public async Task WaitForCompletion(TaskResource[] tasks, int pollIntervalSeconds = 4, TimeSpan? timeoutAfter = null, Func<TaskResource[], Task> interval = null, CancellationToken token = default)
         {
             var start = Stopwatch.StartNew();
             if (tasks == null || tasks.Length == 0)
@@ -284,7 +289,7 @@ namespace Octopus.Client.Repositories.Async
             while (true)
             {
                 var stillRunning = await Task.WhenAll(
-                        tasks.Select(t => Client.Get<TaskResource>(t.Link("Self"), additionalQueryParameters))
+                        tasks.Select(t => Client.Get<TaskResource>(t.Link("Self"), additionalQueryParameters, token))
                     )
                     .ConfigureAwait(false);
 
@@ -299,17 +304,17 @@ namespace Octopus.Client.Repositories.Async
                     throw new TimeoutException($"One or more tasks did not complete before the timeout was reached. We waited {start.Elapsed:hh\\:mm\\:ss}  for the tasks to complete.");
                 }
 
-                await Task.Delay(TimeSpan.FromSeconds(pollIntervalSeconds)).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(pollIntervalSeconds), token).ConfigureAwait(false);
             }
         }
 
-        public Task<List<TaskResource>> GetAllActive(int pageSize = int.MaxValue) => FindAll(pathParameters: new { active = true, take = pageSize });
+        public Task<List<TaskResource>> GetAllActive(int pageSize = int.MaxValue, CancellationToken token = default) => FindAll(pathParameters: new { active = true, take = pageSize }, token: token);
 
-        public async Task<TaskResourceCollection> GetActiveWithSummary(int pageSize = int.MaxValue, int skip = 0)
-            => await Client.Get<TaskResourceCollection>(await ResolveLink(), new {active = true, take = pageSize, skip});
+        public async Task<TaskResourceCollection> GetActiveWithSummary(int pageSize = int.MaxValue, int skip = 0, CancellationToken token = default)
+            => await Client.Get<TaskResourceCollection>(await ResolveLink(), new {active = true, take = pageSize, skip}, token);
 
-        public async Task<TaskResourceCollection> GetAllWithSummary(int pageSize = int.MaxValue, int skip = 0)
-            => await Client.Get<TaskResourceCollection>(await ResolveLink(), new {take = pageSize, skip});
+        public async Task<TaskResourceCollection> GetAllWithSummary(int pageSize = int.MaxValue, int skip = 0, CancellationToken token = default)
+            => await Client.Get<TaskResourceCollection>(await ResolveLink(), new {take = pageSize, skip}, token);
 
         public ITaskRepository UsingContext(SpaceContext spaceContext)
         {
@@ -331,9 +336,9 @@ namespace Octopus.Client.Repositories.Async
             }, () => { });
         }
 
-        async Task<TaskResource> CreateSystemTask(TaskResource task)
+        async Task<TaskResource> CreateSystemTask(TaskResource task, CancellationToken token)
         {
-            return await Client.Create(await Repository.Link(CollectionLinkName).ConfigureAwait(false), task).ConfigureAwait(false);
+            return await Client.Create(await Repository.Link(CollectionLinkName).ConfigureAwait(false), task, token: token).ConfigureAwait(false);
         }
     }
 

--- a/source/Octopus.Client/Repositories/Async/TeamsRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/TeamsRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Util;
@@ -14,7 +15,7 @@ namespace Octopus.Client.Repositories.Async
         IGet<TeamResource>,
         ICanExtendSpaceContext<ITeamsRepository>
     {
-        Task<List<ScopedUserRoleResource>> GetScopedUserRoles(TeamResource team);
+        Task<List<ScopedUserRoleResource>> GetScopedUserRoles(TeamResource team, CancellationToken token = default);
     }
 
     class TeamsRepository : MixedScopeBaseRepository<TeamResource>, ITeamsRepository
@@ -31,7 +32,7 @@ namespace Octopus.Client.Repositories.Async
             MinimumCompatibleVersion("2019.1.0");
         }
 
-        public async Task<List<ScopedUserRoleResource>> GetScopedUserRoles(TeamResource team)
+        public async Task<List<ScopedUserRoleResource>> GetScopedUserRoles(TeamResource team, CancellationToken token = default)
         {
             await ThrowIfServerVersionIsNotCompatible();
             
@@ -42,7 +43,7 @@ namespace Octopus.Client.Repositories.Async
             {
                 resources.AddRange(page.Items);
                 return true;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
 
             return resources;
         }

--- a/source/Octopus.Client/Repositories/Async/TenantVariablesRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/TenantVariablesRepository.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,17 +7,17 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface ITenantVariablesRepository : IGetAll<TenantVariableResource>
     {
-        Task<List<TenantVariableResource>> GetAll(ProjectResource projectResource);
+        Task<List<TenantVariableResource>> GetAll(ProjectResource projectResource, CancellationToken token = default);
     }
 
     class TenantVariablesRepository : BasicRepository<TenantVariableResource>, ITenantVariablesRepository
     {
-        public async Task<List<TenantVariableResource>> GetAll(ProjectResource projectResource)
+        public async Task<List<TenantVariableResource>> GetAll(ProjectResource projectResource, CancellationToken token = default)
         {
             return await Client.Get<List<TenantVariableResource>>(await Repository.Link("TenantVariables").ConfigureAwait(false), new
             {
                 projectId = projectResource?.Id
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
         }
 
         public TenantVariablesRepository(IOctopusAsyncRepository repository) 

--- a/source/Octopus.Client/Repositories/Async/UpgradeConfigurationRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UpgradeConfigurationRepository.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -5,7 +6,7 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IUpgradeConfigurationRepository : IGet<UpgradeConfigurationResource>, IModify<UpgradeConfigurationResource>
     {
-        Task<UpgradeConfigurationResource> Get();
+        Task<UpgradeConfigurationResource> Get(CancellationToken token = default);
     }
     class UpgradeConfigurationRepository : BasicRepository<UpgradeConfigurationResource>, IUpgradeConfigurationRepository
     {
@@ -13,10 +14,10 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<UpgradeConfigurationResource> Get()
+        public async Task<UpgradeConfigurationResource> Get(CancellationToken token = default)
         {
             var link = await ResolveLink();
-            var upgradeConfiguration = await Client.Get<UpgradeConfigurationResource>(link);
+            var upgradeConfiguration = await Client.Get<UpgradeConfigurationResource>(link, token: token);
             return upgradeConfiguration;
         }
     }

--- a/source/Octopus.Client/Repositories/Async/UserInvitesRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserInvitesRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,8 +7,8 @@ namespace Octopus.Client.Repositories.Async
 { 
     public interface IUserInvitesRepository
     {
-        Task<InvitationResource> Invite(string addToTeamId);
-        Task<InvitationResource> Invite(ReferenceCollection addToTeamIds);
+        Task<InvitationResource> Invite(string addToTeamId, CancellationToken token = default);
+        Task<InvitationResource> Invite(ReferenceCollection addToTeamIds, CancellationToken token = default);
     }
     
     class UserInvitesRepository : MixedScopeBaseRepository<InvitationResource>, IUserInvitesRepository
@@ -16,17 +17,17 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<InvitationResource> Invite(string addToTeamId)
+        public Task<InvitationResource> Invite(string addToTeamId, CancellationToken token = default)
         {
             if (addToTeamId == null) throw new ArgumentNullException(nameof(addToTeamId));
-            return Invite(new ReferenceCollection { addToTeamId });
+            return Invite(new ReferenceCollection { addToTeamId }, token);
         }
 
-        public Task<InvitationResource> Invite(ReferenceCollection addToTeamIds)
+        public Task<InvitationResource> Invite(ReferenceCollection addToTeamIds, CancellationToken token = default)
         {
             var invitationResource = new InvitationResource { AddToTeamIds = addToTeamIds ?? new ReferenceCollection() };
             EnrichSpaceId(invitationResource);
-            return Create(invitationResource);
+            return Create(invitationResource, token: token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/UserPermissionsRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserPermissionsRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Util;
@@ -10,9 +11,9 @@ namespace Octopus.Client.Repositories.Async
     public interface IUserPermissionsRepository :
         ICanExtendSpaceContext<IUserPermissionsRepository>
     {
-        Task<UserPermissionSetResource> Get(UserResource user);
-        Task<UserPermissionSetResource> GetConfiguration(UserResource user);
-        Task<Stream> Export(UserPermissionSetResource userPermissions);
+        Task<UserPermissionSetResource> Get(UserResource user, CancellationToken token = default);
+        Task<UserPermissionSetResource> GetConfiguration(UserResource user, CancellationToken token = default);
+        Task<Stream> Export(UserPermissionSetResource userPermissions, CancellationToken token = default);
     }
     
     class UserPermissionsRepository : MixedScopeBaseRepository<UserPermissionSetResource>, IUserPermissionsRepository
@@ -27,22 +28,22 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<UserPermissionSetResource> Get(UserResource user)
+        public async Task<UserPermissionSetResource> Get(UserResource user, CancellationToken token = default)
         {
             if (user == null) throw new ArgumentNullException(nameof(user));
-            return await Client.Get<UserPermissionSetResource>(user.Link("Permissions"), GetAdditionalQueryParameters()).ConfigureAwait(false);
+            return await Client.Get<UserPermissionSetResource>(user.Link("Permissions"), GetAdditionalQueryParameters(), token).ConfigureAwait(false);
         }
 
-        public async Task<UserPermissionSetResource> GetConfiguration(UserResource user)
+        public async Task<UserPermissionSetResource> GetConfiguration(UserResource user, CancellationToken token = default)
         {
             if (user == null) throw new ArgumentNullException(nameof(user));
-            return await Client.Get<UserPermissionSetResource>(user.Link("PermissionsConfiguration"), GetAdditionalQueryParameters()).ConfigureAwait(false);
+            return await Client.Get<UserPermissionSetResource>(user.Link("PermissionsConfiguration"), GetAdditionalQueryParameters(), token).ConfigureAwait(false);
         }
 
-        public async Task<Stream> Export(UserPermissionSetResource userPermissions)
+        public async Task<Stream> Export(UserPermissionSetResource userPermissions, CancellationToken token = default)
         {
             if (userPermissions == null) throw new ArgumentNullException(nameof(userPermissions));
-            return await Client.GetContent(userPermissions.Link("Export"), GetAdditionalQueryParameters()).ConfigureAwait(false);
+            return await Client.GetContent(userPermissions.Link("Export"), GetAdditionalQueryParameters(), token).ConfigureAwait(false);
         }
 
         public IUserPermissionsRepository UsingContext(SpaceContext spaceContext)

--- a/source/Octopus.Client/Repositories/Async/UserRolesRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRolesRepository.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -17,20 +18,20 @@ namespace Octopus.Client.Repositories.Async
             MinimumCompatibleVersion("2019.1.0");
         }
 
-        public override async Task<UserRoleResource> Create(UserRoleResource resource, object pathParameters = null)
+        public override async Task<UserRoleResource> Create(UserRoleResource resource, object pathParameters = null, CancellationToken token = default)
         {
             await ThrowIfServerVersionIsNotCompatible();
             
             await RemoveInvalidPermissions(resource).ConfigureAwait(false);
-            return await base.Create(resource, pathParameters).ConfigureAwait(false);
+            return await base.Create(resource, pathParameters, token).ConfigureAwait(false);
         }
 
-        public override async Task<UserRoleResource> Modify(UserRoleResource resource)
+        public override async Task<UserRoleResource> Modify(UserRoleResource resource, CancellationToken token = default)
         {
             await ThrowIfServerVersionIsNotCompatible();
             
             await RemoveInvalidPermissions(resource).ConfigureAwait(false);
-            return await base.Modify(resource).ConfigureAwait(false);
+            return await base.Modify(resource, token).ConfigureAwait(false);
         }
 
         private async Task RemoveInvalidPermissions(UserRoleResource resource)

--- a/source/Octopus.Client/Repositories/Async/UserTeamsRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserTeamsRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,7 +7,7 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IUserTeamsRepository : ICanExtendSpaceContext<IUserTeamsRepository>
     {
-        Task<TeamNameResource[]> Get(UserResource user);
+        Task<TeamNameResource[]> Get(UserResource user, CancellationToken token = default);
     }
 
     class UserTeamsRepository : MixedScopeBaseRepository<TeamNameResource>, IUserTeamsRepository
@@ -21,10 +22,10 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<TeamNameResource[]> Get(UserResource user)
+        public async Task<TeamNameResource[]> Get(UserResource user, CancellationToken token = default)
         {
             if (user == null) throw new ArgumentNullException(nameof(user));
-            return await Client.Get<TeamNameResource[]>(user.Link("Teams"), GetAdditionalQueryParameters()).ConfigureAwait(false);
+            return await Client.Get<TeamNameResource[]>(user.Link("Teams"), GetAdditionalQueryParameters(), token).ConfigureAwait(false);
         }
 
         public IUserTeamsRepository UsingContext(SpaceContext spaceContext)

--- a/source/Octopus.Client/Repositories/Async/VariableSetRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/VariableSetRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,8 +8,8 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IVariableSetRepository : IGet<VariableSetResource>, IModify<VariableSetResource>, IGetAll<VariableSetResource>
     {
-        Task<string[]> GetVariableNames(string projects, string[] environments);
-        Task<VariableSetResource> GetVariablePreview(string project, string channel, string tenant, string runbook, string action, string environment, string machine, string role);
+        Task<string[]> GetVariableNames(string projects, string[] environments, CancellationToken token = default);
+        Task<VariableSetResource> GetVariablePreview(string project, string channel, string tenant, string runbook, string action, string environment, string machine, string role, CancellationToken token = default);
     }
 
     class VariableSetRepository : BasicRepository<VariableSetResource>, IVariableSetRepository
@@ -18,17 +19,17 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public async Task<string[]> GetVariableNames(string project, string[] environments)
+        public async Task<string[]> GetVariableNames(string project, string[] environments, CancellationToken token = default)
         {
-            return await Client.Get<string[]>(await Repository.Link("VariableNames").ConfigureAwait(false), new { project, projectEnvironmentsFilter = environments ?? new string[0] }).ConfigureAwait(false);
+            return await Client.Get<string[]>(await Repository.Link("VariableNames").ConfigureAwait(false), new { project, projectEnvironmentsFilter = environments ?? new string[0] }, token).ConfigureAwait(false);
         }
 
-        public async Task<VariableSetResource> GetVariablePreview(string project, string channel, string tenant, string runbook, string action, string environment, string machine, string role)
+        public async Task<VariableSetResource> GetVariablePreview(string project, string channel, string tenant, string runbook, string action, string environment, string machine, string role, CancellationToken token = default)
         {
-            return await Client.Get<VariableSetResource>(await Repository.Link("VariablePreview").ConfigureAwait(false), new { project, channel, tenant, runbook, action, environment, machine, role }).ConfigureAwait(false);
+            return await Client.Get<VariableSetResource>(await Repository.Link("VariablePreview").ConfigureAwait(false), new { project, channel, tenant, runbook, action, environment, machine, role }, token).ConfigureAwait(false);
         }
 
-        public override Task<List<VariableSetResource>> Get(params string[] ids)
+        public override Task<List<VariableSetResource>> Get(CancellationToken token = default, params string[] ids)
         {
             throw new NotSupportedException("VariableSet does not support this operation");
         }

--- a/source/Octopus.Client/Repositories/Async/VcsRunbookRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/VcsRunbookRepository.cs
@@ -1,15 +1,16 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IVcsRunbookRepository
     {
-        Task<VcsRunbookResource> Get(string runbookId);
-        Task<VcsRunbookResource> Modify(VcsRunbookResource resource, string commitMessage = null);
-        Task<VcsRunbookResource> Create(VcsRunbookResource resource, string commitMessage = null);
-        Task Delete(VcsRunbookResource resource, string commitMessage = null);
-        Task<ResourceCollection<VcsRunbookResource>> List(string partialName = null, int skip = 0, int? take = null);
+        Task<VcsRunbookResource> Get(string runbookId, CancellationToken token = default);
+        Task<VcsRunbookResource> Modify(VcsRunbookResource resource, string commitMessage = null, CancellationToken token = default);
+        Task<VcsRunbookResource> Create(VcsRunbookResource resource, string commitMessage = null, CancellationToken token = default);
+        Task Delete(VcsRunbookResource resource, string commitMessage = null, CancellationToken token = default);
+        Task<ResourceCollection<VcsRunbookResource>> List(string partialName = null, int skip = 0, int? take = null, CancellationToken token = default);
     }
 
     public class VcsRunbookRepository : IVcsRunbookRepository
@@ -24,13 +25,13 @@ namespace Octopus.Client.Repositories.Async
             this.branch = branch;
         }
 
-        public Task<VcsRunbookResource> Get(string runbookId)
+        public Task<VcsRunbookResource> Get(string runbookId, CancellationToken token = default)
         {
             var uri = branch.Link(RunbookLinkId);
-            return repository.Client.Get<VcsRunbookResource>(uri, new { id = runbookId });
+            return repository.Client.Get<VcsRunbookResource>(uri, new { id = runbookId }, token);
         }
 
-        public Task<VcsRunbookResource> Modify(VcsRunbookResource resource, string commitMessage = null)
+        public Task<VcsRunbookResource> Modify(VcsRunbookResource resource, string commitMessage = null, CancellationToken token = default)
         {
             var uri = resource.Link("Self");
             var resourceWithCommit = new CommitResource<VcsRunbookResource>
@@ -38,11 +39,11 @@ namespace Octopus.Client.Repositories.Async
                 CommitMessage = commitMessage,
                 Resource = resource
             };
-            repository.Client.Put(uri, resourceWithCommit);
-            return repository.Client.Get<VcsRunbookResource>(uri);
+            repository.Client.Put(uri, resourceWithCommit, token: token);
+            return repository.Client.Get<VcsRunbookResource>(uri, token: token);
         }
 
-        public Task<VcsRunbookResource> Create(VcsRunbookResource resource, string commitMessage = null)
+        public Task<VcsRunbookResource> Create(VcsRunbookResource resource, string commitMessage = null, CancellationToken token = default)
         {
             var uri = branch.Link(RunbookLinkId);
             var resourceWithCommit = new CommitResource<VcsRunbookResource>
@@ -50,23 +51,23 @@ namespace Octopus.Client.Repositories.Async
                 CommitMessage = commitMessage,
                 Resource = resource
             };
-            return repository.Client.Post<CommitResource<VcsRunbookResource>, VcsRunbookResource>(uri, resourceWithCommit);
+            return repository.Client.Post<CommitResource<VcsRunbookResource>, VcsRunbookResource>(uri, resourceWithCommit, token: token);
         }
 
-        public Task Delete(VcsRunbookResource resource, string commitMessage = null)
+        public Task Delete(VcsRunbookResource resource, string commitMessage = null, CancellationToken token = default)
         {
             var uri = branch.Link(RunbookLinkId);
             var commit = new CommitResource
             {
                 CommitMessage = commitMessage
             };
-            return repository.Client.Delete(uri, new { id = resource.Id }, commit);
+            return repository.Client.Delete(uri, new { id = resource.Id }, commit, token);
         }
 
-        public Task<ResourceCollection<VcsRunbookResource>> List(string partialName = null, int skip = 0, int? take = null)
+        public Task<ResourceCollection<VcsRunbookResource>> List(string partialName = null, int skip = 0, int? take = null, CancellationToken token = default)
         {
             var uri = branch.Link(RunbookLinkId);
-            return repository.Client.List<VcsRunbookResource>(uri, new { skip, take, partialName });
+            return repository.Client.List<VcsRunbookResource>(uri, new { skip, take, partialName }, token);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/WorkerPoolRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/WorkerPoolRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
@@ -14,7 +15,8 @@ namespace Octopus.Client.Repositories.Async
             string partialName = null,
             bool? isDisabled = false,
             string healthStatuses = null,
-            string commStyles = null);
+            string commStyles = null, 
+            CancellationToken token = default);
         Task<WorkerPoolsSummaryResource> Summary(
             string ids = null,
             string partialName = null,
@@ -22,10 +24,11 @@ namespace Octopus.Client.Repositories.Async
             bool? isDisabled = false,
             string healthStatuses = null,
             string commStyles = null,
-            bool? hideEmptyPools = false);
-        Task Sort(string[] workerPoolIdsInOrder);
-        Task<WorkerPoolEditor> CreateOrModify(string name);
-        Task<WorkerPoolEditor> CreateOrModify(string name, string description);
+            bool? hideEmptyPools = false, 
+            CancellationToken token = default);
+        Task Sort(string[] workerPoolIdsInOrder, CancellationToken token = default);
+        Task<WorkerPoolEditor> CreateOrModify(string name, CancellationToken token = default);
+        Task<WorkerPoolEditor> CreateOrModify(string name, string description, CancellationToken token = default);
     }
 
     class WorkerPoolRepository : BasicRepository<WorkerPoolResource>, IWorkerPoolRepository
@@ -41,7 +44,8 @@ namespace Octopus.Client.Repositories.Async
             string partialName = null,
             bool? isDisabled = false,
             string healthStatuses = null,
-            string commStyles = null)
+            string commStyles = null,
+            CancellationToken token = default)
         {
             var resources = new List<WorkerResource>();
 
@@ -56,7 +60,7 @@ namespace Octopus.Client.Repositories.Async
             {
                 resources.AddRange(page.Items);
                 return true;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
 
             return resources;
         }
@@ -68,7 +72,8 @@ namespace Octopus.Client.Repositories.Async
             bool? isDisabled = false,
             string healthStatuses = null,
             string commStyles = null,
-            bool? hideEmptyPools = false)
+            bool? hideEmptyPools = false,
+            CancellationToken token = default)
         {
             return await Client.Get<WorkerPoolsSummaryResource>(await Repository.Link("WorkerPoolsSummary").ConfigureAwait(false), new
             {
@@ -79,22 +84,22 @@ namespace Octopus.Client.Repositories.Async
                 healthStatuses,
                 commStyles,
                 hideEmptyPools,
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
         }
 
-        public async Task Sort(string[] workerPoolIdsInOrder)
+        public async Task Sort(string[] workerPoolIdsInOrder, CancellationToken token = default)
         {
-            await Client.Put(await Repository.Link("WorkerPoolSortOrder").ConfigureAwait(false), workerPoolIdsInOrder).ConfigureAwait(false);
+            await Client.Put(await Repository.Link("WorkerPoolSortOrder").ConfigureAwait(false), workerPoolIdsInOrder, token: token).ConfigureAwait(false);
         }
 
-        public Task<WorkerPoolEditor> CreateOrModify(string name)
+        public Task<WorkerPoolEditor> CreateOrModify(string name, CancellationToken token = default)
         {
-            return new WorkerPoolEditor(this).CreateOrModify(name);
+            return new WorkerPoolEditor(this).CreateOrModify(name, token);
         }
 
-        public Task<WorkerPoolEditor> CreateOrModify(string name, string description)
+        public Task<WorkerPoolEditor> CreateOrModify(string name, string description, CancellationToken token = default)
         {
-            return new WorkerPoolEditor(this).CreateOrModify(name, description);
+            return new WorkerPoolEditor(this).CreateOrModify(name, description, token);
         }
     }
 }


### PR DESCRIPTION
* Adds an optional `CancellationToken` to all the async public methods
* Update the approvals files for netcore and netframework 
* Fix breaking test due to additional default parameter at certain places 

closes #537 