### PR TITLE
Handle partially-resolved project-scoped route templates for vcs resources (i.e. routes missing gitRef)

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7098,6 +7098,7 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Model.VersionControl.ConvertProjectToVersionControlledResponse ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource, String)
+    IReadOnlyList<RunbookResource> GetAllRunbooks(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.ChannelResource GetChannel(Octopus.Client.Model.ProjectResource, String, String)
     Octopus.Client.Model.ResourceCollection<ChannelResource> GetChannels(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
@@ -7869,6 +7870,7 @@ Octopus.Client.Repositories.Async
   {
     Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource, String)
+    Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(Octopus.Client.Model.ProjectResource, String)
     Task<ChannelResource> GetChannel(Octopus.Client.Model.ProjectResource, String, String)
     Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource, String)
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6831,7 +6831,7 @@ Octopus.Client.Repositories
   }
   interface IChannelBetaRepository
   {
-    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.ChannelResource, Object)
+    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.ICreate<ChannelResource>
@@ -7602,7 +7602,7 @@ Octopus.Client.Repositories.Async
   }
   interface IChannelBetaRepository
   {
-    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.ChannelResource, Object)
+    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.Async.ICreate<ChannelResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7603,6 +7603,7 @@ Octopus.Client.Repositories.Async
   interface IChannelBetaRepository
   {
     Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String)
+    Task<ChannelResource> Get(Octopus.Client.Model.ProjectResource, String, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.Async.ICreate<ChannelResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6920,6 +6920,8 @@ Octopus.Client.Repositories
   interface IDeploymentSettingsRepository
   {
     Octopus.Client.Repositories.IDeploymentSettingsBetaRepository Beta()
+    Octopus.Client.Model.DeploymentSettingsResource Get(Octopus.Client.Model.ProjectResource)
+    Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource)
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.IFindByName<EnvironmentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7124,6 +7124,7 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Model.VersionControl.ConvertProjectToVersionControlledResponse ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource, String)
+    IReadOnlyList<RunbookResource> GetAllRunbooks(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.ChannelResource GetChannel(Octopus.Client.Model.ProjectResource, String, String)
     Octopus.Client.Model.ResourceCollection<ChannelResource> GetChannels(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
@@ -7895,6 +7896,7 @@ Octopus.Client.Repositories.Async
   {
     Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource, String)
+    Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(Octopus.Client.Model.ProjectResource, String)
     Task<ChannelResource> GetChannel(Octopus.Client.Model.ProjectResource, String, String)
     Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource, String)
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6857,7 +6857,7 @@ Octopus.Client.Repositories
   }
   interface IChannelBetaRepository
   {
-    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.ChannelResource, Object)
+    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.ICreate<ChannelResource>
@@ -7628,7 +7628,7 @@ Octopus.Client.Repositories.Async
   }
   interface IChannelBetaRepository
   {
-    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.ChannelResource, Object)
+    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.Async.ICreate<ChannelResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6946,6 +6946,8 @@ Octopus.Client.Repositories
   interface IDeploymentSettingsRepository
   {
     Octopus.Client.Repositories.IDeploymentSettingsBetaRepository Beta()
+    Octopus.Client.Model.DeploymentSettingsResource Get(Octopus.Client.Model.ProjectResource)
+    Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource)
   }
   interface IEnvironmentRepository
     Octopus.Client.Repositories.IFindByName<EnvironmentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7629,6 +7629,7 @@ Octopus.Client.Repositories.Async
   interface IChannelBetaRepository
   {
     Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String)
+    Task<ChannelResource> Get(Octopus.Client.Model.ProjectResource, String, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.Async.ICreate<ChannelResource>

--- a/source/Octopus.Server.Client/Repositories/Async/ChannelRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ChannelRepository.cs
@@ -61,6 +61,7 @@ namespace Octopus.Client.Repositories.Async
 
     public interface IChannelBetaRepository
     {
+        Task<ChannelResource> Get(ProjectResource projectResource, string idOrHref, string gitRef = null);
         Task<ChannelResource> Create(ProjectResource projectResource, ChannelResource channelResource, string gitRef = null);
     }
 
@@ -73,6 +74,17 @@ namespace Octopus.Client.Repositories.Async
         {
             this.repository = repository;
             client = repository.Client;
+        }
+
+        public async Task<ChannelResource> Get(ProjectResource projectResource, string idOrHref, string gitRef = null)
+        {
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return await repository.Channels.Get(projectResource, idOrHref);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var link = projectResource.Link("Channels");
+            return await client.Get<ChannelResource>(link, new { id = idOrHref, gitRef });
         }
 
         public async Task<ChannelResource> Create(

--- a/source/Octopus.Server.Client/Repositories/Async/DeploymentProcessRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/DeploymentProcessRepository.cs
@@ -52,14 +52,12 @@ namespace Octopus.Client.Repositories.Async
 
         public async Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitRef = null)
         {
-            if (!string.IsNullOrWhiteSpace(gitRef))
-            {
-                var branchResource = await repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitRef);
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return await repository.DeploymentProcesses.Get(projectResource.DeploymentProcessId);
 
-                return await client.Get<DeploymentProcessResource>(branchResource.Link("DeploymentProcess"));
-            }
+            gitRef = gitRef ?? settings.DefaultBranch;
 
-            return await client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
+            return await client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"), new { gitRef });
         }
 
         public async Task<DeploymentProcessResource> Modify(ProjectResource projectResource,

--- a/source/Octopus.Server.Client/Repositories/Async/DeploymentProcessRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/DeploymentProcessRepository.cs
@@ -33,7 +33,7 @@ namespace Octopus.Client.Repositories.Async
 
     public interface IDeploymentProcessBetaRepository
     {
-        Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitref = null);
+        Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitRef = null);
 
         Task<DeploymentProcessResource> Modify(ProjectResource projectResource, DeploymentProcessResource resource,
             string commitMessage = null);
@@ -50,11 +50,11 @@ namespace Octopus.Client.Repositories.Async
             this.client = repository.Client;
         }
 
-        public async Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitref = null)
+        public async Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitRef = null)
         {
-            if (!string.IsNullOrWhiteSpace(gitref))
+            if (!string.IsNullOrWhiteSpace(gitRef))
             {
-                var branchResource = await repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitref);
+                var branchResource = await repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitRef);
 
                 return await client.Get<DeploymentProcessResource>(branchResource.Link("DeploymentProcess"));
             }

--- a/source/Octopus.Server.Client/Repositories/Async/DeploymentSettingsRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/DeploymentSettingsRepository.cs
@@ -52,7 +52,7 @@ namespace Octopus.Client.Repositories.Async
 
     public interface IDeploymentSettingsBetaRepository
     {
-        Task<DeploymentSettingsResource> Get(ProjectResource project, string gitref = null);
+        Task<DeploymentSettingsResource> Get(ProjectResource project, string gitRef = null);
 
         Task<DeploymentSettingsResource> Modify(ProjectResource project, DeploymentSettingsResource resource,
             string commitMessage = null);
@@ -69,13 +69,13 @@ namespace Octopus.Client.Repositories.Async
             client = repository.Client;
         }
 
-        public async Task<DeploymentSettingsResource> Get(ProjectResource project, string gitref = null)
+        public async Task<DeploymentSettingsResource> Get(ProjectResource project, string gitRef = null)
         {
             if (!(project.PersistenceSettings is VersionControlSettingsResource settings))
                 return await repository.DeploymentSettings.Get(project);
 
-            gitref = gitref ?? settings.DefaultBranch;
-            var branch = await repository.Projects.Beta().GetVersionControlledBranch(project, gitref);
+            gitRef = gitRef ?? settings.DefaultBranch;
+            var branch = await repository.Projects.Beta().GetVersionControlledBranch(project, gitRef);
 
             return await client.Get<DeploymentSettingsResource>(branch.Link("DeploymentSettings"));
         }

--- a/source/Octopus.Server.Client/Repositories/Async/DeploymentSettingsRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/DeploymentSettingsRepository.cs
@@ -75,9 +75,8 @@ namespace Octopus.Client.Repositories.Async
                 return await repository.DeploymentSettings.Get(project);
 
             gitRef = gitRef ?? settings.DefaultBranch;
-            var branch = await repository.Projects.Beta().GetVersionControlledBranch(project, gitRef);
 
-            return await client.Get<DeploymentSettingsResource>(branch.Link("DeploymentSettings"));
+            return await client.Get<DeploymentSettingsResource>(project.Link("DeploymentSettings"), new { gitRef });
         }
 
         public async Task<DeploymentSettingsResource> Modify(ProjectResource project,

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
@@ -61,6 +61,10 @@ namespace Octopus.Client.Repositories.Async
 
         public Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource project)
         {
+            if (project.PersistenceSettings is VersionControlSettingsResource)
+                throw new NotSupportedException(
+                    $"Version Controlled projects are still in Beta. Use {nameof(IProjectBetaRepository)}.");
+            
             return Client.List<ChannelResource>(project.Link("Channels"));
         }
 
@@ -130,17 +134,20 @@ namespace Octopus.Client.Repositories.Async
         Task<ResourceCollection<VersionControlBranchResource>> GetVersionControlledBranches(ProjectResource projectResource);
         Task<VersionControlBranchResource> GetVersionControlledBranch(ProjectResource projectResource, string branch);
         Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage);
-        Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource projectResource, string gitRef);
-        Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource projectResource, string gitRef);
+        Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource projectResource, string gitRef = null);
+        Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource projectResource, string gitRef = null);
         Task<ChannelResource> GetChannel(ProjectResource projectResource, string gitRef, string idOrName);
+        Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(ProjectResource projectResource, string gitRef = null);
     }
 
     class ProjectBetaRepository : IProjectBetaRepository
     {
+        private readonly IOctopusAsyncRepository repository;
         private readonly IOctopusAsyncClient client;
 
         public ProjectBetaRepository(IOctopusAsyncRepository repository)
         {
+            this.repository = repository;
             client = repository.Client;
         }
 
@@ -168,28 +175,50 @@ namespace Octopus.Client.Repositories.Async
             return response;
         }
 
-        public async Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource projectResource, string gitRef)
+        public async Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource projectResource, string gitRef = null)
         {
-            projectResource.EnsureVersionControlled();
-            VersionControlBranchResource branch = await GetVersionControlledBranch(projectResource, gitRef);
-            return await client.List<ChannelResource>(branch.Link("Channels"));
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return await repository.Projects.GetChannels(projectResource);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var branch = await GetVersionControlledBranch(projectResource, gitRef);
+
+            return await client.List<ChannelResource>(branch.Link("Channels"), new { gitRef });
         }
 
-        public async Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource projectResource, string gitRef)
+        public async Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource projectResource, string gitRef = null)
         {
-            projectResource.EnsureVersionControlled();
-            VersionControlBranchResource branch = await GetVersionControlledBranch(projectResource, gitRef);
-            return await client.ListAll<ChannelResource>(branch.Link("Channels"));
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return await repository.Projects.GetAllChannels(projectResource);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var branch = await GetVersionControlledBranch(projectResource, gitRef);
+
+            return await client.ListAll<ChannelResource>(branch.Link("Channels"), new { gitRef });
         }
 
         public async Task<ChannelResource> GetChannel(ProjectResource projectResource, string gitRef, string idOrName)
         {
             projectResource.EnsureVersionControlled();
 
-            VersionControlBranchResource branch = await GetVersionControlledBranch(projectResource, gitRef);
+            var branch = await GetVersionControlledBranch(projectResource, gitRef);
             var url = $"{branch.Link("Channels")}/{idOrName}";
 
             return await client.Get<ChannelResource>(url);
+        }
+
+        public async Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(ProjectResource projectResource, string gitRef = null)
+        {
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return await repository.Projects.GetAllRunbooks(projectResource);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var branch = await GetVersionControlledBranch(projectResource, gitRef);
+
+            return await client.ListAll<RunbookResource>(branch.Link("Runbooks"), new { gitRef });
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
@@ -216,9 +216,7 @@ namespace Octopus.Client.Repositories.Async
             
             gitRef = gitRef ?? settings.DefaultBranch;
             
-            var branch = await GetVersionControlledBranch(projectResource, gitRef);
-
-            return await client.ListAll<RunbookResource>(branch.Link("Runbooks"), new { gitRef });
+            return await client.ListAll<RunbookResource>(projectResource.Link("Runbooks"), new { gitRef });
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectScopedRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectScopedRepository.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Octopus.Client.Exceptions;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Model;
-using Octopus.Client.Util;
-using Octopus.Client.Validation;
 
 namespace Octopus.Client.Repositories.Async
 {
@@ -51,13 +45,8 @@ namespace Octopus.Client.Repositories.Async
             if (string.IsNullOrWhiteSpace(id))
                 return null;
 
-            if (projectResource.PersistenceSettings.Type == PersistenceSettingsType.VersionControlled)
-            {
-                var link = projectResource.Link(CollectionLinkName);
-                var additionalQueryParameters = GetAdditionalQueryParameters();
-                var parameters = ParameterHelper.CombineParameters(additionalQueryParameters, new {id = id});
-                return await Client.Get<TResource>(link, parameters).ConfigureAwait(false);
-            }
+            if (projectResource.PersistenceSettings is VersionControlSettingsResource)
+                throw new NotSupportedException($"Version Controlled projects are still in Beta. Use the Beta Repository instead.");
 
             return await Get(id);
         }

--- a/source/Octopus.Server.Client/Repositories/ChannelRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ChannelRepository.cs
@@ -53,6 +53,17 @@ namespace Octopus.Client.Repositories
             client = repository.Client;
         }
 
+        public ChannelResource Get(ProjectResource projectResource, string idOrHref, string gitRef = null)
+        {
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return repository.Channels.Get(projectResource, idOrHref);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var link = projectResource.Link("Channels");
+            return client.Get<ChannelResource>(link, new { id = idOrHref, gitRef });
+        }
+
         public ChannelResource Create(
             ProjectResource projectResource, 
             ChannelResource channelResource,

--- a/source/Octopus.Server.Client/Repositories/DeploymentProcessRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/DeploymentProcessRepository.cs
@@ -32,7 +32,7 @@ namespace Octopus.Client.Repositories
 
     public interface IDeploymentProcessRepositoryBeta
     {
-        DeploymentProcessResource Get(ProjectResource projectResource, string gitref = null);
+        DeploymentProcessResource Get(ProjectResource projectResource, string gitRef = null);
         DeploymentProcessResource Modify(ProjectResource projectResource, DeploymentProcessResource resource, string commitMessage = null);
     }
 
@@ -47,11 +47,11 @@ namespace Octopus.Client.Repositories
             this.client = repository.Client;
         }
 
-        public DeploymentProcessResource Get(ProjectResource projectResource, string gitref = null)
+        public DeploymentProcessResource Get(ProjectResource projectResource, string gitRef = null)
         {
-            if (!string.IsNullOrWhiteSpace(gitref))
+            if (!string.IsNullOrWhiteSpace(gitRef))
             {
-                var branchResource = repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitref);
+                var branchResource = repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitRef);
 
                 return client.Get<DeploymentProcessResource>(branchResource.Link("DeploymentProcess"));
             }

--- a/source/Octopus.Server.Client/Repositories/DeploymentProcessRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/DeploymentProcessRepository.cs
@@ -1,4 +1,3 @@
-using System;
 using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
@@ -44,19 +43,17 @@ namespace Octopus.Client.Repositories
         public DeploymentProcessRepositoryBeta(IOctopusRepository repository)
         {
             this.repository = repository;
-            this.client = repository.Client;
+            client = repository.Client;
         }
 
         public DeploymentProcessResource Get(ProjectResource projectResource, string gitRef = null)
         {
-            if (!string.IsNullOrWhiteSpace(gitRef))
-            {
-                var branchResource = repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitRef);
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return repository.DeploymentProcesses.Get(projectResource.DeploymentProcessId);
 
-                return client.Get<DeploymentProcessResource>(branchResource.Link("DeploymentProcess"));
-            }
+            gitRef = gitRef ?? settings.DefaultBranch;
 
-            return client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
+            return client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"), new { gitRef });
         }
 
         public DeploymentProcessResource Modify(ProjectResource projectResource, DeploymentProcessResource resource, string commitMessage = null)

--- a/source/Octopus.Server.Client/Repositories/DeploymentSettingsRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/DeploymentSettingsRepository.cs
@@ -24,7 +24,7 @@ namespace Octopus.Client.Repositories
 
     public interface IDeploymentSettingsBetaRepository
     {
-        DeploymentSettingsResource Get(ProjectResource project, string gitref = null);
+        DeploymentSettingsResource Get(ProjectResource project, string gitRef = null);
         DeploymentSettingsResource Modify(ProjectResource project, DeploymentSettingsResource resource, string commitMessage = null);
     }
 
@@ -39,11 +39,11 @@ namespace Octopus.Client.Repositories
             client = repository.Client;
         }
 
-        public DeploymentSettingsResource Get(ProjectResource projectResource, string gitref = null)
+        public DeploymentSettingsResource Get(ProjectResource projectResource, string gitRef = null)
         {
-            if (!string.IsNullOrWhiteSpace(gitref))
+            if (!string.IsNullOrWhiteSpace(gitRef))
             {
-                var branchResource = repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitref);
+                var branchResource = repository.Projects.Beta().GetVersionControlledBranch(projectResource, gitRef);
 
                 return client.Get<DeploymentSettingsResource>(branchResource.Link("DeploymentSettings"));
             }

--- a/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
@@ -221,9 +221,7 @@ namespace Octopus.Client.Repositories
             
             gitRef = gitRef ?? settings.DefaultBranch;
             
-            var branch = GetVersionControlledBranch(projectResource, gitRef);
-
-            return client.ListAll<RunbookResource>(branch.Link("Runbooks"), new { gitRef });
+            return client.ListAll<RunbookResource>(projectResource.Link("Runbooks"), new { gitRef });
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
@@ -60,6 +60,10 @@ namespace Octopus.Client.Repositories
 
         public ResourceCollection<ChannelResource> GetChannels(ProjectResource project)
         {
+            if (project.PersistenceSettings is VersionControlSettingsResource)
+                throw new NotSupportedException(
+                    $"Version Controlled projects are still in Beta. Use {nameof(IProjectBetaRepository)}.");
+            
             return Client.List<ChannelResource>(project.Link("Channels"));
         }
 
@@ -120,6 +124,10 @@ namespace Octopus.Client.Repositories
 
         public IReadOnlyList<RunbookResource> GetAllRunbooks(ProjectResource project)
         {
+            if (project.PersistenceSettings is VersionControlSettingsResource)
+                throw new NotSupportedException(
+                    $"Version Controlled projects are still in Beta. Use {nameof(IProjectBetaRepository)}.");
+            
             return Client.ListAll<RunbookResource>(project.Link("Runbooks"));
         }
     }
@@ -129,17 +137,20 @@ namespace Octopus.Client.Repositories
         ResourceCollection<VersionControlBranchResource> GetVersionControlledBranches(ProjectResource projectResource);
         VersionControlBranchResource GetVersionControlledBranch(ProjectResource projectResource, string branch);
         ConvertProjectToVersionControlledResponse ConvertToVersionControlled(ProjectResource project, VersionControlSettingsResource versionControlSettings, string commitMessage);
-        ResourceCollection<ChannelResource> GetChannels(ProjectResource projectResource, string gitRef);
-        IReadOnlyList<ChannelResource> GetAllChannels(ProjectResource projectResource, string gitRef);
+        ResourceCollection<ChannelResource> GetChannels(ProjectResource projectResource, string gitRef = null);
+        IReadOnlyList<ChannelResource> GetAllChannels(ProjectResource projectResource, string gitRef = null);
         ChannelResource GetChannel(ProjectResource projectResource, string gitRef, string idOrName);
+        IReadOnlyList<RunbookResource> GetAllRunbooks(ProjectResource projectResource, string gitRef = null);
     }
 
     internal class ProjectBetaRepository : IProjectBetaRepository
     {
+        private readonly IOctopusRepository repository;
         private readonly IOctopusClient client;
 
         public ProjectBetaRepository(IOctopusRepository repository)
         {
+            this.repository = repository;
             client = repository.Client;
         }
 
@@ -171,16 +182,26 @@ namespace Octopus.Client.Repositories
 
         public ResourceCollection<ChannelResource> GetChannels(ProjectResource projectResource, string gitRef)
         {
-            projectResource.EnsureVersionControlled();
-            VersionControlBranchResource branch = GetVersionControlledBranch(projectResource, gitRef);
-            return client.List<ChannelResource>(branch.Link("Channels"));
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return repository.Projects.GetChannels(projectResource);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var branch = GetVersionControlledBranch(projectResource, gitRef);
+
+            return client.List<ChannelResource>(branch.Link("Channels"), new { gitRef });
         }
 
         public IReadOnlyList<ChannelResource> GetAllChannels(ProjectResource projectResource, string gitRef)
         {
-            projectResource.EnsureVersionControlled();
-            VersionControlBranchResource branch = GetVersionControlledBranch(projectResource, gitRef);
-            return client.ListAll<ChannelResource>(branch.Link("Channels"));
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return repository.Projects.GetAllChannels(projectResource);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var branch = GetVersionControlledBranch(projectResource, gitRef);
+
+            return client.ListAll<ChannelResource>(branch.Link("Channels"), new { gitRef });
         }
 
         public ChannelResource GetChannel(ProjectResource projectResource, string gitRef, string idOrName)
@@ -191,6 +212,18 @@ namespace Octopus.Client.Repositories
             var url = $"{branch.Link("Channels")}/{idOrName}";
 
             return client.Get<ChannelResource>(url);
+        }
+
+        public IReadOnlyList<RunbookResource> GetAllRunbooks(ProjectResource projectResource, string gitRef = null)
+        {
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return repository.Projects.GetAllRunbooks(projectResource);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var branch = GetVersionControlledBranch(projectResource, gitRef);
+
+            return client.ListAll<RunbookResource>(branch.Link("Runbooks"), new { gitRef });
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/ProjectScopedRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ProjectScopedRepository.cs
@@ -48,12 +48,8 @@ namespace Octopus.Client.Repositories
             if (string.IsNullOrWhiteSpace(id))
                 return null;
 
-            if (projectResource.PersistenceSettings.Type == PersistenceSettingsType.VersionControlled)
-            {
-                var link = projectResource.Link(CollectionLinkName);
-                var parameters = ParameterHelper.CombineParameters(AdditionalQueryParameters, new { id = id });
-                return Client.Get<TResource>(link, parameters);
-            }
+            if (projectResource.PersistenceSettings is VersionControlSettingsResource)
+                throw new NotSupportedException($"Version Controlled projects are still in Beta. Use the Beta Repository instead.");
 
             return Get(id);
         }


### PR DESCRIPTION
Relates to https://github.com/OctopusDeploy/OctopusDeploy/pull/9495 (internal link)

- Gives the user a meaningful error rather than a response from the wrong endpoint.
- Adds a fallback to current repos from beta so that we can use the beta API for both DB and Git Projects