### PR TITLE
Minor nuke file cleanup

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -28,15 +28,22 @@
             "GitHubActions",
             "GitLab",
             "Jenkins",
+            "Rider",
             "SpaceAutomation",
             "TeamCity",
             "Terminal",
-            "TravisCI"
+            "TravisCI",
+            "VisualStudio",
+            "VSCode"
           ]
         },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
         },
         "Plan": {
           "type": "boolean",
@@ -74,8 +81,7 @@
               "PackNormalClientNuget",
               "Restore",
               "Test",
-              "TestClientNugetPackage",
-              "TestNormalClientNugetPackage"
+              "TestClientNugetPackage"
             ]
           }
         },
@@ -94,8 +100,7 @@
               "PackNormalClientNuget",
               "Restore",
               "Test",
-              "TestClientNugetPackage",
-              "TestNormalClientNugetPackage"
+              "TestClientNugetPackage"
             ]
           }
         },

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -7,12 +7,13 @@
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.1.0" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
-    <PackageReference Include="Nuke.OctoVersion" Version="0.2.453" />
+    <PackageReference Include="Nuke.Common" Version="5.2.1" />
+    <PackageReference Include="Nuke.OctoVersion" Version="0.2.560" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates the `build.schema.json` file with the latest changes.
Fixes up a few resharper warnings.
Bumps to latest Nuke.Common and Nuke.OctoVersion.