### PR TITLE
Improve Tentacle command line validation

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6573,6 +6573,12 @@ Octopus.Client.Model.Versioning
 }
 Octopus.Client.Operations
 {
+  class InvalidRegistrationArgumentsException
+    ISerializable
+    ArgumentException
+  {
+    .ctor(String)
+  }
   interface IRegisterMachineOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6598,6 +6598,13 @@ Octopus.Client.Model.Versioning
 }
 Octopus.Client.Operations
 {
+  class InvalidRegistrationArgumentsException
+    ISerializable
+    _Exception
+    ArgumentException
+  {
+    .ctor(String)
+  }
   interface IRegisterMachineOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
   {

--- a/source/Octopus.Client/Operations/InvalidRegistrationArgumentsException.cs
+++ b/source/Octopus.Client/Operations/InvalidRegistrationArgumentsException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Octopus.Client.Operations
+{
+    public class InvalidRegistrationArgumentsException : ArgumentException
+    {
+        public InvalidRegistrationArgumentsException(string message)
+            : base(message)
+        { }
+    }
+}

--- a/source/Octopus.Client/Operations/RegisterMachineOperation.cs
+++ b/source/Octopus.Client/Operations/RegisterMachineOperation.cs
@@ -61,7 +61,7 @@ namespace Octopus.Client.Operations
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="repository">The Octopus Deploy server repository.</param>
-        /// <exception cref="System.ArgumentException">
+        /// <exception cref="InvalidRegistrationArgumentsException">
         /// </exception>
         public override void Execute(IOctopusSpaceRepository repository)
         {
@@ -95,7 +95,7 @@ namespace Octopus.Client.Operations
             missing = missing.Except(tenantsById.Select(e => e.Id), StringComparer.OrdinalIgnoreCase).ToArray();
 
             if (missing.Any())
-                throw new ArgumentException(CouldNotFindMessage("tenant", missing));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("tenant", missing));
 
             return tenantsById.Concat(tenantsByName).ToList();
         }
@@ -109,7 +109,7 @@ namespace Octopus.Client.Operations
             var missingTags = TenantTags.Where(tt => !tagSets.Any(ts => ts.Tags.Any(t => t.CanonicalTagName.Equals(tt, StringComparison.OrdinalIgnoreCase)))).ToList();
 
             if (missingTags.Any())
-                throw new ArgumentException(CouldNotFindMessage("tag", missingTags.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("tag", missingTags.ToArray()));
         }
 
         List<EnvironmentResource> GetEnvironments(IOctopusSpaceRepository repository)
@@ -119,7 +119,7 @@ namespace Octopus.Client.Operations
             var missing = EnvironmentNames.Except(selectedEnvironments.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToList();
 
             if (missing.Any())
-                throw new ArgumentException(CouldNotFindMessage("environment", missing.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("environment", missing.ToArray()));
 
             return selectedEnvironments;
         }
@@ -131,7 +131,7 @@ namespace Octopus.Client.Operations
             {
                 existing = repository.Machines.FindByName(MachineName);
                 if (!AllowOverwrite && existing?.Id != null)
-                    throw new ArgumentException($"A machine named '{MachineName}' already exists on the Octopus Server in the target space. Use the 'force' parameter if you intended to update the existing machine.");
+                    throw new InvalidRegistrationArgumentsException($"A machine named '{MachineName}' already exists on the Octopus Server in the target space. Use the 'force' parameter if you intended to update the existing machine.");
             }
             catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
             {
@@ -143,7 +143,7 @@ namespace Octopus.Client.Operations
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="repository">The Octopus Deploy server repository.</param>
-        /// <exception cref="System.ArgumentException">
+        /// <exception cref="InvalidRegistrationArgumentsException">
         /// </exception>
         public override async Task ExecuteAsync(IOctopusSpaceAsyncRepository repository)
         {
@@ -185,7 +185,7 @@ namespace Octopus.Client.Operations
             missing = missing.Except(tenantsById.Select(e => e.Id), StringComparer.OrdinalIgnoreCase).ToArray();
 
             if (missing.Any())
-                throw new ArgumentException(CouldNotFindMessage("tenant", missing));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("tenant", missing));
 
             return tenantsById.Concat(tenantsByName).ToList();
         }
@@ -199,7 +199,7 @@ namespace Octopus.Client.Operations
             var missingTags = TenantTags.Where(tt => !tagSets.Any(ts => ts.Tags.Any(t => t.CanonicalTagName.Equals(tt, StringComparison.OrdinalIgnoreCase)))).ToList();
 
             if (missingTags.Any())
-                throw new ArgumentException(CouldNotFindMessage("tag", missingTags.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("tag", missingTags.ToArray()));
         }
 
         async Task<List<EnvironmentResource>> GetEnvironments(IOctopusSpaceAsyncRepository repository)
@@ -215,7 +215,7 @@ namespace Octopus.Client.Operations
             var missing = EnvironmentNames.Except(selectedEnvironments.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToList();
 
             if (missing.Any())
-                throw new ArgumentException(CouldNotFindMessage("environment", missing.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("environment", missing.ToArray()));
 
             return selectedEnvironments;
         }
@@ -227,7 +227,7 @@ namespace Octopus.Client.Operations
             {
                 existing = await repository.Machines.FindByName(MachineName).ConfigureAwait(false);
                 if (!AllowOverwrite && existing?.Id != null)
-                    throw new ArgumentException($"A machine named '{MachineName}' already exists in the environment. Use the 'force' parameter if you intended to update the existing machine.");
+                    throw new InvalidRegistrationArgumentsException($"A machine named '{MachineName}' already exists in the environment. Use the 'force' parameter if you intended to update the existing machine.");
             }
             catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
             {

--- a/source/Octopus.Client/Operations/RegisterWorkerOperation.cs
+++ b/source/Octopus.Client/Operations/RegisterWorkerOperation.cs
@@ -39,7 +39,7 @@ namespace Octopus.Client.Operations
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="repository">The Octopus Deploy server repository.</param>
-        /// <exception cref="System.ArgumentException">
+        /// <exception cref="InvalidRegistrationArgumentsException">
         /// </exception>
         public override void Execute(IOctopusSpaceRepository repository)
         {
@@ -65,7 +65,7 @@ namespace Octopus.Client.Operations
             var missing = WorkerPoolNames.Except(selectedPools.Select(p => p.Name), StringComparer.OrdinalIgnoreCase).ToList();
 
             if (missing.Any())
-                throw new ArgumentException(CouldNotFindMessage("worker pool", missing.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("worker pool", missing.ToArray()));
 
             return selectedPools;
         }
@@ -77,7 +77,7 @@ namespace Octopus.Client.Operations
             {
                 existing = repository.Workers.FindByName(MachineName);
                 if (!AllowOverwrite && existing?.Id != null)
-                    throw new ArgumentException($"A worker named '{MachineName}' already exists. Use the 'force' parameter if you intended to update the existing machine.");
+                    throw new InvalidRegistrationArgumentsException($"A worker named '{MachineName}' already exists. Use the 'force' parameter if you intended to update the existing machine.");
             }
             catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
             {
@@ -89,7 +89,7 @@ namespace Octopus.Client.Operations
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
         /// <param name="repository">The Octopus Deploy server repository.</param>
-        /// <exception cref="System.ArgumentException">
+        /// <exception cref="InvalidRegistrationArgumentsException">
         /// </exception>
         public override async Task ExecuteAsync(IOctopusSpaceAsyncRepository repository)
         {
@@ -116,7 +116,7 @@ namespace Octopus.Client.Operations
             var missing = WorkerPoolNames.Except(selectedPools.Select(p => p.Name), StringComparer.OrdinalIgnoreCase).ToList();
 
             if (missing.Any())
-                throw new ArgumentException(CouldNotFindMessage("worker pool", missing.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("worker pool", missing.ToArray()));
 
             return selectedPools;
         }
@@ -128,7 +128,7 @@ namespace Octopus.Client.Operations
             {
                 existing = await repository.Workers.FindByName(MachineName).ConfigureAwait(false);
                 if (!AllowOverwrite && existing?.Id != null)
-                    throw new ArgumentException($"A worker named '{MachineName}' already exists. Use the 'force' parameter if you intended to update the existing machine.");
+                    throw new InvalidRegistrationArgumentsException($"A worker named '{MachineName}' already exists. Use the 'force' parameter if you intended to update the existing machine.");
             }
             catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
             {


### PR DESCRIPTION
This PR changes the type of exception thrown when validation arguments for the `register-with` and `register-worker` commands from `ArgumentException` to a new custom type `InvalidRegistrationArgumentsException`, so we can handle it better.

The new type inherits from `ArgumentException`, so this should be backwards compatible.

This PR is required by https://github.com/OctopusDeploy/OctopusTentacle/pull/282.

## Review

Please confirm my thinking that this is backwards compatible.
Other than that, :eyes: and a 💚 build should be sufficient for this PR.