### PR TITLE
Structured Inputs for StepPackageEndpointResource

### DIFF
--- a/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
+++ b/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
@@ -123,6 +123,7 @@ namespace Octopus.Client.Tests.Integration
                          { "SpaceHome", $"{TestRootPath}/api/{{spaceId}}" },
                          { "Users", $"{TestRootPath}/api/users/{{id}}" },
                          { "SignIn", $"{TestRootPath}/api/users/login" },
+                         { "Machines", $"{TestRootPath}/api/machines" },
                      }
                  }
              ));

--- a/source/Octopus.Client.Tests/Integration/Repository/MachineRepositoryTest.cs
+++ b/source/Octopus.Client.Tests/Integration/Repository/MachineRepositoryTest.cs
@@ -1,16 +1,21 @@
-using System;
-using System.IO;
-using System.Reflection;
+using System.Collections.Concurrent;
+using System.Linq;
 using Nancy;
+using Nancy.Extensions;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Model;
+using Octopus.Client.Model.Endpoints;
 using Octopus.Client.Repositories.Async;
+using Octopus.Client.Serialization;
 
 namespace Octopus.Client.Tests.Integration.Repository
 {
     public class MachineRepositoryTest : HttpIntegrationTestBase
     {
+        private static ConcurrentDictionary<string, MachineResource> machines = new ConcurrentDictionary<string, MachineResource>();
+        
         public MachineRepositoryTest()
             : base(UrlPathPrefixBehaviour.UseNoPrefix) //as the canned responses have no prefix, it falls over if we try and isolate the tests with a different prefix
         {
@@ -18,6 +23,26 @@ namespace Octopus.Client.Tests.Integration.Repository
             {
                 string content = GetCannedResponse(parameters);
                 return Response.AsText(content, "application/json");
+            });
+            
+            Get($"{TestRootPath}api/machines", parameters =>
+            {
+                var machinesArray = machines.ToArray().Select(x => x.Value).ToArray();
+                if (machinesArray.Length == 1)
+                    return Response.AsText(JsonConvert.SerializeObject(machinesArray[0],
+                        JsonSerialization.GetDefaultSerializerSettings()), "application/json"); 
+                
+                return Response.AsText(JsonConvert.SerializeObject(machinesArray,
+                    JsonSerialization.GetDefaultSerializerSettings()), "application/json"); 
+            });
+            
+            Post($"{TestRootPath}api/machines", parameters =>
+            {
+                string requestAsString = Context.Request.Body.AsString();
+                var machine = JsonConvert.DeserializeObject<MachineResource>(requestAsString,
+                    JsonSerialization.GetDefaultSerializerSettings());
+                machines.TryAdd(machine.Id, machine);
+                return Response.AsText(requestAsString, "application/json");
             });
         }
 
@@ -39,6 +64,28 @@ namespace Octopus.Client.Tests.Integration.Repository
             var tasks = repository.GetTasks(machine);
 
             Assert.That(tasks.Count, Is.EqualTo(139));
+        }
+
+        [Test]
+        public void StepPackageEndpointInputs_IsSerializedAsObject()
+        {
+            var machine = new MachineResource
+            {
+                Id = "test-target",
+                Endpoint = new StepPackageEndpointResource
+                {
+                    Id = "test-target",
+                    Inputs = new { structureInput = "a", structuredInputB = new { accountId = "2" } }
+                },
+                Links = new LinkCollection {{"Machines", $"{TestRootPath}api/machines"}}
+            };
+            var repository = new Client.Repositories.MachineRepository(SyncClient.Repository);
+            var result = repository.Create(machine);
+            
+            var stepPackageEndpoint = result.Endpoint as StepPackageEndpointResource;
+            Assert.NotNull(stepPackageEndpoint);
+            Assert.NotNull(stepPackageEndpoint.Inputs);
+            Assert.IsNull(stepPackageEndpoint.Inputs as string);
         }
     }
 }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6106,8 +6106,8 @@ Octopus.Client.Model.Endpoints
   {
     .ctor()
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
-    String DeploymentTargetId { get; set; }
-    String Inputs { get; set; }
+    String DeploymentTargetTypeId { get; set; }
+    Object Inputs { get; set; }
     String StepPackageId { get; set; }
     String StepPackageVersion { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6131,8 +6131,8 @@ Octopus.Client.Model.Endpoints
   {
     .ctor()
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
-    String DeploymentTargetId { get; set; }
-    String Inputs { get; set; }
+    String DeploymentTargetTypeId { get; set; }
+    Object Inputs { get; set; }
     String StepPackageId { get; set; }
     String StepPackageVersion { get; set; }
   }

--- a/source/Octopus.Server.Client/Model/Endpoints/StepPackageEndpointResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/StepPackageEndpointResource.cs
@@ -8,11 +8,11 @@ namespace Octopus.Client.Model.Endpoints
 
         [Trim]
         [Writeable]
-        public string Inputs { get; set; }
+        public object Inputs { get; set; }
 
         [Trim]
         [Writeable]
-        public string DeploymentTargetId { get; set; }
+        public string DeploymentTargetTypeId { get; set; }
 
         [Trim]
         [Writeable]


### PR DESCRIPTION
Small fix to allow `StepPackageEndpointResource.Inputs` to be passed as an object (with an unknown set of properties). This is serialized into `DeploymentActionInputs` in Server.

Parent PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/9082