### PR TITLE
When deleting remove channel from trackedChannelBuilders

### DIFF
--- a/source/Octopus.Client/Editors/ProjectChannelsEditor.cs
+++ b/source/Octopus.Client/Editors/ProjectChannelsEditor.cs
@@ -35,6 +35,7 @@ namespace Octopus.Client.Editors
         {
             var channel = repository.FindByName(owner, name);
             if (channel != null) repository.Delete(channel);
+            this.trackedChannelBuilders.RemoveAll(x=>x.Instance.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
             return this;
         }
 


### PR DESCRIPTION
code example of issue.
Removing the default channel in a project.

```
                    var defaultChannelEditor = projectEditor.Channels.CreateOrModify("Default");
                    defaultChannelEditor.Customize(x => x.IsDefault = false);
                    defaultChannelEditor.Save();
                    projectEditor.Channels.Delete("Default");
                    projectEditor.Save();
```
the call to `projectEditor.Save();` will error as it tries to save the channel that has just been deleted.
We need to do `CreateOrModify` in order to set `IsDefault` as false to allow it to be deleted