### PR TITLE
Add messages to ConvertProjectToVersionControlledResponse

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6388,6 +6388,25 @@ Octopus.Client.Model.VersionControl
     Octopus.Client.Model.VersionControlSettingsResource VersionControlSettings { get; set; }
   }
   class ConvertProjectToVersionControlledResponse
+    Octopus.Client.Model.VersionControl.IHaveCustomerVisibleMessages
+  {
+    .ctor()
+    Octopus.Client.Model.VersionControl.MessageCollection Messages { get; }
+  }
+  interface IHaveCustomerVisibleMessages
+  {
+    Octopus.Client.Model.VersionControl.MessageCollection Messages { get; }
+  }
+  class MessageCollection
+    IList<String>
+    ICollection<String>
+    IEnumerable<String>
+    IEnumerable
+    IList
+    ICollection
+    IReadOnlyList<String>
+    IReadOnlyCollection<String>
+    List<String>
   {
     .ctor()
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6413,6 +6413,25 @@ Octopus.Client.Model.VersionControl
     Octopus.Client.Model.VersionControlSettingsResource VersionControlSettings { get; set; }
   }
   class ConvertProjectToVersionControlledResponse
+    Octopus.Client.Model.VersionControl.IHaveCustomerVisibleMessages
+  {
+    .ctor()
+    Octopus.Client.Model.VersionControl.MessageCollection Messages { get; }
+  }
+  interface IHaveCustomerVisibleMessages
+  {
+    Octopus.Client.Model.VersionControl.MessageCollection Messages { get; }
+  }
+  class MessageCollection
+    IList<String>
+    ICollection<String>
+    IEnumerable<String>
+    IEnumerable
+    IList
+    ICollection
+    IReadOnlyList<String>
+    IReadOnlyCollection<String>
+    List<String>
   {
     .ctor()
   }

--- a/source/Octopus.Client/Model/VersionControl/ConvertProjectToVersionControlledResponse.cs
+++ b/source/Octopus.Client/Model/VersionControl/ConvertProjectToVersionControlledResponse.cs
@@ -1,6 +1,12 @@
 ﻿namespace Octopus.Client.Model.VersionControl
 {
-    public class ConvertProjectToVersionControlledResponse
+    public class ConvertProjectToVersionControlledResponse : IHaveCustomerVisibleMessages
     {
+        public ConvertProjectToVersionControlledResponse()
+        {
+            Messages = new MessageCollection();
+        }
+
+        public MessageCollection Messages { get; }
     }
 }

--- a/source/Octopus.Client/Model/VersionControl/IHaveCustomerVisibleMessages.cs
+++ b/source/Octopus.Client/Model/VersionControl/IHaveCustomerVisibleMessages.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model.VersionControl
+{
+    public interface IHaveCustomerVisibleMessages
+    {
+        MessageCollection Messages { get; }
+    }
+}

--- a/source/Octopus.Client/Model/VersionControl/MessageCollection.cs
+++ b/source/Octopus.Client/Model/VersionControl/MessageCollection.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Octopus.Client.Model.VersionControl
+{
+    public class MessageCollection : List<string>
+    {
+    }
+}


### PR DESCRIPTION
The response when converting a project to version control now includes messages about what happened when the project conversion was undertaken.