### PR TITLE
Add non-beta path for Deployment Settings endpoints

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7626,6 +7626,8 @@ Octopus.Client.Repositories.Async
   interface IDeploymentSettingsRepository
   {
     Octopus.Client.Repositories.Async.IDeploymentSettingsBetaRepository Beta()
+    Task<DeploymentSettingsResource> Get(Octopus.Client.Model.ProjectResource)
+    Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource)
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7652,6 +7652,8 @@ Octopus.Client.Repositories.Async
   interface IDeploymentSettingsRepository
   {
     Octopus.Client.Repositories.Async.IDeploymentSettingsBetaRepository Beta()
+    Task<DeploymentSettingsResource> Get(Octopus.Client.Model.ProjectResource)
+    Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource)
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>

--- a/source/Octopus.Client/Repositories/Async/DeploymentSettingsRepository.cs
+++ b/source/Octopus.Client/Repositories/Async/DeploymentSettingsRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -6,6 +7,9 @@ namespace Octopus.Client.Repositories.Async
     public interface IDeploymentSettingsRepository
     {
         IDeploymentSettingsBetaRepository Beta();
+
+        Task<DeploymentSettingsResource> Get(ProjectResource project);
+        Task<DeploymentSettingsResource> Modify(ProjectResource project, DeploymentSettingsResource resource);
     }
 
     class DeploymentSettingsRepository : IDeploymentSettingsRepository
@@ -16,10 +20,19 @@ namespace Octopus.Client.Repositories.Async
         {
             beta = new DeploymentSettingsBetaRepository(repository);
         }
-
         public IDeploymentSettingsBetaRepository Beta()
         {
             return beta;
+        }
+
+        public Task<DeploymentSettingsResource> Get(ProjectResource project)
+        {
+            return beta.Get(project);
+        }
+
+        public Task<DeploymentSettingsResource> Modify(ProjectResource project, DeploymentSettingsResource resource)
+        {
+            return beta.Modify(project, resource);
         }
     }
 


### PR DESCRIPTION
# Background
Deployment Settings props on `ProjectResource` have been [deprecated](https://github.com/OctopusDeploy/OctopusClients/blob/8a6acb14a9e412d5829560cebd2963d86a89dccd/source/Octopus.Client/Model/ProjectResource.cs#L94). This was done to unlock functionality for Config as Code - allowing these settings to persist to git. 

The supported path forward for Database Projects (i.e. traditional non-version controlled projects in Octopus Deploy) is to modify these settings via 

```http
POST api/projects/{projectId}/deploymentsettings
``` 

In future `POST projects/{projectId}/{gitRef}/deploymentsettings` will also be supported.

## Current workaround
```csharp
octopusRepository.Client.Post($"projects/{projectResource.Id}/deploymentsettings", deploymentSettingsResource);
```

# Results

This PR provides a strong typing for the supported (i.e. non-beta) endpoint for DeploymentSettings for DB projects.

```csharp
octopusRepository.DeploymentSettings.Modify(projectResource, deploymentSettingsResource);
```