### PR TITLE
Add step package deployment targets

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2251,6 +2251,7 @@ Octopus.Client.Model
       AzureCloudService = 7
       AzureServiceFabricCluster = 8
       Kubernetes = 9
+      StepPackage = 10
   }
   class CommunityActionTemplateResource
     Octopus.Client.Extensibility.IResource
@@ -6063,6 +6064,15 @@ Octopus.Client.Model.Endpoints
       static System.String Linux64
       static System.String Osx64
     }
+  }
+  class StepPackageEndpointResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Endpoints.EndpointResource
+  {
+    .ctor()
+    Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
+    String Inputs { get; set; }
   }
   class TentacleDetailsResource
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6073,6 +6073,7 @@ Octopus.Client.Model.Endpoints
     .ctor()
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
     String Inputs { get; set; }
+    String StepPackageId { get; set; }
   }
   class TentacleDetailsResource
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2267,6 +2267,7 @@ Octopus.Client.Model
       AzureCloudService = 7
       AzureServiceFabricCluster = 8
       Kubernetes = 9
+      StepPackage = 10
   }
   class CommunityActionTemplateResource
     Octopus.Client.Extensibility.IResource
@@ -6088,6 +6089,15 @@ Octopus.Client.Model.Endpoints
       static System.String Linux64
       static System.String Osx64
     }
+  }
+  class StepPackageEndpointResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Endpoints.EndpointResource
+  {
+    .ctor()
+    Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
+    String Inputs { get; set; }
   }
   class TentacleDetailsResource
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6098,6 +6098,7 @@ Octopus.Client.Model.Endpoints
     .ctor()
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
     String Inputs { get; set; }
+    String StepPackageId { get; set; }
   }
   class TentacleDetailsResource
   {

--- a/source/Octopus.Client/Model/CommunicationStyle.cs
+++ b/source/Octopus.Client/Model/CommunicationStyle.cs
@@ -29,6 +29,8 @@ namespace Octopus.Client.Model
 
         AzureServiceFabricCluster = 8,
 
-        [SupportedAccountTypes(AccountType.UsernamePassword)] [ScriptConsoleSupported] Kubernetes = 9
+        [SupportedAccountTypes(AccountType.UsernamePassword)] [ScriptConsoleSupported] Kubernetes = 9,
+        
+        StepPackage = 10
     }
 }

--- a/source/Octopus.Client/Model/Endpoints/StepPackageEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/StepPackageEndpointResource.cs
@@ -1,0 +1,13 @@
+﻿using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.Endpoints
+{
+    public class StepPackageEndpointResource : EndpointResource
+    {
+        public override CommunicationStyle CommunicationStyle => CommunicationStyle.StepPackage;
+
+        [Trim]
+        [Writeable]
+        public string Inputs { get; set; }
+    }
+}

--- a/source/Octopus.Client/Model/Endpoints/StepPackageEndpointResource.cs
+++ b/source/Octopus.Client/Model/Endpoints/StepPackageEndpointResource.cs
@@ -9,5 +9,9 @@ namespace Octopus.Client.Model.Endpoints
         [Trim]
         [Writeable]
         public string Inputs { get; set; }
+        
+        [Trim]
+        [Writeable]
+        public string StepPackageId { get; set; }
     }
 }

--- a/source/Octopus.Client/Serialization/EndpointConverter.cs
+++ b/source/Octopus.Client/Serialization/EndpointConverter.cs
@@ -21,7 +21,8 @@ namespace Octopus.Client.Serialization
                 {CommunicationStyle.AzureWebApp, typeof (AzureWebAppEndpointResource)},
                 {CommunicationStyle.None, typeof (CloudRegionEndpointResource)},
                 {CommunicationStyle.Kubernetes, typeof (KubernetesEndpointResource)},
-                {CommunicationStyle.AzureServiceFabricCluster, typeof(ServiceFabricEndpointResource)}
+                {CommunicationStyle.AzureServiceFabricCluster, typeof(ServiceFabricEndpointResource)},
+                {CommunicationStyle.StepPackage, typeof(StepPackageEndpointResource)}
           };
 
         protected override IDictionary<CommunicationStyle, Type> DerivedTypeMappings => EndpointTypes;


### PR DESCRIPTION
Adds StepPackageEndpointResource to the client to enable integration tests within Server. Due to endpoints using a custom serializer this is not possible to do by extending Client within Server project.