### PR TITLE
Removing unnecessary calls to GET resources after a POST/PUT

### DIFF
--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -224,7 +224,7 @@ namespace Octopus.Client
             var uri = QualifyUri(path, pathParameters);
 
             var response = DispatchRequest<TResource>(new OctopusRequest("POST", uri, requestResource: resource), true);
-            return Get<TResource>(response.Location);
+            return response.ResponseResource;
         }
 
         /// <summary>
@@ -352,8 +352,8 @@ namespace Octopus.Client
         {
             var uri = QualifyUri(path, pathParameters);
 
-            DispatchRequest<TResource>(new OctopusRequest("PUT", uri, requestResource: resource), false);
-            return DispatchRequest<TResource>(new OctopusRequest("GET", uri), true).ResponseResource;
+            var response = DispatchRequest<TResource>(new OctopusRequest("PUT", uri, requestResource: resource), true);
+            return response.ResponseResource;
         }
 
         /// <summary>


### PR DESCRIPTION
See equivalent [Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/8019)

Customers using an older version of Octopus should not be affected (E.g. version 2.6 that may not have returned the resource as part of a POST/PUT), as they should be using an older version of OctopusClients - [see compatibility documentation](https://octopus.com/docs/support/compatibility).