### PR TITLE
Adding VersionControlReference to DeployNewReleaseActionResource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6468,6 +6468,7 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     String EnvironmentId { get; set; }
     String Variables { get; set; }
+    Octopus.Client.Model.VersionControl.VersionControlReferenceResource VersionControlReference { get; set; }
   }
   MonthlyScheduleType
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6493,6 +6493,7 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     String EnvironmentId { get; set; }
     String Variables { get; set; }
+    Octopus.Client.Model.VersionControl.VersionControlReferenceResource VersionControlReference { get; set; }
   }
   MonthlyScheduleType
   {

--- a/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DeployNewReleaseActionResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DeployNewReleaseActionResource.cs
@@ -1,4 +1,5 @@
 ﻿using Octopus.Client.Extensibility.Attributes;
+using Octopus.Client.Model.VersionControl;
 
 namespace Octopus.Client.Model.Triggers.ScheduledTriggers
 {
@@ -11,5 +12,7 @@ namespace Octopus.Client.Model.Triggers.ScheduledTriggers
 
         [Writeable]
         public string EnvironmentId { get; set; }
+
+        public VersionControlReferenceResource VersionControlReference { get; set; }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/OctopusDeploy/OctopusDeploy/pull/9452

# Background

For Deploy new release we need to do the following to support Git:
* We will have two additional fields, one to select a git ref and one to select a channel from the git ref.
* We will then be able to get the list of environments made available by the lifecycle on the selected channel.

# Results

`DeployNewReleaseActionResource` has a new field: `VersionControlReference` to support selecting a Channel from a GitRef for VCS DeployNewRelease Actions