### PR TITLE
Added a Repository implementation for project-scoped resources

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6946,7 +6946,6 @@ Octopus.Client.Repositories
   interface IGetProjectScoped`1
   {
     Octopus.Client.Repositories.TResource Get(Octopus.Client.Model.ProjectResource, String)
-    List<TResource> Get(Octopus.Client.Model.ProjectResource, String[])
   }
   interface IGet`1
   {
@@ -7719,7 +7718,6 @@ Octopus.Client.Repositories.Async
   interface IGetProjectScoped`1
   {
     Task<TResource> Get(Octopus.Client.Model.ProjectResource, String)
-    Task<List<TResource>> Get(Octopus.Client.Model.ProjectResource, String[])
   }
   interface IGet`1
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2191,6 +2191,7 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Extensibility.INamedResource
     Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveProject
     Octopus.Client.Model.Resource
   {
     .ctor()
@@ -3085,6 +3086,10 @@ Octopus.Client.Model
     String TenantId { get; set; }
     Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
     Boolean UseGuidedFailure { get; set; }
+  }
+  interface IHaveProject
+  {
+    String ProjectId { get; set; }
   }
   class InterruptionResource
     Octopus.Client.Extensibility.IResource
@@ -6803,6 +6808,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICreateProjectScoped<ChannelResource>
     Octopus.Client.Repositories.IModify<ChannelResource>
     Octopus.Client.Repositories.IGet<ChannelResource>
+    Octopus.Client.Repositories.IGetProjectScoped<ChannelResource>
     Octopus.Client.Repositories.IDelete<ChannelResource>
     Octopus.Client.Repositories.IPaginate<ChannelResource>
     Octopus.Client.Repositories.IGetAll<ChannelResource>
@@ -6936,6 +6942,11 @@ Octopus.Client.Repositories
   interface IGetAll`1
   {
     List<TResource> GetAll()
+  }
+  interface IGetProjectScoped`1
+  {
+    Octopus.Client.Repositories.TResource Get(Octopus.Client.Model.ProjectResource, String)
+    List<TResource> Get(Octopus.Client.Model.ProjectResource, String[])
   }
   interface IGet`1
   {
@@ -7566,6 +7577,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.ICreateProjectScoped<ChannelResource>
     Octopus.Client.Repositories.Async.IModify<ChannelResource>
     Octopus.Client.Repositories.Async.IGet<ChannelResource>
+    Octopus.Client.Repositories.Async.IGetProjectScoped<ChannelResource>
     Octopus.Client.Repositories.Async.IDelete<ChannelResource>
     Octopus.Client.Repositories.Async.IPaginate<ChannelResource>
   {
@@ -7703,6 +7715,11 @@ Octopus.Client.Repositories.Async
   interface IGetAll`1
   {
     Task<List<TResource>> GetAll()
+  }
+  interface IGetProjectScoped`1
+  {
+    Task<TResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<List<TResource>> Get(Octopus.Client.Model.ProjectResource, String[])
   }
   interface IGet`1
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2207,6 +2207,7 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Extensibility.INamedResource
     Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveProject
     Octopus.Client.Model.Resource
   {
     .ctor()
@@ -3101,6 +3102,10 @@ Octopus.Client.Model
     String TenantId { get; set; }
     Octopus.Client.Model.RetentionPeriod TentacleRetentionPeriod { get; set; }
     Boolean UseGuidedFailure { get; set; }
+  }
+  interface IHaveProject
+  {
+    String ProjectId { get; set; }
   }
   class InterruptionResource
     Octopus.Client.Extensibility.IResource
@@ -6829,6 +6834,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICreateProjectScoped<ChannelResource>
     Octopus.Client.Repositories.IModify<ChannelResource>
     Octopus.Client.Repositories.IGet<ChannelResource>
+    Octopus.Client.Repositories.IGetProjectScoped<ChannelResource>
     Octopus.Client.Repositories.IDelete<ChannelResource>
     Octopus.Client.Repositories.IPaginate<ChannelResource>
     Octopus.Client.Repositories.IGetAll<ChannelResource>
@@ -6962,6 +6968,11 @@ Octopus.Client.Repositories
   interface IGetAll`1
   {
     List<TResource> GetAll()
+  }
+  interface IGetProjectScoped`1
+  {
+    Octopus.Client.Repositories.TResource Get(Octopus.Client.Model.ProjectResource, String)
+    List<TResource> Get(Octopus.Client.Model.ProjectResource, String[])
   }
   interface IGet`1
   {
@@ -7592,6 +7603,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.ICreateProjectScoped<ChannelResource>
     Octopus.Client.Repositories.Async.IModify<ChannelResource>
     Octopus.Client.Repositories.Async.IGet<ChannelResource>
+    Octopus.Client.Repositories.Async.IGetProjectScoped<ChannelResource>
     Octopus.Client.Repositories.Async.IDelete<ChannelResource>
     Octopus.Client.Repositories.Async.IPaginate<ChannelResource>
   {
@@ -7729,6 +7741,11 @@ Octopus.Client.Repositories.Async
   interface IGetAll`1
   {
     Task<List<TResource>> GetAll()
+  }
+  interface IGetProjectScoped`1
+  {
+    Task<TResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<List<TResource>> Get(Octopus.Client.Model.ProjectResource, String[])
   }
   interface IGet`1
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6972,7 +6972,6 @@ Octopus.Client.Repositories
   interface IGetProjectScoped`1
   {
     Octopus.Client.Repositories.TResource Get(Octopus.Client.Model.ProjectResource, String)
-    List<TResource> Get(Octopus.Client.Model.ProjectResource, String[])
   }
   interface IGet`1
   {
@@ -7745,7 +7744,6 @@ Octopus.Client.Repositories.Async
   interface IGetProjectScoped`1
   {
     Task<TResource> Get(Octopus.Client.Model.ProjectResource, String)
-    Task<List<TResource>> Get(Octopus.Client.Model.ProjectResource, String[])
   }
   interface IGet`1
   {

--- a/source/Octopus.Server.Client/Model/ChannelResource.cs
+++ b/source/Octopus.Server.Client/Model/ChannelResource.cs
@@ -5,7 +5,7 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model
 {
-    public class ChannelResource : Resource, INamedResource, IHaveSpaceResource
+    public class ChannelResource : Resource, INamedResource, IHaveSpaceResource, IHaveProject
     {
         public ChannelResource()
         {

--- a/source/Octopus.Server.Client/Model/IHaveProject.cs
+++ b/source/Octopus.Server.Client/Model/IHaveProject.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model
+{
+    public interface IHaveProject
+    {
+        string ProjectId { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/Async/IGet.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IGet.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
@@ -9,5 +10,11 @@ namespace Octopus.Client.Repositories.Async
         Task<TResource> Get(string idOrHref);
         Task<List<TResource>> Get(params string[] ids);
         Task<TResource> Refresh(TResource resource);
+    }
+
+    public interface IGetProjectScoped<TResource>
+    {
+        Task<TResource> Get(ProjectResource projectResource, string idOrHref);
+        Task<List<TResource>> Get(ProjectResource projectResource, params string[] ids);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/IGet.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IGet.cs
@@ -15,6 +15,5 @@ namespace Octopus.Client.Repositories.Async
     public interface IGetProjectScoped<TResource>
     {
         Task<TResource> Get(ProjectResource projectResource, string idOrHref);
-        Task<List<TResource>> Get(ProjectResource projectResource, params string[] ids);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectScopedRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectScopedRepository.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Octopus.Client.Exceptions;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Util;
+using Octopus.Client.Validation;
+
+namespace Octopus.Client.Repositories.Async
+{
+    // ReSharper disable MemberCanBePrivate.Local
+    // ReSharper disable UnusedMember.Local
+    // ReSharper disable MemberCanBeProtected.Local
+    abstract class ProjectScopedRepository<TResource> : BasicRepository<TResource> where TResource : class, IResource, IHaveProject
+    {
+        protected ProjectScopedRepository(
+            IOctopusAsyncRepository repository,
+            string collectionLinkName,
+            Func<IOctopusAsyncRepository, Task<string>> getCollectionLinkName = null)
+        : base(repository, collectionLinkName, getCollectionLinkName)
+        {
+        }
+
+        public override async Task<TResource> Create(TResource resource, object pathParameters = null)
+        {
+            var projectResource = await Repository.Projects.Get(resource.ProjectId);
+            if (projectResource.PersistenceSettings.Type == PersistenceSettingsType.VersionControlled)
+            {
+                return await Create(projectResource, resource, pathParameters);
+            }
+
+            return await base.Create(resource, pathParameters);
+        }
+
+        public async Task<TResource> Create(ProjectResource projectResource, TResource resource, object pathParameters = null)
+        {
+            await ThrowIfServerVersionIsNotCompatible();
+
+            var link = projectResource.Link(CollectionLinkName);
+            EnrichSpaceId(resource);
+            return await Client.Create(link, resource, pathParameters).ConfigureAwait(false);
+        }
+
+        public async Task<TResource> Get(ProjectResource projectResource, string idOrHref)
+        {
+            await ThrowIfServerVersionIsNotCompatible();
+
+            if (string.IsNullOrWhiteSpace(idOrHref))
+                return null;
+
+            var link = projectResource.Link(CollectionLinkName);
+            var additionalQueryParameters = GetAdditionalQueryParameters();
+            var parameters = ParameterHelper.CombineParameters(additionalQueryParameters, new { id = idOrHref });
+            var  getTask = idOrHref.StartsWith("/", StringComparison.OrdinalIgnoreCase)
+                ? Client.Get<TResource>(idOrHref, additionalQueryParameters).ConfigureAwait(false)
+                : Client.Get<TResource>(link, parameters).ConfigureAwait(false);
+            return await getTask;
+        }
+
+        public async Task<List<TResource>> Get(ProjectResource projectResource, params string[] ids)
+        {
+            await ThrowIfServerVersionIsNotCompatible();
+
+            if (ids == null) return new List<TResource>();
+            var actualIds = ids.Where(id => !string.IsNullOrWhiteSpace(id)).ToArray();
+            if (actualIds.Length == 0) return new List<TResource>();
+
+            var resources = new List<TResource>();
+
+            var link = projectResource.Link(CollectionLinkName);
+            if (!Regex.IsMatch(link, @"\{\?.*\Wids\W"))
+                link += "{?ids}";
+
+            var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new { ids = actualIds });
+            await Client.Paginate<TResource>(
+                    link,
+                    parameters,
+                    page =>
+                    {
+                        resources.AddRange(page.Items);
+                        return true;
+                    })
+                .ConfigureAwait(false);
+
+            return resources;
+        }
+    }
+
+    // ReSharper restore MemberCanBePrivate.Local
+    // ReSharper restore UnusedMember.Local
+    // ReSharper restore MemberCanBeProtected.Local
+}

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectScopedRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectScopedRepository.cs
@@ -44,48 +44,16 @@ namespace Octopus.Client.Repositories.Async
             return await Client.Create(link, resource, pathParameters).ConfigureAwait(false);
         }
 
-        public async Task<TResource> Get(ProjectResource projectResource, string idOrHref)
+        public async Task<TResource> Get(ProjectResource projectResource, string id)
         {
             await ThrowIfServerVersionIsNotCompatible();
 
-            if (string.IsNullOrWhiteSpace(idOrHref))
+            if (string.IsNullOrWhiteSpace(id))
                 return null;
 
-            var link = projectResource.Link(CollectionLinkName);
+            var link = $"{projectResource.Link(CollectionLinkName)}/{id}";
             var additionalQueryParameters = GetAdditionalQueryParameters();
-            var parameters = ParameterHelper.CombineParameters(additionalQueryParameters, new { id = idOrHref });
-            var  getTask = idOrHref.StartsWith("/", StringComparison.OrdinalIgnoreCase)
-                ? Client.Get<TResource>(idOrHref, additionalQueryParameters).ConfigureAwait(false)
-                : Client.Get<TResource>(link, parameters).ConfigureAwait(false);
-            return await getTask;
-        }
-
-        public async Task<List<TResource>> Get(ProjectResource projectResource, params string[] ids)
-        {
-            await ThrowIfServerVersionIsNotCompatible();
-
-            if (ids == null) return new List<TResource>();
-            var actualIds = ids.Where(id => !string.IsNullOrWhiteSpace(id)).ToArray();
-            if (actualIds.Length == 0) return new List<TResource>();
-
-            var resources = new List<TResource>();
-
-            var link = projectResource.Link(CollectionLinkName);
-            if (!Regex.IsMatch(link, @"\{\?.*\Wids\W"))
-                link += "{?ids}";
-
-            var parameters = ParameterHelper.CombineParameters(GetAdditionalQueryParameters(), new { ids = actualIds });
-            await Client.Paginate<TResource>(
-                    link,
-                    parameters,
-                    page =>
-                    {
-                        resources.AddRange(page.Items);
-                        return true;
-                    })
-                .ConfigureAwait(false);
-
-            return resources;
+            return await Client.Get<TResource>(link, additionalQueryParameters).ConfigureAwait(false);
         }
     }
 

--- a/source/Octopus.Server.Client/Repositories/IGet.cs
+++ b/source/Octopus.Server.Client/Repositories/IGet.cs
@@ -14,6 +14,5 @@ namespace Octopus.Client.Repositories
     public interface IGetProjectScoped<TResource>
     {
         TResource Get(ProjectResource projectResource, string idOrHref);
-        List<TResource> Get(ProjectResource projectResource, params string[] ids);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/IGet.cs
+++ b/source/Octopus.Server.Client/Repositories/IGet.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
 {
@@ -8,5 +9,11 @@ namespace Octopus.Client.Repositories
         TResource Get(string idOrHref);
         List<TResource> Get(params string[] ids);
         TResource Refresh(TResource resource);
+    }
+
+    public interface IGetProjectScoped<TResource>
+    {
+        TResource Get(ProjectResource projectResource, string idOrHref);
+        List<TResource> Get(ProjectResource projectResource, params string[] ids);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/ProjectScopedRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ProjectScopedRepository.cs
@@ -41,44 +41,14 @@ namespace Octopus.Client.Repositories
             return Client.Create(link, resource, pathParameters);
         }
 
-        public TResource Get(ProjectResource projectResource, string idOrHref)
+        public TResource Get(ProjectResource projectResource, string id)
         {
             ThrowIfServerVersionIsNotCompatible();
 
-            if (string.IsNullOrWhiteSpace(idOrHref))
+            if (string.IsNullOrWhiteSpace(id))
                 return null;
-            var link = projectResource.Link(CollectionLinkName);
-            if (idOrHref.StartsWith("/", StringComparison.OrdinalIgnoreCase))
-            {
-                return Client.Get<TResource>(idOrHref, AdditionalQueryParameters);
-            }
-            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new { id = idOrHref });
-            return Client.Get<TResource>(link, parameters);
-        }
-
-        public  List<TResource> Get(ProjectResource projectResource, params string[] ids)
-        {
-            ThrowIfServerVersionIsNotCompatible();
-
-            if (ids == null) return new List<TResource>();
-            var actualIds = ids.Where(id => !string.IsNullOrWhiteSpace(id)).ToArray();
-            if (actualIds.Length == 0) return new List<TResource>();
-
-            var resources = new List<TResource>();
-            var link = projectResource.Link(CollectionLinkName);
-            if (!Regex.IsMatch(link, @"\{\?.*\Wids\W"))
-                link += "{?ids}";
-            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new { ids = actualIds });
-            Client.Paginate<TResource>(
-                link,
-                parameters,
-                page =>
-                {
-                    resources.AddRange(page.Items);
-                    return true;
-                });
-
-            return resources;
+            var link = $"{projectResource.Link(CollectionLinkName)}/{id}";
+            return Client.Get<TResource>(link, AdditionalQueryParameters);
         }
     }
 

--- a/source/Octopus.Server.Client/Repositories/ProjectScopedRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ProjectScopedRepository.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Util;
+
+namespace Octopus.Client.Repositories
+{
+    // ReSharper disable MemberCanBePrivate.Local
+    // ReSharper disable UnusedMember.Local
+    // ReSharper disable MemberCanBeProtected.Local
+    abstract class ProjectScopedRepository<TResource> : BasicRepository<TResource> where TResource : class, IResource, IHaveProject
+    {
+        protected ProjectScopedRepository(
+            IOctopusRepository repository,
+            string collectionLinkName,
+            Func<IOctopusRepository, string> getCollectionLinkName = null)
+        : base(repository, collectionLinkName, getCollectionLinkName)
+        {
+        }
+
+        public override TResource Create(TResource resource, object pathParameters = null)
+        {
+            var projectResource = Repository.Projects.Get(resource.ProjectId);
+            if (projectResource.PersistenceSettings.Type == PersistenceSettingsType.VersionControlled)
+            {
+                return Create(projectResource, resource, pathParameters);
+            }
+
+            return base.Create(resource, pathParameters);
+        }
+
+        public TResource Create(ProjectResource projectResource, TResource resource, object pathParameters = null)
+        {
+            ThrowIfServerVersionIsNotCompatible();
+
+            var link = projectResource.Link(CollectionLinkName);
+            EnrichSpaceId(resource);
+            return Client.Create(link, resource, pathParameters);
+        }
+
+        public TResource Get(ProjectResource projectResource, string idOrHref)
+        {
+            ThrowIfServerVersionIsNotCompatible();
+
+            if (string.IsNullOrWhiteSpace(idOrHref))
+                return null;
+            var link = projectResource.Link(CollectionLinkName);
+            if (idOrHref.StartsWith("/", StringComparison.OrdinalIgnoreCase))
+            {
+                return Client.Get<TResource>(idOrHref, AdditionalQueryParameters);
+            }
+            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new { id = idOrHref });
+            return Client.Get<TResource>(link, parameters);
+        }
+
+        public  List<TResource> Get(ProjectResource projectResource, params string[] ids)
+        {
+            ThrowIfServerVersionIsNotCompatible();
+
+            if (ids == null) return new List<TResource>();
+            var actualIds = ids.Where(id => !string.IsNullOrWhiteSpace(id)).ToArray();
+            if (actualIds.Length == 0) return new List<TResource>();
+
+            var resources = new List<TResource>();
+            var link = projectResource.Link(CollectionLinkName);
+            if (!Regex.IsMatch(link, @"\{\?.*\Wids\W"))
+                link += "{?ids}";
+            var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new { ids = actualIds });
+            Client.Paginate<TResource>(
+                link,
+                parameters,
+                page =>
+                {
+                    resources.AddRange(page.Items);
+                    return true;
+                });
+
+            return resources;
+        }
+    }
+
+    // ReSharper restore MemberCanBePrivate.Local
+    // ReSharper restore UnusedMember.Local
+    // ReSharper restore MemberCanBeProtected.Local
+}


### PR DESCRIPTION
# Background
As we move towards a world where where project scoped resources (E.g. Channels) are accessed using the project route (`/projects/{projectId}/channels`) rather than their standalone routes (`/channels`), we're gonna see our C# client library change to reflect that.

# Results
This PR introduces a new Repository implementation based off of the `BasicRepository<TResource>`, which has project scoped methods for creating and getting resources.

Modifying and Deleting resources _shouldn't_ need their own project-scoped methods, as they use the "Self" links populated by Octopus Server.

This _should_ make converting new resources to use the project-scoped routes much easier in the future. the only changes that will be required are:
1. Ensure the resource implements the `IHaveProject` interface
2. Change the repositories base class from `BasicRepository` to `ProjectScopedRepository`