### PR TITLE
Expect page metadata in branch response

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5295,12 +5295,12 @@ Octopus.Client.Model
     String Name { get; set; }
   }
   class VersionControlBranchResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
   {
     .ctor(String)
-    Octopus.Client.Extensibility.LinkCollection Links { get; }
     String Name { get; }
-    String Link(String)
-    void WithLinks(Octopus.Client.Extensibility.LinkCollection)
   }
   class VersionControlSettingsResource
   {
@@ -6907,7 +6907,7 @@ Octopus.Client.Repositories
   interface IProjectBetaRepository
   {
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.VersionControlBranchResource[] GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
+    Octopus.Client.Model.ResourceCollection<VersionControlBranchResource> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
   interface IProjectGroupRepository
     Octopus.Client.Repositories.IFindByName<ProjectGroupResource>
@@ -7647,7 +7647,7 @@ Octopus.Client.Repositories.Async
   interface IProjectBetaRepository
   {
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
-    Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
+    Task<ResourceCollection<VersionControlBranchResource>> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
   interface IProjectGroupRepository
     Octopus.Client.Repositories.Async.IFindByName<ProjectGroupResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5319,12 +5319,12 @@ Octopus.Client.Model
     String Name { get; set; }
   }
   class VersionControlBranchResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
   {
     .ctor(String)
-    Octopus.Client.Extensibility.LinkCollection Links { get; }
     String Name { get; }
-    String Link(String)
-    void WithLinks(Octopus.Client.Extensibility.LinkCollection)
   }
   class VersionControlSettingsResource
   {
@@ -6932,7 +6932,7 @@ Octopus.Client.Repositories
   interface IProjectBetaRepository
   {
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.VersionControlBranchResource[] GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
+    Octopus.Client.Model.ResourceCollection<VersionControlBranchResource> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
   interface IProjectGroupRepository
     Octopus.Client.Repositories.IFindByName<ProjectGroupResource>
@@ -7672,7 +7672,7 @@ Octopus.Client.Repositories.Async
   interface IProjectBetaRepository
   {
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
-    Task<VersionControlBranchResource[]> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
+    Task<ResourceCollection<VersionControlBranchResource>> GetVersionControlledBranches(Octopus.Client.Model.ProjectResource)
   }
   interface IProjectGroupRepository
     Octopus.Client.Repositories.Async.IFindByName<ProjectGroupResource>

--- a/source/Octopus.Client/Model/VersionControlBranchResource.cs
+++ b/source/Octopus.Client/Model/VersionControlBranchResource.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Octopus.Client.Extensibility;
+﻿using Octopus.Client.Extensibility;
 
 namespace Octopus.Client.Model
 {
-    public class VersionControlBranchResource
+    public class VersionControlBranchResource : Resource
     {
         public VersionControlBranchResource(string name)
         {
@@ -12,26 +11,5 @@ namespace Octopus.Client.Model
         }
 
         public string Name { get; }
-
-        public LinkCollection Links { get; }
-
-        public void WithLinks(LinkCollection links)
-        {
-            Links.Clear();
-            foreach (var link in links)
-            {
-                Links.Add(link.Key, link.Value);
-            }
-        }
-
-        public string Link(string name)
-        {
-            if (!(Links ?? new LinkCollection()).TryGetValue(name, out var value))
-            {
-                throw new Exception($"The document does not define a link for '{name}'");
-            }
-
-            return value;
-        }
     }
 }

--- a/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/ProjectRepository.cs
@@ -126,7 +126,7 @@ namespace Octopus.Client.Repositories.Async
 
     public interface IProjectBetaRepository
     {
-        Task<VersionControlBranchResource[]> GetVersionControlledBranches(ProjectResource projectResource);
+        Task<ResourceCollection<VersionControlBranchResource>> GetVersionControlledBranches(ProjectResource projectResource);
         Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch);
     }
 
@@ -136,12 +136,12 @@ namespace Octopus.Client.Repositories.Async
 
         public ProjectBetaRepository(IOctopusAsyncRepository repository)
         {
-            this.client = repository.Client;
+            client = repository.Client;
         }
 
-        public Task<VersionControlBranchResource[]> GetVersionControlledBranches(ProjectResource projectResource)
+        public Task<ResourceCollection<VersionControlBranchResource>> GetVersionControlledBranches(ProjectResource projectResource)
         {
-            return client.Get<VersionControlBranchResource[]>(projectResource.Link("Branches"));
+            return client.Get<ResourceCollection<VersionControlBranchResource>>(projectResource.Link("Branches"));
         }
 
         public Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch)

--- a/source/Octopus.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Client/Repositories/ProjectRepository.cs
@@ -125,7 +125,7 @@ namespace Octopus.Client.Repositories
 
     public interface IProjectBetaRepository
     {
-        VersionControlBranchResource[] GetVersionControlledBranches(ProjectResource projectResource);
+        ResourceCollection<VersionControlBranchResource> GetVersionControlledBranches(ProjectResource projectResource);
         VersionControlBranchResource GetVersionControlledBranch(ProjectResource projectResource, string branch);
     }
 
@@ -138,9 +138,9 @@ namespace Octopus.Client.Repositories
             this.client = repository.Client;
         }
 
-        public VersionControlBranchResource[] GetVersionControlledBranches(ProjectResource projectResource)
+        public ResourceCollection<VersionControlBranchResource> GetVersionControlledBranches(ProjectResource projectResource)
         {
-            return client.Get<VersionControlBranchResource[]>(projectResource.Link("Branches"));
+            return client.Get<ResourceCollection<VersionControlBranchResource>>(projectResource.Link("Branches"));
         }
 
         public VersionControlBranchResource GetVersionControlledBranch(ProjectResource projectResource, string branch)


### PR DESCRIPTION
The server now returns a `ResourceCollection` of `VersionControlBranchResource` instead of array.

This relates to the server PR https://github.com/OctopusDeploy/OctopusDeploy/pull/7637