### PR TITLE
Add Support for API Key Hints

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1748,6 +1748,7 @@ Octopus.Client.Model
   {
     .ctor()
     String ApiKey { get; set; }
+    String ApiKeyHint { get; set; }
     DateTimeOffset Created { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1741,15 +1741,27 @@ Octopus.Client.Model
     static System.String SupportedApiSchemaVersionMin
     .ctor()
   }
+  class ApiKeyCreatedResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.ApiKeyResourceBase
+  {
+    .ctor()
+    String ApiKey { get; set; }
+  }
   class ApiKeyResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.ApiKeyResourceBase
+  {
+    .ctor()
+    Octopus.Client.Model.SensitiveValue ApiKey { get; set; }
+  }
+  abstract class ApiKeyResourceBase
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.Resource
   {
-    .ctor()
-    String ApiKey { get; set; }
-    String ApiKeyHint { get; set; }
-    String ApiKeyMasked { get; set; }
     DateTimeOffset Created { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }
@@ -4620,6 +4632,7 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean HasValue { get; set; }
+    String Hint { get; set; }
     String NewValue { get; set; }
     Boolean Equals(Octopus.Client.Model.SensitiveValue)
   }
@@ -7170,7 +7183,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICreate<UserResource>
   {
     Octopus.Client.Model.UserResource Create(String, String, String, String)
-    Octopus.Client.Model.ApiKeyResource CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String)
     Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     Octopus.Client.Model.UserResource FindByUsername(String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -7179,7 +7192,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.InvitationResource Invite(String)
     Octopus.Client.Model.InvitationResource Invite(Octopus.Client.Model.ReferenceCollection)
     Octopus.Client.Model.UserResource Register(Octopus.Client.Model.RegisterCommand)
-    void RevokeApiKey(Octopus.Client.Model.ApiKeyResource)
+    void RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignIn(String, String, Boolean)
     void SignOut()
@@ -7911,7 +7924,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
     Task<UserResource> Create(String, String, String, String)
-    Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -7920,7 +7933,7 @@ Octopus.Client.Repositories.Async
     Task<InvitationResource> Invite(String)
     Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection)
     Task<UserResource> Register(Octopus.Client.Model.RegisterCommand)
-    Task RevokeApiKey(Octopus.Client.Model.ApiKeyResource)
+    Task RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(String, String, Boolean)
     Task SignOut()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1749,6 +1749,7 @@ Octopus.Client.Model
     .ctor()
     String ApiKey { get; set; }
     String ApiKeyHint { get; set; }
+    String ApiKeyMasked { get; set; }
     DateTimeOffset Created { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1765,6 +1765,7 @@ Octopus.Client.Model
     .ctor()
     String ApiKey { get; set; }
     String ApiKeyHint { get; set; }
+    String ApiKeyMasked { get; set; }
     DateTimeOffset Created { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1757,15 +1757,27 @@ Octopus.Client.Model
     static System.String SupportedApiSchemaVersionMin
     .ctor()
   }
+  class ApiKeyCreatedResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.ApiKeyResourceBase
+  {
+    .ctor()
+    String ApiKey { get; set; }
+  }
   class ApiKeyResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.ApiKeyResourceBase
+  {
+    .ctor()
+    Octopus.Client.Model.SensitiveValue ApiKey { get; set; }
+  }
+  abstract class ApiKeyResourceBase
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.Resource
   {
-    .ctor()
-    String ApiKey { get; set; }
-    String ApiKeyHint { get; set; }
-    String ApiKeyMasked { get; set; }
     DateTimeOffset Created { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }
@@ -4640,6 +4652,7 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean HasValue { get; set; }
+    String Hint { get; set; }
     String NewValue { get; set; }
     Boolean Equals(Octopus.Client.Model.SensitiveValue)
   }
@@ -7195,7 +7208,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICreate<UserResource>
   {
     Octopus.Client.Model.UserResource Create(String, String, String, String)
-    Octopus.Client.Model.ApiKeyResource CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String)
     Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     Octopus.Client.Model.UserResource FindByUsername(String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -7204,7 +7217,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.InvitationResource Invite(String)
     Octopus.Client.Model.InvitationResource Invite(Octopus.Client.Model.ReferenceCollection)
     Octopus.Client.Model.UserResource Register(Octopus.Client.Model.RegisterCommand)
-    void RevokeApiKey(Octopus.Client.Model.ApiKeyResource)
+    void RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignIn(String, String, Boolean)
     void SignOut()
@@ -7936,7 +7949,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
     Task<UserResource> Create(String, String, String, String)
-    Task<ApiKeyResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -7945,7 +7958,7 @@ Octopus.Client.Repositories.Async
     Task<InvitationResource> Invite(String)
     Task<InvitationResource> Invite(Octopus.Client.Model.ReferenceCollection)
     Task<UserResource> Register(Octopus.Client.Model.RegisterCommand)
-    Task RevokeApiKey(Octopus.Client.Model.ApiKeyResource)
+    Task RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(String, String, Boolean)
     Task SignOut()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1764,6 +1764,7 @@ Octopus.Client.Model
   {
     .ctor()
     String ApiKey { get; set; }
+    String ApiKeyHint { get; set; }
     DateTimeOffset Created { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }

--- a/source/Octopus.Client/Model/ApiKeyResource.cs
+++ b/source/Octopus.Client/Model/ApiKeyResource.cs
@@ -3,15 +3,21 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model
 {
-    public class ApiKeyResource : Resource
+    public abstract class ApiKeyResourceBase : Resource
     {
         [WriteableOnCreate]
         public string Purpose { get; set; }
-
         public string UserId { get; set; }
-        public string ApiKey { get; set; }
-        public string ApiKeyMasked { get; set; }
-        public string ApiKeyHint { get; set; }
         public DateTimeOffset Created { get; set; }
+    }
+
+    public class ApiKeyResource : ApiKeyResourceBase
+    {
+        public SensitiveValue ApiKey { get; set; }
+    }
+
+    public class ApiKeyCreatedResource : ApiKeyResourceBase
+    {
+        public string ApiKey { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/ApiKeyResource.cs
+++ b/source/Octopus.Client/Model/ApiKeyResource.cs
@@ -10,6 +10,7 @@ namespace Octopus.Client.Model
 
         public string UserId { get; set; }
         public string ApiKey { get; set; }
+        public string ApiKeyMasked { get; set; }
         public string ApiKeyHint { get; set; }
         public DateTimeOffset Created { get; set; }
     }

--- a/source/Octopus.Client/Model/ApiKeyResource.cs
+++ b/source/Octopus.Client/Model/ApiKeyResource.cs
@@ -10,6 +10,7 @@ namespace Octopus.Client.Model
 
         public string UserId { get; set; }
         public string ApiKey { get; set; }
+        public string ApiKeyHint { get; set; }
         public DateTimeOffset Created { get; set; }
     }
 }

--- a/source/Octopus.Client/Model/PropertyValueResource.cs
+++ b/source/Octopus.Client/Model/PropertyValueResource.cs
@@ -75,7 +75,8 @@ namespace Octopus.Client.Model
                                 new SensitiveValue
                                 {
                                     HasValue = jo.GetValue("HasValue")?.ToObject<bool>() ?? false,
-                                    NewValue = jo.GetValue("NewValue").ToObject<string>()
+                                    NewValue = jo.GetValue("NewValue").ToObject<string>(),
+                                    Hint = jo.GetValue("Hint")?.ToObject<string>()
                                 });
                         }
 

--- a/source/Octopus.Client/Model/SensitiveValue.cs
+++ b/source/Octopus.Client/Model/SensitiveValue.cs
@@ -13,6 +13,7 @@ namespace Octopus.Client.Model
     {
         public bool HasValue { get; set; }
         public string NewValue { get; set; }
+        public string Hint { get; set; }
 
         public static implicit operator SensitiveValue(string newValue)
         {

--- a/source/Octopus.Client/Repositories/Async/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRepository.cs
@@ -21,9 +21,9 @@ namespace Octopus.Client.Repositories.Async
         Task SignOut();
         Task<UserResource> GetCurrent();
         Task<SpaceResource[]> GetSpaces(UserResource user);
-        Task<ApiKeyResource> CreateApiKey(UserResource user, string purpose = null);
+        Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null);
         Task<List<ApiKeyResource>> GetApiKeys(UserResource user);
-        Task RevokeApiKey(ApiKeyResource apiKey);
+        Task RevokeApiKey(ApiKeyResourceBase apiKey);
         [Obsolete("Use the " + nameof(IUserInvitesRepository) + " instead", false)]
         Task<InvitationResource> Invite(string addToTeamId);
         [Obsolete("Use the " + nameof(IUserInvitesRepository) + " instead", false)]
@@ -98,10 +98,10 @@ namespace Octopus.Client.Repositories.Async
             return Client.Get<SpaceResource[]>(user.Link("Spaces"));
         }
 
-        public Task<ApiKeyResource> CreateApiKey(UserResource user, string purpose = null)
+        public Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null)
         {
             if (user == null) throw new ArgumentNullException("user");
-            return Client.Post<object, ApiKeyResource>(user.Link("ApiKeys"), new
+            return Client.Post<object, ApiKeyCreatedResource>(user.Link("ApiKeys"), new
             {
                 Purpose = purpose ?? "Requested by Octopus.Client"
             });
@@ -121,7 +121,7 @@ namespace Octopus.Client.Repositories.Async
             return resources;
         }
 
-        public Task RevokeApiKey(ApiKeyResource apiKey)
+        public Task RevokeApiKey(ApiKeyResourceBase apiKey)
         {
             return Client.Delete(apiKey.Link("Self"));
         }

--- a/source/Octopus.Client/Repositories/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/UserRepository.cs
@@ -20,9 +20,9 @@ namespace Octopus.Client.Repositories
         void SignOut();
         UserResource GetCurrent();
         SpaceResource[] GetSpaces(UserResource user);
-        ApiKeyResource CreateApiKey(UserResource user, string purpose = null);
+        ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null);
         List<ApiKeyResource> GetApiKeys(UserResource user);
-        void RevokeApiKey(ApiKeyResource apiKey);
+        void RevokeApiKey(ApiKeyResourceBase apiKey);
         [Obsolete("Use the " + nameof(IUserInvitesRepository) + " instead", false)]
         InvitationResource Invite(string addToTeamId);
         [Obsolete("Use the " + nameof(IUserInvitesRepository) + " instead", false)]
@@ -96,10 +96,10 @@ namespace Octopus.Client.Repositories
             return Client.Get<SpaceResource[]>(user.Link("Spaces"));
         }
 
-        public ApiKeyResource CreateApiKey(UserResource user, string purpose = null)
+        public ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null)
         {
             if (user == null) throw new ArgumentNullException("user");
-            return Client.Post<object, ApiKeyResource>(user.Link("ApiKeys"), new
+            return Client.Post<object, ApiKeyCreatedResource>(user.Link("ApiKeys"), new
             {
                 Purpose = purpose ?? "Requested by Octopus.Client"
             });
@@ -119,7 +119,7 @@ namespace Octopus.Client.Repositories
             return resources;
         }
 
-        public void RevokeApiKey(ApiKeyResource apiKey)
+        public void RevokeApiKey(ApiKeyResourceBase apiKey)
         {
             Client.Delete(apiKey.Link("Self"));
         }


### PR DESCRIPTION
Create asymmetric ApiKey resources to match the changes in the Server.
Add support for the Hint property within SensitiveValue.

Used in [Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/7542)

[Trello Card](https://trello.com/c/iJGDDeQk/398-display-masked-api-key)