### PR TITLE
Use HttpClient consistently across async and sync clients

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -12,8 +12,8 @@ Octopus.Client
     Octopus.Client.IOctopusClient
     IDisposable
   {
-    event Action<WebResponse> AfterReceivingHttpResponse
-    event Action<WebRequest> BeforeSendingHttpRequest
+    event Action<HttpResponseMessage> AfterReceivingHttpResponse
+    event Action<HttpRequestMessage> BeforeSendingHttpRequest
   }
   interface ILinkResolver
   {
@@ -373,8 +373,8 @@ Octopus.Client
     Octopus.Client.IOctopusClient
     IDisposable
   {
-    event Action<WebResponse> AfterReceivingHttpResponse
-    event Action<WebRequest> BeforeSendingHttpRequest
+    event Action<HttpResponseMessage> AfterReceivingHttpResponse
+    event Action<HttpRequestMessage> BeforeSendingHttpRequest
     event Action<OctopusResponse> ReceivedOctopusResponse
     event Action<OctopusRequest> SendingOctopusRequest
     .ctor(Octopus.Client.OctopusServerEndpoint)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -12,8 +12,8 @@ Octopus.Client
     Octopus.Client.IOctopusClient
     IDisposable
   {
-    event Action<WebResponse> AfterReceivingHttpResponse
-    event Action<WebRequest> BeforeSendingHttpRequest
+    event Action<HttpResponseMessage> AfterReceivingHttpResponse
+    event Action<HttpRequestMessage> BeforeSendingHttpRequest
   }
   interface ILinkResolver
   {
@@ -373,8 +373,8 @@ Octopus.Client
     Octopus.Client.IOctopusClient
     IDisposable
   {
-    event Action<WebResponse> AfterReceivingHttpResponse
-    event Action<WebRequest> BeforeSendingHttpRequest
+    event Action<HttpResponseMessage> AfterReceivingHttpResponse
+    event Action<HttpRequestMessage> BeforeSendingHttpRequest
     event Action<OctopusResponse> ReceivedOctopusResponse
     event Action<OctopusRequest> SendingOctopusRequest
     .ctor(Octopus.Client.OctopusServerEndpoint)

--- a/source/Octopus.Client/IHttpOctopusClient.cs
+++ b/source/Octopus.Client/IHttpOctopusClient.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Net;
+using System.Net.Http;
 
 namespace Octopus.Client
 {
@@ -11,11 +11,11 @@ namespace Octopus.Client
         /// <summary>
         /// Occurs when a request is about to be sent.
         /// </summary>
-        event Action<WebRequest> BeforeSendingHttpRequest;
+        event Action<HttpRequestMessage> BeforeSendingHttpRequest;
 
         /// <summary>
         /// Occurs when a response has been received.
         /// </summary>
-        event Action<WebResponse> AfterReceivingHttpResponse;
+        event Action<HttpResponseMessage> AfterReceivingHttpResponse;
     }
 }

--- a/source/Octopus.Client/Octopus.Client.csproj
+++ b/source/Octopus.Client/Octopus.Client.csproj
@@ -11,6 +11,7 @@
 
 This package contains the client library for the HTTP API in Octopus.</Description>
     <NuspecFile>Octopus.Client.nuspec</NuspecFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>

--- a/source/Octopus.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Client/OctopusAsyncClient.cs
@@ -526,9 +526,9 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                     }
                 }
 
-                SendingOctopusRequest?.Invoke(request);
+                OnSendingOctopusRequest(request);
 
-                BeforeSendingHttpRequest?.Invoke(message);
+                OnBeforeSendingHttpRequest(message);
 
                 if (request.RequestResource != null)
                     message.Content = GetContent(request);
@@ -542,7 +542,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                 {
                     using (var response = await client.SendAsync(message, completionOption).ConfigureAwait(false))
                     {
-                        AfterReceivedHttpResponse?.Invoke(response);
+                        OnAfterReceivedHttpResponse(response);
 
                         if (!response.IsSuccessStatusCode)
                             throw await OctopusExceptionFactory.CreateException(response).ConfigureAwait(false);
@@ -554,7 +554,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                         var locationHeader = response.Headers.Location?.OriginalString;
                         var octopusResponse = new OctopusResponse<TResponseResource>(request, response.StatusCode,
                             locationHeader, resource);
-                        ReceivedOctopusResponse?.Invoke(octopusResponse);
+                        OnReceivedOctopusResponse(octopusResponse);
 
                         return octopusResponse;
                     }
@@ -565,6 +565,14 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                 }
             }
         }
+
+        protected virtual void OnSendingOctopusRequest(OctopusRequest request) => SendingOctopusRequest?.Invoke(request);
+
+        protected virtual void OnBeforeSendingHttpRequest(HttpRequestMessage request) => BeforeSendingHttpRequest?.Invoke(request);
+
+        protected virtual void OnAfterReceivedHttpResponse(HttpResponseMessage response) => AfterReceivedHttpResponse?.Invoke(response);
+
+        protected virtual void OnReceivedOctopusResponse(OctopusResponse response) => ReceivedOctopusResponse?.Invoke(response);
 
         private HttpContent GetContent(OctopusRequest request)
         {

--- a/source/Octopus.Client/OctopusClient.cs
+++ b/source/Octopus.Client/OctopusClient.cs
@@ -439,9 +439,9 @@ namespace Octopus.Client
                 }
             }
 
-            SendingOctopusRequest?.Invoke(request);
+            OnSendingOctopusRequest(request);
 
-            BeforeSendingHttpRequest?.Invoke(webRequest);
+            OnBeforeSendingHttpRequest(requestMessage);
 
             HttpWebResponse webResponse = null;
 
@@ -500,7 +500,7 @@ namespace Octopus.Client
                 Logger.Trace($"DispatchRequest: {webRequest.Method} {webRequest.RequestUri}");
 
                 webResponse = (HttpWebResponse)webRequest.GetResponse();
-                AfterReceivingHttpResponse?.Invoke(webResponse);
+                OnAfterReceivingHttpResponse(response);
 
                 var resource = default(TResponseResource);
                 if (readResponse)
@@ -548,7 +548,7 @@ namespace Octopus.Client
 
                 var locationHeader = webResponse.Headers.Get("Location");
                 var octopusResponse = new OctopusResponse<TResponseResource>(request, webResponse.StatusCode, locationHeader, resource);
-                ReceivedOctopusResponse?.Invoke(octopusResponse);
+                OnReceivedOctopusResponse(octopusResponse);
 
                 return octopusResponse;
             }
@@ -576,6 +576,14 @@ namespace Octopus.Client
                 }
             }
         }
+
+        protected virtual void OnBeforeSendingHttpRequest(WebRequest request) => BeforeSendingHttpRequest?.Invoke(request);
+
+        protected virtual void OnAfterReceivingHttpResponse(WebResponse response) => AfterReceivingHttpResponse?.Invoke(response);
+
+        protected virtual void OnSendingOctopusRequest(OctopusRequest request) => SendingOctopusRequest?.Invoke(request);
+
+        protected virtual void OnReceivedOctopusResponse(OctopusResponse response) => ReceivedOctopusResponse?.Invoke(response);
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.


### PR DESCRIPTION
## Description
Use `HttpClient` in both `OctopusClient` and `OctopusAsyncClient`.

## Breaking Changes
- Changes the event signatures for `OctopusClient`. Will require major version bump.