### PR TITLE
Mark Comments property on DeploymentResource obsolete

### DIFF
--- a/source/Octopus.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Client/Model/DeploymentResource.cs
@@ -65,6 +65,7 @@ namespace Octopus.Client.Model
         [WriteableOnCreate]
         public bool UseGuidedFailure { get; set; }
 
+        [Obsolete("Deployment comments were made obsolete by prompted variables. This property is no longer used.")]
         [WriteableOnCreate]
         public string Comments { get; set; }
 


### PR DESCRIPTION
Comments property on deployments hasn't been used for a long time.
See https://github.com/OctopusDeploy/Issues/issues/472