### PR TITLE
Add IGetAll<> interface to the IChannelRepository

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -177,7 +177,7 @@ class Build : NukeBuild
             .SetFiles(files.Select(x => x.ToString()).ToArray())
             .SetProcessToolPath(RootDirectory / "certificates" / "signtool.exe")
             .SetTimestampServerDigestAlgorithm("sha256")
-            .SetRfc3161TimestampServerUrl("http://rfc3161timestamp.globalsign.com/advanced"));
+            .SetRfc3161TimestampServerUrl("https://rfc3161timestamp.globalsign.com/advanced"));
     }
 
 

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6766,6 +6766,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<ChannelResource>
     Octopus.Client.Repositories.IDelete<ChannelResource>
     Octopus.Client.Repositories.IPaginate<ChannelResource>
+    Octopus.Client.Repositories.IGetAll<ChannelResource>
   {
     Octopus.Client.Editors.ChannelEditor CreateOrModify(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Editors.ChannelEditor CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6791,6 +6791,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<ChannelResource>
     Octopus.Client.Repositories.IDelete<ChannelResource>
     Octopus.Client.Repositories.IPaginate<ChannelResource>
+    Octopus.Client.Repositories.IGetAll<ChannelResource>
   {
     Octopus.Client.Editors.ChannelEditor CreateOrModify(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Editors.ChannelEditor CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)

--- a/source/Octopus.Client/Repositories/ChannelRepository.cs
+++ b/source/Octopus.Client/Repositories/ChannelRepository.cs
@@ -4,7 +4,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
 {
-    public interface IChannelRepository : ICreate<ChannelResource>, IModify<ChannelResource>, IGet<ChannelResource>, IDelete<ChannelResource>, IPaginate<ChannelResource>
+    public interface IChannelRepository : ICreate<ChannelResource>, IModify<ChannelResource>, IGet<ChannelResource>, IDelete<ChannelResource>, IPaginate<ChannelResource>, IGetAll<ChannelResource>
     {
         ChannelResource FindByName(ProjectResource project, string name);
         ChannelEditor CreateOrModify(ProjectResource project, string name);


### PR DESCRIPTION
We support the `/all` endpoint in[ OctopusServer for Channels](https://github.com/OctopusDeploy/OctopusDeploy/blob/1f1a7a667daa86a14e8dee4f448d346c3b673389/source/Octopus.Server/Web/Api/Actions/Channels/ChannelsNancyModule.cs#L27) so in to synchronize the surface area we should probably ensure the C# client can interact with it.