### PR TITLE
Add command and response DTOs for converting projects to version-controlled

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6906,6 +6906,7 @@ Octopus.Client.Repositories
   }
   interface IProjectBetaRepository
   {
+    void ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.VersionControlBranchResource[] GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6380,6 +6380,16 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
 }
 Octopus.Client.Model.VersionControl
 {
+  class ConvertProjectToVersionControlledCommand
+  {
+    .ctor()
+    String CommitMessage { get; set; }
+    Octopus.Client.Model.VersionControlSettingsResource VersionControlSettings { get; set; }
+  }
+  class ConvertProjectToVersionControlledResponse
+  {
+    .ctor()
+  }
   class VersionControlReferenceResource
   {
     .ctor()
@@ -6906,7 +6916,7 @@ Octopus.Client.Repositories
   }
   interface IProjectBetaRepository
   {
-    void ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
+    Octopus.Client.Model.VersionControl.ConvertProjectToVersionControlledResponse ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.VersionControlBranchResource[] GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
@@ -7647,7 +7657,7 @@ Octopus.Client.Repositories.Async
   }
   interface IProjectBetaRepository
   {
-    Task ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
+    Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
     Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7647,6 +7647,7 @@ Octopus.Client.Repositories.Async
   }
   interface IProjectBetaRepository
   {
+    Task ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
     Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6931,6 +6931,7 @@ Octopus.Client.Repositories
   }
   interface IProjectBetaRepository
   {
+    void ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.VersionControlBranchResource[] GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7672,6 +7672,7 @@ Octopus.Client.Repositories.Async
   }
   interface IProjectBetaRepository
   {
+    Task ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
     Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6405,6 +6405,16 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
 }
 Octopus.Client.Model.VersionControl
 {
+  class ConvertProjectToVersionControlledCommand
+  {
+    .ctor()
+    String CommitMessage { get; set; }
+    Octopus.Client.Model.VersionControlSettingsResource VersionControlSettings { get; set; }
+  }
+  class ConvertProjectToVersionControlledResponse
+  {
+    .ctor()
+  }
   class VersionControlReferenceResource
   {
     .ctor()
@@ -6931,7 +6941,7 @@ Octopus.Client.Repositories
   }
   interface IProjectBetaRepository
   {
-    void ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
+    Octopus.Client.Model.VersionControl.ConvertProjectToVersionControlledResponse ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.VersionControlBranchResource[] GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
@@ -7672,7 +7682,7 @@ Octopus.Client.Repositories.Async
   }
   interface IProjectBetaRepository
   {
-    Task ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
+    Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
     Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
@@ -28,9 +28,9 @@ namespace Octopus.Client.Tests
             var framework = string.Concat(RuntimeInformation.FrameworkDescription.Split(' ').Take(2));
             try
             {
-                var recieved = string.Join("\r\n", lines);
+                var received = string.Join("\r\n", lines);
                 this.Assent(
-                    recieved,
+                    received,
                     new Configuration().UsingNamer(new PostfixNamer(framework))
                 );
             }

--- a/source/Octopus.Client/Model/CommitResource.cs
+++ b/source/Octopus.Client/Model/CommitResource.cs
@@ -5,7 +5,7 @@
         public string CommitMessage { get; set; }
     }
 
-    public class CommitResource<TResource> : CommitResource where TResource : Resource
+    public class CommitResource<TResource> : CommitResource where TResource : class
     {
         public TResource Resource { get; set; }
     }

--- a/source/Octopus.Client/Model/CommitResource.cs
+++ b/source/Octopus.Client/Model/CommitResource.cs
@@ -5,7 +5,7 @@
         public string CommitMessage { get; set; }
     }
 
-    public class CommitResource<TResource> : CommitResource where TResource : class
+    public class CommitResource<TResource> : CommitResource where TResource : Resource
     {
         public TResource Resource { get; set; }
     }

--- a/source/Octopus.Client/Model/VersionControl/ConvertProjectToVersionControlledCommand.cs
+++ b/source/Octopus.Client/Model/VersionControl/ConvertProjectToVersionControlledCommand.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.VersionControl
+{
+    public class ConvertProjectToVersionControlledCommand
+    {
+        [Required]
+        public string CommitMessage { get; set; }
+
+        [Required]
+        public VersionControlSettingsResource VersionControlSettings { get; set; }
+    }
+}

--- a/source/Octopus.Client/Model/VersionControl/ConvertProjectToVersionControlledResponse.cs
+++ b/source/Octopus.Client/Model/VersionControl/ConvertProjectToVersionControlledResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace Octopus.Client.Model.VersionControl
+{
+    public class ConvertProjectToVersionControlledResponse
+    {
+    }
+}

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Model;
+using Octopus.Client.Model.VersionControl;
 
 namespace Octopus.Client.Repositories.Async
 {
@@ -128,7 +129,7 @@ namespace Octopus.Client.Repositories.Async
     {
         Task<VersionControlBranchResource[]> GetVersionControlledBranches(ProjectResource projectResource);
         Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch);
-        Task ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage);
+        Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage);
     }
 
     class ProjectBetaRepository : IProjectBetaRepository
@@ -150,17 +151,18 @@ namespace Octopus.Client.Repositories.Async
             return client.Get<VersionControlBranchResource>(projectResource.Link("Branches"), new { name = branch });
         }
 
-        public async Task ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings,
+        public async Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings,
             string commitMessage)
         {
-            var payload = new CommitResource<VersionControlSettingsResource>
+            var payload = new ConvertProjectToVersionControlledCommand
             {
-                Resource = versionControlSettings,
+                VersionControlSettings = versionControlSettings,
                 CommitMessage = commitMessage
             };
 
             var url = project.Link("ConvertToVcs");
-            await client.Post(url, payload);
+            var response = await client.Post<ConvertProjectToVersionControlledCommand,ConvertProjectToVersionControlledResponse>(url, payload);
+            return response;
         }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -128,6 +128,7 @@ namespace Octopus.Client.Repositories.Async
     {
         Task<VersionControlBranchResource[]> GetVersionControlledBranches(ProjectResource projectResource);
         Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch);
+        Task ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage);
     }
 
     class ProjectBetaRepository : IProjectBetaRepository
@@ -147,6 +148,19 @@ namespace Octopus.Client.Repositories.Async
         public Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch)
         {
             return client.Get<VersionControlBranchResource>(projectResource.Link("Branches"), new { name = branch });
+        }
+
+        public async Task ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings,
+            string commitMessage)
+        {
+            var payload = new CommitResource<VersionControlSettingsResource>
+            {
+                Resource = versionControlSettings,
+                CommitMessage = commitMessage
+            };
+
+            var url = project.Link("ConvertToVcs");
+            await client.Post(url, payload);
         }
     }
 }

--- a/source/Octopus.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Octopus.Client.Editors;
 using Octopus.Client.Model;
+using Octopus.Client.Model.VersionControl;
 
 namespace Octopus.Client.Repositories
 {
@@ -127,7 +128,7 @@ namespace Octopus.Client.Repositories
     {
         VersionControlBranchResource[] GetVersionControlledBranches(ProjectResource projectResource);
         VersionControlBranchResource GetVersionControlledBranch(ProjectResource projectResource, string branch);
-        void ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage);
+        ConvertProjectToVersionControlledResponse ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage);
     }
 
     internal class ProjectBetaRepository : IProjectBetaRepository
@@ -149,16 +150,20 @@ namespace Octopus.Client.Repositories
             return client.Get<VersionControlBranchResource>(projectResource.Link("Branches"), new {name = branch});
         }
 
-        public void ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage)
+        public ConvertProjectToVersionControlledResponse ConvertToVersionControlled(ProjectResource project,
+            VersionControlSettingsResource versionControlSettings, string commitMessage)
         {
-            var payload = new CommitResource<VersionControlSettingsResource>
+            var payload = new ConvertProjectToVersionControlledCommand
             {
-                Resource = versionControlSettings,
+                VersionControlSettings = versionControlSettings,
                 CommitMessage = commitMessage
             };
 
             var url = project.Link("ConvertToVcs");
-            client.Post(url, payload);
+            var response =
+                client.Post<ConvertProjectToVersionControlledCommand, ConvertProjectToVersionControlledResponse>(url,
+                    payload);
+            return response;
         }
     }
 }

--- a/source/Octopus.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectRepository.cs
@@ -127,15 +127,16 @@ namespace Octopus.Client.Repositories
     {
         VersionControlBranchResource[] GetVersionControlledBranches(ProjectResource projectResource);
         VersionControlBranchResource GetVersionControlledBranch(ProjectResource projectResource, string branch);
+        void ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage);
     }
 
-    class ProjectBetaRepository : IProjectBetaRepository
+    internal class ProjectBetaRepository : IProjectBetaRepository
     {
         private readonly IOctopusClient client;
 
         public ProjectBetaRepository(IOctopusRepository repository)
         {
-            this.client = repository.Client;
+            client = repository.Client;
         }
 
         public VersionControlBranchResource[] GetVersionControlledBranches(ProjectResource projectResource)
@@ -145,7 +146,19 @@ namespace Octopus.Client.Repositories
 
         public VersionControlBranchResource GetVersionControlledBranch(ProjectResource projectResource, string branch)
         {
-            return client.Get<VersionControlBranchResource>(projectResource.Link("Branches"), new { name = branch });
+            return client.Get<VersionControlBranchResource>(projectResource.Link("Branches"), new {name = branch});
+        }
+
+        public void ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage)
+        {
+            var payload = new CommitResource<VersionControlSettingsResource>
+            {
+                Resource = versionControlSettings,
+                CommitMessage = commitMessage
+            };
+
+            var url = project.Link("ConvertToVcs");
+            client.Post(url, payload);
         }
     }
 }


### PR DESCRIPTION
We have a need in Server to pass commit messages and other paraphernalia through when performing actions.

This PR adds a command DTO and corresponding method on the `IProjectBetaRepository` to allow us to convert projects to version-controlled and pass through a commit message.