### PR TITLE
Added BasePath to VersionControlSettingsResource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5305,6 +5305,7 @@ Octopus.Client.Model
   class VersionControlSettingsResource
   {
     .ctor()
+    String BasePath { get; set; }
     String DefaultBranch { get; set; }
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Url { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5329,6 +5329,7 @@ Octopus.Client.Model
   class VersionControlSettingsResource
   {
     .ctor()
+    String BasePath { get; set; }
     String DefaultBranch { get; set; }
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Url { get; set; }

--- a/source/Octopus.Client/Model/VersionControlSettingsResource.cs
+++ b/source/Octopus.Client/Model/VersionControlSettingsResource.cs
@@ -12,5 +12,7 @@ namespace Octopus.Client.Model
         public SensitiveValue Password { get; set; } = new SensitiveValue();
         [Writeable]
         public string DefaultBranch { get; set; }
+        [Writeable]
+        public string BasePath { get; set; }
     }
 }


### PR DESCRIPTION
Added a `BasePath` property to the `VersionControlSettingsResource` allowing for the ability to specify a base path for the Octopus project's .ocl files as part of Config as Code.