### PR TITLE
Separate deployment settings API and resource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -146,6 +146,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IDefectsRepository Defects { get; }
     Octopus.Client.Repositories.Async.IDeploymentProcessRepository DeploymentProcesses { get; }
     Octopus.Client.Repositories.Async.IDeploymentRepository Deployments { get; }
+    Octopus.Client.Repositories.Async.IDeploymentSettingsRepository DeploymentSettings { get; }
     Octopus.Client.Repositories.Async.IEnvironmentRepository Environments { get; }
     Octopus.Client.Repositories.Async.IFeedRepository Feeds { get; }
     Octopus.Client.Repositories.Async.IInterruptionRepository Interruptions { get; }
@@ -318,6 +319,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IDefectsRepository Defects { get; }
     Octopus.Client.Repositories.Async.IDeploymentProcessRepository DeploymentProcesses { get; }
     Octopus.Client.Repositories.Async.IDeploymentRepository Deployments { get; }
+    Octopus.Client.Repositories.Async.IDeploymentSettingsRepository DeploymentSettings { get; }
     Octopus.Client.Repositories.Async.IEnvironmentRepository Environments { get; }
     Octopus.Client.Repositories.Async.IEventRepository Events { get; }
     Octopus.Client.Repositories.Async.IFeaturesConfigurationRepository FeaturesConfiguration { get; }
@@ -7580,6 +7582,15 @@ Octopus.Client.Repositories.Async
     Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource)
     Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
+  }
+  interface IDeploymentSettingsBetaRepository
+  {
+    Task<DeploymentSettingsResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource, String)
+  }
+  interface IDeploymentSettingsRepository
+  {
+    Octopus.Client.Repositories.Async.IDeploymentSettingsBetaRepository Beta()
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2528,6 +2528,14 @@ Octopus.Client.Model
       Approved = 0
       Rejected = 1
   }
+  class DeploymentConnectivityPolicy
+  {
+    .ctor()
+    Boolean AllowDeploymentsToNoTargets { get; set; }
+    Boolean ExcludeUnhealthyTargets { get; set; }
+    Octopus.Client.Model.SkipMachineBehavior SkipMachineBehavior { get; set; }
+    Octopus.Client.Model.ReferenceCollection TargetRoles { get; set; }
+  }
   class DeploymentPreviewBaseResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -2626,9 +2634,9 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    Octopus.Client.Model.ProjectConnectivityPolicy ConnectivityPolicy { get; set; }
+    Octopus.Client.Model.DeploymentConnectivityPolicy ConnectivityPolicy { get; set; }
     Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
-    String DefaultToSkipIfAlreadyInstalled { get; set; }
+    Boolean DefaultToSkipIfAlreadyInstalled { get; set; }
     String DeploymentChangesTemplate { get; set; }
     String ProjectId { get; set; }
     String ReleaseNotesTemplate { get; set; }
@@ -3986,14 +3994,6 @@ Octopus.Client.Model
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
   }
-  class ProjectConnectivityPolicy
-  {
-    .ctor()
-    Boolean AllowDeploymentsToNoTargets { get; set; }
-    Boolean ExcludeUnhealthyTargets { get; set; }
-    Octopus.Client.Model.SkipMachineBehavior SkipMachineBehavior { get; set; }
-    Octopus.Client.Model.ReferenceCollection TargetRoles { get; set; }
-  }
   class ProjectedTeamReferenceDataItem
     Octopus.Client.Model.ReferenceDataItem
   {
@@ -4042,7 +4042,7 @@ Octopus.Client.Model
     String LifecycleId { get; set; }
     String Name { get; set; }
     Octopus.Client.Model.PersistenceSettingsResource PersistenceSettings { get; set; }
-    Octopus.Client.Model.ProjectConnectivityPolicy ProjectConnectivityPolicy { get; set; }
+    Octopus.Client.Model.DeploymentConnectivityPolicy ProjectConnectivityPolicy { get; set; }
     String ProjectGroupId { get; set; }
     Octopus.Client.Model.ReleaseCreationStrategyResource ReleaseCreationStrategy { get; set; }
     String ReleaseNotesTemplate { get; set; }
@@ -4372,7 +4372,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    Octopus.Client.Model.ProjectConnectivityPolicy ConnectivityPolicy { get; set; }
+    Octopus.Client.Model.DeploymentConnectivityPolicy ConnectivityPolicy { get; set; }
     Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
     String Description { get; set; }
     Octopus.Client.Model.ReferenceCollection Environments { get; }
@@ -5342,7 +5342,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    Octopus.Client.Model.ProjectConnectivityPolicy ConnectivityPolicy { get; set; }
+    Octopus.Client.Model.DeploymentConnectivityPolicy ConnectivityPolicy { get; set; }
     Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
     String Description { get; set; }
     Octopus.Client.Model.ReferenceCollection Environments { get; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -191,6 +191,7 @@ Octopus.Client
     Octopus.Client.Repositories.IDefectsRepository Defects { get; }
     Octopus.Client.Repositories.IDeploymentProcessRepository DeploymentProcesses { get; }
     Octopus.Client.Repositories.IDeploymentRepository Deployments { get; }
+    Octopus.Client.Repositories.IDeploymentSettingsRepository DeploymentSettings { get; }
     Octopus.Client.Repositories.IEnvironmentRepository Environments { get; }
     Octopus.Client.Repositories.IFeedRepository Feeds { get; }
     Octopus.Client.Repositories.IInterruptionRepository Interruptions { get; }
@@ -449,6 +450,7 @@ Octopus.Client
     Octopus.Client.Repositories.IDefectsRepository Defects { get; }
     Octopus.Client.Repositories.IDeploymentProcessRepository DeploymentProcesses { get; }
     Octopus.Client.Repositories.IDeploymentRepository Deployments { get; }
+    Octopus.Client.Repositories.IDeploymentSettingsRepository DeploymentSettings { get; }
     Octopus.Client.Repositories.IEnvironmentRepository Environments { get; }
     Octopus.Client.Repositories.IEventRepository Events { get; }
     Octopus.Client.Repositories.IFeaturesConfigurationRepository FeaturesConfiguration { get; }
@@ -2614,6 +2616,22 @@ Octopus.Client.Model
     String TenantId { get; set; }
     Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
     Boolean UseGuidedFailure { get; set; }
+  }
+  class DeploymentSettingsResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Octopus.Client.Model.ProjectConnectivityPolicy ConnectivityPolicy { get; set; }
+    Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
+    String DefaultToSkipIfAlreadyInstalled { get; set; }
+    String DeploymentChangesTemplate { get; set; }
+    String ProjectId { get; set; }
+    String ReleaseNotesTemplate { get; set; }
+    String SpaceId { get; set; }
+    Octopus.Client.Model.VersioningStrategyResource VersioningStrategy { get; set; }
   }
   DeploymentStepCondition
   {
@@ -6810,6 +6828,15 @@ Octopus.Client.Repositories
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.DeploymentResource)
     void Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     void Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
+  }
+  interface IDeploymentSettingsBetaRepository
+  {
+    Octopus.Client.Model.DeploymentSettingsResource Get(Octopus.Client.Model.ProjectResource, String)
+    Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource, String)
+  }
+  interface IDeploymentSettingsRepository
+  {
+    Octopus.Client.Repositories.IDeploymentSettingsBetaRepository Beta()
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.IFindByName<EnvironmentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -146,6 +146,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IDefectsRepository Defects { get; }
     Octopus.Client.Repositories.Async.IDeploymentProcessRepository DeploymentProcesses { get; }
     Octopus.Client.Repositories.Async.IDeploymentRepository Deployments { get; }
+    Octopus.Client.Repositories.Async.IDeploymentSettingsRepository DeploymentSettings { get; }
     Octopus.Client.Repositories.Async.IEnvironmentRepository Environments { get; }
     Octopus.Client.Repositories.Async.IFeedRepository Feeds { get; }
     Octopus.Client.Repositories.Async.IInterruptionRepository Interruptions { get; }
@@ -318,6 +319,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IDefectsRepository Defects { get; }
     Octopus.Client.Repositories.Async.IDeploymentProcessRepository DeploymentProcesses { get; }
     Octopus.Client.Repositories.Async.IDeploymentRepository Deployments { get; }
+    Octopus.Client.Repositories.Async.IDeploymentSettingsRepository DeploymentSettings { get; }
     Octopus.Client.Repositories.Async.IEnvironmentRepository Environments { get; }
     Octopus.Client.Repositories.Async.IEventRepository Events { get; }
     Octopus.Client.Repositories.Async.IFeaturesConfigurationRepository FeaturesConfiguration { get; }
@@ -7605,6 +7607,15 @@ Octopus.Client.Repositories.Async
     Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource)
     Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
+  }
+  interface IDeploymentSettingsBetaRepository
+  {
+    Task<DeploymentSettingsResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource, String)
+  }
+  interface IDeploymentSettingsRepository
+  {
+    Octopus.Client.Repositories.Async.IDeploymentSettingsBetaRepository Beta()
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -191,6 +191,7 @@ Octopus.Client
     Octopus.Client.Repositories.IDefectsRepository Defects { get; }
     Octopus.Client.Repositories.IDeploymentProcessRepository DeploymentProcesses { get; }
     Octopus.Client.Repositories.IDeploymentRepository Deployments { get; }
+    Octopus.Client.Repositories.IDeploymentSettingsRepository DeploymentSettings { get; }
     Octopus.Client.Repositories.IEnvironmentRepository Environments { get; }
     Octopus.Client.Repositories.IFeedRepository Feeds { get; }
     Octopus.Client.Repositories.IInterruptionRepository Interruptions { get; }
@@ -447,6 +448,7 @@ Octopus.Client
     Octopus.Client.Repositories.IDefectsRepository Defects { get; }
     Octopus.Client.Repositories.IDeploymentProcessRepository DeploymentProcesses { get; }
     Octopus.Client.Repositories.IDeploymentRepository Deployments { get; }
+    Octopus.Client.Repositories.IDeploymentSettingsRepository DeploymentSettings { get; }
     Octopus.Client.Repositories.IEnvironmentRepository Environments { get; }
     Octopus.Client.Repositories.IEventRepository Events { get; }
     Octopus.Client.Repositories.IFeaturesConfigurationRepository FeaturesConfiguration { get; }
@@ -2630,6 +2632,22 @@ Octopus.Client.Model
     String TenantId { get; set; }
     Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
     Boolean UseGuidedFailure { get; set; }
+  }
+  class DeploymentSettingsResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Octopus.Client.Model.ProjectConnectivityPolicy ConnectivityPolicy { get; set; }
+    Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
+    String DefaultToSkipIfAlreadyInstalled { get; set; }
+    String DeploymentChangesTemplate { get; set; }
+    String ProjectId { get; set; }
+    String ReleaseNotesTemplate { get; set; }
+    String SpaceId { get; set; }
+    Octopus.Client.Model.VersioningStrategyResource VersioningStrategy { get; set; }
   }
   DeploymentStepCondition
   {
@@ -6835,6 +6853,15 @@ Octopus.Client.Repositories
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.DeploymentResource)
     void Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     void Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
+  }
+  interface IDeploymentSettingsBetaRepository
+  {
+    Octopus.Client.Model.DeploymentSettingsResource Get(Octopus.Client.Model.ProjectResource, String)
+    Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource, String)
+  }
+  interface IDeploymentSettingsRepository
+  {
+    Octopus.Client.Repositories.IDeploymentSettingsBetaRepository Beta()
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.IFindByName<EnvironmentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2544,6 +2544,14 @@ Octopus.Client.Model
       Approved = 0
       Rejected = 1
   }
+  class DeploymentConnectivityPolicy
+  {
+    .ctor()
+    Boolean AllowDeploymentsToNoTargets { get; set; }
+    Boolean ExcludeUnhealthyTargets { get; set; }
+    Octopus.Client.Model.SkipMachineBehavior SkipMachineBehavior { get; set; }
+    Octopus.Client.Model.ReferenceCollection TargetRoles { get; set; }
+  }
   class DeploymentPreviewBaseResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -2642,9 +2650,9 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    Octopus.Client.Model.ProjectConnectivityPolicy ConnectivityPolicy { get; set; }
+    Octopus.Client.Model.DeploymentConnectivityPolicy ConnectivityPolicy { get; set; }
     Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
-    String DefaultToSkipIfAlreadyInstalled { get; set; }
+    Boolean DefaultToSkipIfAlreadyInstalled { get; set; }
     String DeploymentChangesTemplate { get; set; }
     String ProjectId { get; set; }
     String ReleaseNotesTemplate { get; set; }
@@ -4005,14 +4013,6 @@ Octopus.Client.Model
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
   }
-  class ProjectConnectivityPolicy
-  {
-    .ctor()
-    Boolean AllowDeploymentsToNoTargets { get; set; }
-    Boolean ExcludeUnhealthyTargets { get; set; }
-    Octopus.Client.Model.SkipMachineBehavior SkipMachineBehavior { get; set; }
-    Octopus.Client.Model.ReferenceCollection TargetRoles { get; set; }
-  }
   class ProjectedTeamReferenceDataItem
     Octopus.Client.Model.ReferenceDataItem
   {
@@ -4061,7 +4061,7 @@ Octopus.Client.Model
     String LifecycleId { get; set; }
     String Name { get; set; }
     Octopus.Client.Model.PersistenceSettingsResource PersistenceSettings { get; set; }
-    Octopus.Client.Model.ProjectConnectivityPolicy ProjectConnectivityPolicy { get; set; }
+    Octopus.Client.Model.DeploymentConnectivityPolicy ProjectConnectivityPolicy { get; set; }
     String ProjectGroupId { get; set; }
     Octopus.Client.Model.ReleaseCreationStrategyResource ReleaseCreationStrategy { get; set; }
     String ReleaseNotesTemplate { get; set; }
@@ -4391,7 +4391,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    Octopus.Client.Model.ProjectConnectivityPolicy ConnectivityPolicy { get; set; }
+    Octopus.Client.Model.DeploymentConnectivityPolicy ConnectivityPolicy { get; set; }
     Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
     String Description { get; set; }
     Octopus.Client.Model.ReferenceCollection Environments { get; }
@@ -5366,7 +5366,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
-    Octopus.Client.Model.ProjectConnectivityPolicy ConnectivityPolicy { get; set; }
+    Octopus.Client.Model.DeploymentConnectivityPolicy ConnectivityPolicy { get; set; }
     Octopus.Client.Model.GuidedFailureMode DefaultGuidedFailureMode { get; set; }
     String Description { get; set; }
     Octopus.Client.Model.ReferenceCollection Environments { get; }

--- a/source/Octopus.Client/IOctopusSpaceAsyncRepository.cs
+++ b/source/Octopus.Client/IOctopusSpaceAsyncRepository.cs
@@ -23,6 +23,7 @@ namespace Octopus.Client
         IDashboardRepository Dashboards { get; }
         IDefectsRepository Defects { get; }
         IDeploymentProcessRepository DeploymentProcesses { get; }
+        IDeploymentSettingsRepository DeploymentSettings { get; }
         IDeploymentRepository Deployments { get; }
         IEnvironmentRepository Environments { get; }
         IFeedRepository Feeds { get; }

--- a/source/Octopus.Client/IOctopusSpaceRepository.cs
+++ b/source/Octopus.Client/IOctopusSpaceRepository.cs
@@ -23,6 +23,7 @@ namespace Octopus.Client
         IDashboardRepository Dashboards { get; }
         IDefectsRepository Defects { get; }
         IDeploymentProcessRepository DeploymentProcesses { get; }
+        IDeploymentSettingsRepository DeploymentSettings { get; }
         IDeploymentRepository Deployments { get; }
         IEnvironmentRepository Environments { get; }
         IFeedRepository Feeds { get; }

--- a/source/Octopus.Client/Model/DeploymentConnectivityPolicy.cs
+++ b/source/Octopus.Client/Model/DeploymentConnectivityPolicy.cs
@@ -6,7 +6,7 @@
         SkipUnavailableMachines
     }
 
-    public class ProjectConnectivityPolicy
+    public class DeploymentConnectivityPolicy
     {
         public SkipMachineBehavior SkipMachineBehavior { get; set; }
         public ReferenceCollection TargetRoles { get; set; }
@@ -15,7 +15,7 @@
 
         public bool ExcludeUnhealthyTargets { get; set; }
 
-        public ProjectConnectivityPolicy()
+        public DeploymentConnectivityPolicy()
         {
             TargetRoles = new ReferenceCollection();
         }

--- a/source/Octopus.Client/Model/DeploymentSettingsResource.cs
+++ b/source/Octopus.Client/Model/DeploymentSettingsResource.cs
@@ -12,7 +12,7 @@ namespace Octopus.Client.Model
 
         [Writeable]
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        public ProjectConnectivityPolicy ConnectivityPolicy { get; set; } = new ProjectConnectivityPolicy { AllowDeploymentsToNoTargets = false };
+        public DeploymentConnectivityPolicy ConnectivityPolicy { get; set; } = new DeploymentConnectivityPolicy { AllowDeploymentsToNoTargets = false };
 
         [Writeable]
         public GuidedFailureMode DefaultGuidedFailureMode { get; set; }

--- a/source/Octopus.Client/Model/DeploymentSettingsResource.cs
+++ b/source/Octopus.Client/Model/DeploymentSettingsResource.cs
@@ -1,0 +1,32 @@
+using Newtonsoft.Json;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model
+{
+    public class DeploymentSettingsResource : Resource, IHaveSpaceResource
+    {
+        public string SpaceId { get; set; }
+
+        public string ProjectId { get; set; }
+
+        [Writeable]
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public ProjectConnectivityPolicy ConnectivityPolicy { get; set; } = new ProjectConnectivityPolicy { AllowDeploymentsToNoTargets = false };
+
+        [Writeable]
+        public GuidedFailureMode DefaultGuidedFailureMode { get; set; }
+
+        [Writeable]
+        public VersioningStrategyResource VersioningStrategy { get; set; }
+
+        [Writeable]
+        public string ReleaseNotesTemplate { get; set; }
+
+        [Writeable]
+        public bool DefaultToSkipIfAlreadyInstalled { get; set; }
+
+        [Writeable]
+        public string DeploymentChangesTemplate { get; set; }
+    }
+}

--- a/source/Octopus.Client/Model/ProjectResource.cs
+++ b/source/Octopus.Client/Model/ProjectResource.cs
@@ -17,9 +17,13 @@ namespace Octopus.Client.Model
 
         public ProjectResource()
         {
+#pragma warning disable 618
             IncludedLibraryVariableSetIds = new List<string>();
+#pragma warning restore 618
             Templates = new List<ActionTemplateParameterResource>();
+#pragma warning disable 618
             ProjectConnectivityPolicy = new ProjectConnectivityPolicy();
+#pragma warning restore 618
             AutoDeployReleaseOverrides = new HashSet<AutoDeployReleaseOverrideResource>(AutoDeployReleaseOverrideResource.EnvironmentIdTenantIdComparer);
             variableTemplateEditor = new VariableTemplateContainerEditor<ProjectResource>(this);
             PersistenceSettings = new DatabasePersistenceSettingsResource();
@@ -118,7 +122,7 @@ namespace Octopus.Client.Model
         [Writeable]
         [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
         public string ReleaseNotesTemplate { get; set; }
-        
+
         [Writeable]
         [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
         public string DeploymentChangesTemplate { get; set; }
@@ -179,9 +183,13 @@ namespace Octopus.Client.Model
 
             foreach (var set in libraryVariableSets)
             {
+#pragma warning disable 618
                 if (!IncludedLibraryVariableSetIds.Contains(set.Id))
+#pragma warning restore 618
                 {
+#pragma warning disable 618
                     IncludedLibraryVariableSetIds.Add(set.Id);
+#pragma warning restore 618
                 }
             }
 

--- a/source/Octopus.Client/Model/ProjectResource.cs
+++ b/source/Octopus.Client/Model/ProjectResource.cs
@@ -84,18 +84,22 @@ namespace Octopus.Client.Model
         /// with the same name and scope definition appearing later in the list.
         /// </summary>
         [Writeable]
+        [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
         public List<string> IncludedLibraryVariableSetIds { get; set; }
 
         [Writeable]
+        [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
         public bool DefaultToSkipIfAlreadyInstalled { get; set; }
 
         [Writeable]
         public TenantedDeploymentMode TenantedDeploymentMode { get; set; }
 
         [Writeable]
+        [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
         public GuidedFailureMode DefaultGuidedFailureMode { get; set; }
 
         [Writeable]
+        [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
         public VersioningStrategyResource VersioningStrategy { get; set; }
 
         [Writeable]
@@ -105,15 +109,18 @@ namespace Octopus.Client.Model
 
         [Writeable]
         [JsonProperty(Order = 45, ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        public ProjectConnectivityPolicy ProjectConnectivityPolicy { get; set; }
+        [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
+        public DeploymentConnectivityPolicy ProjectConnectivityPolicy { get; set; }
 
         [Writeable]
         public ISet<AutoDeployReleaseOverrideResource> AutoDeployReleaseOverrides { get; }
 
         [Writeable]
+        [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
         public string ReleaseNotesTemplate { get; set; }
         
         [Writeable]
+        [Obsolete("Use " + nameof(DeploymentSettingsResource) + " instead on the `deploymentsettings` API.")]
         public string DeploymentChangesTemplate { get; set; }
 
         public ProjectResource Clear()

--- a/source/Octopus.Client/Model/ProjectResource.cs
+++ b/source/Octopus.Client/Model/ProjectResource.cs
@@ -22,7 +22,7 @@ namespace Octopus.Client.Model
 #pragma warning restore 618
             Templates = new List<ActionTemplateParameterResource>();
 #pragma warning disable 618
-            ProjectConnectivityPolicy = new ProjectConnectivityPolicy();
+            ProjectConnectivityPolicy = new DeploymentConnectivityPolicy();
 #pragma warning restore 618
             AutoDeployReleaseOverrides = new HashSet<AutoDeployReleaseOverrideResource>(AutoDeployReleaseOverrideResource.EnvironmentIdTenantIdComparer);
             variableTemplateEditor = new VariableTemplateContainerEditor<ProjectResource>(this);

--- a/source/Octopus.Client/Model/RunbookResource.cs
+++ b/source/Octopus.Client/Model/RunbookResource.cs
@@ -30,7 +30,7 @@ namespace Octopus.Client.Model
 
         [Writeable]
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        public ProjectConnectivityPolicy ConnectivityPolicy { get; set; } = new ProjectConnectivityPolicy() { AllowDeploymentsToNoTargets = true};
+        public DeploymentConnectivityPolicy ConnectivityPolicy { get; set; } = new DeploymentConnectivityPolicy() { AllowDeploymentsToNoTargets = true};
 
         [Writeable]
         public RunbookEnvironmentScope EnvironmentScope { get; set; }

--- a/source/Octopus.Client/Model/VcsRunbookResource.cs
+++ b/source/Octopus.Client/Model/VcsRunbookResource.cs
@@ -12,7 +12,7 @@ namespace Octopus.Client.Model
         public TenantedDeploymentMode MultiTenancyMode { get; set; }
 
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        public ProjectConnectivityPolicy ConnectivityPolicy { get; set; } = new ProjectConnectivityPolicy() { AllowDeploymentsToNoTargets = true};
+        public DeploymentConnectivityPolicy ConnectivityPolicy { get; set; } = new DeploymentConnectivityPolicy() { AllowDeploymentsToNoTargets = true};
 
         public RunbookEnvironmentScope EnvironmentScope { get; set; }
 

--- a/source/Octopus.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Client/OctopusAsyncRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
@@ -71,6 +71,7 @@ namespace Octopus.Client
             Dashboards = new DashboardRepository(this);
             Defects = new DefectsRepository(this);
             DeploymentProcesses = new DeploymentProcessRepository(this);
+            DeploymentSettings = new DeploymentSettingsRepository(this);
             Deployments = new DeploymentRepository(this);
             Environments = new EnvironmentRepository(this);
             Events = new EventRepository(this);
@@ -139,6 +140,7 @@ namespace Octopus.Client
         public IDashboardRepository Dashboards { get; }
         public IDefectsRepository Defects { get; }
         public IDeploymentProcessRepository DeploymentProcesses { get; }
+        public IDeploymentSettingsRepository DeploymentSettings { get; }
         public IDeploymentRepository Deployments { get; }
         public IEnvironmentRepository Environments { get; }
         public IEventRepository Events { get; }

--- a/source/Octopus.Client/OctopusRepository.cs
+++ b/source/Octopus.Client/OctopusRepository.cs
@@ -69,6 +69,7 @@ namespace Octopus.Client
             Dashboards = new DashboardRepository(this);
             Defects = new DefectsRepository(this);
             DeploymentProcesses = new DeploymentProcessRepository(this);
+            DeploymentSettings = new DeploymentSettingsRepository(this);
             Deployments = new DeploymentRepository(this);
             Environments = new EnvironmentRepository(this);
             Events = new EventRepository(this);
@@ -136,6 +137,7 @@ namespace Octopus.Client
         public IDashboardRepository Dashboards { get; }
         public IDefectsRepository Defects { get; }
         public IDeploymentProcessRepository DeploymentProcesses { get; }
+        public IDeploymentSettingsRepository DeploymentSettings { get; }
         public IDeploymentRepository Deployments { get; }
         public IEnvironmentRepository Environments { get; }
         public IEventRepository Events { get; }

--- a/source/Octopus.Client/Repositories/Async/DeploymentSettingsRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DeploymentSettingsRepository.cs
@@ -1,0 +1,75 @@
+using System.Threading.Tasks;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Repositories.Async
+{
+    public interface IDeploymentSettingsRepository
+    {
+        IDeploymentSettingsBetaRepository Beta();
+    }
+
+    class DeploymentSettingsRepository : IDeploymentSettingsRepository
+    {
+        private readonly IDeploymentSettingsBetaRepository beta;
+
+        public DeploymentSettingsRepository(IOctopusAsyncRepository repository)
+        {
+            beta = new DeploymentSettingsBetaRepository(repository);
+        }
+
+        public IDeploymentSettingsBetaRepository Beta()
+        {
+            return beta;
+        }
+    }
+
+    public interface IDeploymentSettingsBetaRepository
+    {
+        Task<DeploymentSettingsResource> Get(ProjectResource project, string gitref = null);
+        Task<DeploymentSettingsResource> Modify(ProjectResource project, DeploymentSettingsResource resource,
+            string commitMessage = null);
+    }
+
+    class DeploymentSettingsBetaRepository : IDeploymentSettingsBetaRepository
+    {
+        private readonly IOctopusAsyncRepository repository;
+        private readonly IOctopusAsyncClient client;
+
+        public DeploymentSettingsBetaRepository(IOctopusAsyncRepository repository)
+        {
+            this.repository = repository;
+            client = repository.Client;
+        }
+
+        public async Task<DeploymentSettingsResource> Get(ProjectResource projectResource, string gitref = null)
+        {
+            if (!string.IsNullOrWhiteSpace(gitref))
+            {
+                var branchResource = await repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitref);
+
+                return await client.Get<DeploymentSettingsResource>(branchResource.Link("DeploymentSettings"));
+            }
+
+            return await client.Get<DeploymentSettingsResource>(projectResource.Link("DeploymentSettings"));
+        }
+
+        public async Task<DeploymentSettingsResource> Modify(ProjectResource projectResource,
+            DeploymentSettingsResource resource, string commitMessage = null)
+        {
+            if (!projectResource.IsVersionControlled)
+            {
+                return await client.Update(projectResource.Link("DeploymentSettings"), resource);
+            }
+
+            var commitResource = new CommitResource<DeploymentSettingsResource>
+            {
+                Resource = resource,
+                CommitMessage = commitMessage
+            };
+
+            await client.Put(resource.Link("Self"), commitResource);
+
+            return await client.Get<DeploymentSettingsResource>(resource.Link("Self"));
+        }
+    }
+}

--- a/source/Octopus.Client/Repositories/DeploymentSettingsRepository.cs
+++ b/source/Octopus.Client/Repositories/DeploymentSettingsRepository.cs
@@ -1,0 +1,72 @@
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Repositories
+{
+    public interface IDeploymentSettingsRepository
+    {
+        IDeploymentSettingsBetaRepository Beta();
+    }
+
+    class DeploymentSettingsRepository : IDeploymentSettingsRepository
+    {
+        private readonly IDeploymentSettingsBetaRepository beta;
+
+        public DeploymentSettingsRepository(IOctopusRepository repository)
+        {
+            beta = new DeploymentSettingsBetaRepository(repository);
+        }
+
+        public IDeploymentSettingsBetaRepository Beta()
+        {
+            return beta;
+        }
+    }
+
+    public interface IDeploymentSettingsBetaRepository
+    {
+        DeploymentSettingsResource Get(ProjectResource project, string gitref = null);
+        DeploymentSettingsResource Modify(ProjectResource project, DeploymentSettingsResource resource, string commitMessage = null);
+    }
+
+    class DeploymentSettingsBetaRepository : IDeploymentSettingsBetaRepository
+    {
+        private readonly IOctopusRepository repository;
+        private readonly IOctopusClient client;
+
+        public DeploymentSettingsBetaRepository(IOctopusRepository repository)
+        {
+            this.repository = repository;
+            client = repository.Client;
+        }
+
+        public DeploymentSettingsResource Get(ProjectResource projectResource, string gitref = null)
+        {
+            if (!string.IsNullOrWhiteSpace(gitref))
+            {
+                var branchResource = repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitref);
+
+                return client.Get<DeploymentSettingsResource>(branchResource.Link("DeploymentSettings"));
+            }
+
+            return client.Get<DeploymentSettingsResource>(projectResource.Link("DeploymentSettings"));
+        }
+
+        public DeploymentSettingsResource Modify(ProjectResource projectResource, DeploymentSettingsResource resource, string commitMessage = null)
+        {
+            if (!projectResource.IsVersionControlled)
+            {
+                return client.Update(projectResource.Link("DeploymentSettings"), resource);
+            }
+
+            var commitResource = new CommitResource<DeploymentSettingsResource>
+            {
+                Resource = resource,
+                CommitMessage = commitMessage
+            };
+
+            client.Put(resource.Link("Self"), commitResource);
+
+            return client.Get<DeploymentSettingsResource>(resource.Link("Self"));
+        }
+    }
+}


### PR DESCRIPTION
Adds support for deployment settings endpoints.

*Note:* this is a breaking change for VCS projects.

## Background

See [Config-as-Code: Project Settings API](https://github.com/OctopusDeploy/Architecture/blob/master/OctopusServer/ConfigAsCode/ConfigAsCodeSettingsAPI.md)

# Before

All projects get/update deployment-related settings via get/modify Project.

# After

Get/Modify Project endpoints:
- Maintain backwards compatibility for db projects. 
- Deployment Settings are no longer populated for VCS projects 
   _in future this will be a [Bad Request](https://github.com/OctopusDeploy/Architecture/blob/master/OctopusServer/ConfigAsCode/ConfigAsCodeSettingsAPI.md#considered-solution-3) - see [implementation](https://github.com/OctopusDeploy/OctopusDeploy/pull/8073/files#diff-4809639251bd9cfba039cb763e088a5632123ede8e8c11c9b8765e276481123cR46) (internal link)_

Get/Modify Deployment Settings endpoints:
- Should be used going forward for both db and CaC projects.

Config as Code, here we come!