### PR TITLE
Add expiry date to API keys

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1763,7 +1763,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     DateTimeOffset Created { get; set; }
-    Nullable<DateTimeOffset> Expiry { get; set; }
+    Nullable<DateTimeOffset> Expires { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1763,6 +1763,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     DateTimeOffset Created { get; set; }
+    Nullable<DateTimeOffset> Expiry { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }
   }
@@ -7183,7 +7184,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICreate<UserResource>
   {
     Octopus.Client.Model.UserResource Create(String, String, String, String)
-    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     Octopus.Client.Model.UserResource FindByUsername(String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -7924,7 +7925,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
     Task<UserResource> Create(String, String, String, String)
-    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1779,6 +1779,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     DateTimeOffset Created { get; set; }
+    Nullable<DateTimeOffset> Expiry { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }
   }
@@ -7208,7 +7209,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICreate<UserResource>
   {
     Octopus.Client.Model.UserResource Create(String, String, String, String)
-    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     Octopus.Client.Model.UserResource FindByUsername(String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -7949,7 +7950,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
     Task<UserResource> Create(String, String, String, String)
-    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String)
+    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1779,7 +1779,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     DateTimeOffset Created { get; set; }
-    Nullable<DateTimeOffset> Expiry { get; set; }
+    Nullable<DateTimeOffset> Expires { get; set; }
     String Purpose { get; set; }
     String UserId { get; set; }
   }

--- a/source/Octopus.Client/Model/ApiKeyResource.cs
+++ b/source/Octopus.Client/Model/ApiKeyResource.cs
@@ -9,6 +9,7 @@ namespace Octopus.Client.Model
         public string Purpose { get; set; }
         public string UserId { get; set; }
         public DateTimeOffset Created { get; set; }
+        public DateTimeOffset? Expiry { get; set; }
     }
 
     public class ApiKeyResource : ApiKeyResourceBase

--- a/source/Octopus.Client/Model/ApiKeyResource.cs
+++ b/source/Octopus.Client/Model/ApiKeyResource.cs
@@ -9,7 +9,7 @@ namespace Octopus.Client.Model
         public string Purpose { get; set; }
         public string UserId { get; set; }
         public DateTimeOffset Created { get; set; }
-        public DateTimeOffset? Expiry { get; set; }
+        public DateTimeOffset? Expires { get; set; }
     }
 
     public class ApiKeyResource : ApiKeyResourceBase

--- a/source/Octopus.Client/Repositories/Async/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRepository.cs
@@ -21,7 +21,7 @@ namespace Octopus.Client.Repositories.Async
         Task SignOut();
         Task<UserResource> GetCurrent();
         Task<SpaceResource[]> GetSpaces(UserResource user);
-        Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expiry = null);
+        Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expires = null);
         Task<List<ApiKeyResource>> GetApiKeys(UserResource user);
         Task RevokeApiKey(ApiKeyResourceBase apiKey);
         [Obsolete("Use the " + nameof(IUserInvitesRepository) + " instead", false)]
@@ -98,13 +98,13 @@ namespace Octopus.Client.Repositories.Async
             return Client.Get<SpaceResource[]>(user.Link("Spaces"));
         }
 
-        public Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expiry = null)
+        public Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expires = null)
         {
             if (user == null) throw new ArgumentNullException("user");
             return Client.Post<object, ApiKeyCreatedResource>(user.Link("ApiKeys"), new
             {
                 Purpose = purpose ?? "Requested by Octopus.Client",
-                Expiry = expiry
+                Expires = expires
             });
         }
 

--- a/source/Octopus.Client/Repositories/Async/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRepository.cs
@@ -21,7 +21,7 @@ namespace Octopus.Client.Repositories.Async
         Task SignOut();
         Task<UserResource> GetCurrent();
         Task<SpaceResource[]> GetSpaces(UserResource user);
-        Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null);
+        Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expiry = null);
         Task<List<ApiKeyResource>> GetApiKeys(UserResource user);
         Task RevokeApiKey(ApiKeyResourceBase apiKey);
         [Obsolete("Use the " + nameof(IUserInvitesRepository) + " instead", false)]
@@ -98,12 +98,13 @@ namespace Octopus.Client.Repositories.Async
             return Client.Get<SpaceResource[]>(user.Link("Spaces"));
         }
 
-        public Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null)
+        public Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expiry = null)
         {
             if (user == null) throw new ArgumentNullException("user");
             return Client.Post<object, ApiKeyCreatedResource>(user.Link("ApiKeys"), new
             {
-                Purpose = purpose ?? "Requested by Octopus.Client"
+                Purpose = purpose ?? "Requested by Octopus.Client",
+                Expiry = expiry
             });
         }
 

--- a/source/Octopus.Client/Repositories/Async/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/UserRepository.cs
@@ -21,6 +21,16 @@ namespace Octopus.Client.Repositories.Async
         Task SignOut();
         Task<UserResource> GetCurrent();
         Task<SpaceResource[]> GetSpaces(UserResource user);
+        /// <summary>
+        /// Creates a new API key for a user.
+        /// </summary>
+        /// <param name="user">The user to create the key for.</param>
+        /// <param name="purpose">The purpose of the API key.</param>
+        /// <param name="expires">The expiry date of the key. If null, the key will never expire.</param>
+        /// <returns>The newly created API key resource.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="user"/> was null.
+        /// </exception>
         Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expires = null);
         Task<List<ApiKeyResource>> GetApiKeys(UserResource user);
         Task RevokeApiKey(ApiKeyResourceBase apiKey);

--- a/source/Octopus.Client/Repositories/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/UserRepository.cs
@@ -20,7 +20,7 @@ namespace Octopus.Client.Repositories
         void SignOut();
         UserResource GetCurrent();
         SpaceResource[] GetSpaces(UserResource user);
-        ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expiry = null);
+        ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expires = null);
         List<ApiKeyResource> GetApiKeys(UserResource user);
         void RevokeApiKey(ApiKeyResourceBase apiKey);
         [Obsolete("Use the " + nameof(IUserInvitesRepository) + " instead", false)]
@@ -96,13 +96,13 @@ namespace Octopus.Client.Repositories
             return Client.Get<SpaceResource[]>(user.Link("Spaces"));
         }
 
-        public ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expiry = null)
+        public ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expires = null)
         {
             if (user == null) throw new ArgumentNullException("user");
             return Client.Post<object, ApiKeyCreatedResource>(user.Link("ApiKeys"), new
             {
                 Purpose = purpose ?? "Requested by Octopus.Client",
-                Expiry = expiry
+                Expires = expires
             });
         }
 

--- a/source/Octopus.Client/Repositories/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/UserRepository.cs
@@ -20,6 +20,16 @@ namespace Octopus.Client.Repositories
         void SignOut();
         UserResource GetCurrent();
         SpaceResource[] GetSpaces(UserResource user);
+        /// <summary>
+        /// Creates a new API key for a user.
+        /// </summary>
+        /// <param name="user">The user to create the key for.</param>
+        /// <param name="purpose">The purpose of the API key.</param>
+        /// <param name="expires">The expiry date of the key. If null, the key will never expire.</param>
+        /// <returns>The newly created API key resource.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="user"/> was null.
+        /// </exception>
         ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expires = null);
         List<ApiKeyResource> GetApiKeys(UserResource user);
         void RevokeApiKey(ApiKeyResourceBase apiKey);

--- a/source/Octopus.Client/Repositories/UserRepository.cs
+++ b/source/Octopus.Client/Repositories/UserRepository.cs
@@ -20,7 +20,7 @@ namespace Octopus.Client.Repositories
         void SignOut();
         UserResource GetCurrent();
         SpaceResource[] GetSpaces(UserResource user);
-        ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null);
+        ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expiry = null);
         List<ApiKeyResource> GetApiKeys(UserResource user);
         void RevokeApiKey(ApiKeyResourceBase apiKey);
         [Obsolete("Use the " + nameof(IUserInvitesRepository) + " instead", false)]
@@ -96,12 +96,13 @@ namespace Octopus.Client.Repositories
             return Client.Get<SpaceResource[]>(user.Link("Spaces"));
         }
 
-        public ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null)
+        public ApiKeyCreatedResource CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expiry = null)
         {
             if (user == null) throw new ArgumentNullException("user");
             return Client.Post<object, ApiKeyCreatedResource>(user.Link("ApiKeys"), new
             {
-                Purpose = purpose ?? "Requested by Octopus.Client"
+                Purpose = purpose ?? "Requested by Octopus.Client",
+                Expiry = expiry
             });
         }
 


### PR DESCRIPTION
# Background

This PR is part of the [API Key Management](https://docs.google.com/document/d/1BwF_RjvOAX0Rc-6JEr3D1w88BJcyqxXuhYr8GPpV5Gc/edit#) pitch.

Allows setting and retrieving an expiry date for an API key.

Related to Server PR https://github.com/OctopusDeploy/OctopusDeploy/pull/7575.