### PR TITLE
Remove GetAllRunbooks operation from beta repository

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7100,7 +7100,6 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Model.VersionControl.ConvertProjectToVersionControlledResponse ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource, String)
-    IReadOnlyList<RunbookResource> GetAllRunbooks(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.ChannelResource GetChannel(Octopus.Client.Model.ProjectResource, String, String)
     Octopus.Client.Model.ResourceCollection<ChannelResource> GetChannels(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
@@ -7873,7 +7872,6 @@ Octopus.Client.Repositories.Async
   {
     Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource, String)
-    Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(Octopus.Client.Model.ProjectResource, String)
     Task<ChannelResource> GetChannel(Octopus.Client.Model.ProjectResource, String, String)
     Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource, String)
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7126,7 +7126,6 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Model.VersionControl.ConvertProjectToVersionControlledResponse ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource, String)
-    IReadOnlyList<RunbookResource> GetAllRunbooks(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.ChannelResource GetChannel(Octopus.Client.Model.ProjectResource, String, String)
     Octopus.Client.Model.ResourceCollection<ChannelResource> GetChannels(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.VersionControlBranchResource GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)
@@ -7899,7 +7898,6 @@ Octopus.Client.Repositories.Async
   {
     Task<ConvertProjectToVersionControlledResponse> ConvertToVersionControlled(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.VersionControlSettingsResource, String)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource, String)
-    Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(Octopus.Client.Model.ProjectResource, String)
     Task<ChannelResource> GetChannel(Octopus.Client.Model.ProjectResource, String, String)
     Task<ResourceCollection<ChannelResource>> GetChannels(Octopus.Client.Model.ProjectResource, String)
     Task<VersionControlBranchResource> GetVersionControlledBranch(Octopus.Client.Model.ProjectResource, String)

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
@@ -137,7 +137,6 @@ namespace Octopus.Client.Repositories.Async
         Task<ResourceCollection<ChannelResource>> GetChannels(ProjectResource projectResource, string gitRef = null);
         Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource projectResource, string gitRef = null);
         Task<ChannelResource> GetChannel(ProjectResource projectResource, string gitRef, string idOrName);
-        Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(ProjectResource projectResource, string gitRef = null);
     }
 
     class ProjectBetaRepository : IProjectBetaRepository
@@ -207,16 +206,6 @@ namespace Octopus.Client.Repositories.Async
             var url = $"{branch.Link("Channels")}/{idOrName}";
 
             return await client.Get<ChannelResource>(url);
-        }
-
-        public async Task<IReadOnlyList<RunbookResource>> GetAllRunbooks(ProjectResource projectResource, string gitRef = null)
-        {
-            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
-                return await repository.Projects.GetAllRunbooks(projectResource);
-            
-            gitRef = gitRef ?? settings.DefaultBranch;
-            
-            return await client.ListAll<RunbookResource>(projectResource.Link("Runbooks"), new { gitRef });
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
@@ -124,10 +124,6 @@ namespace Octopus.Client.Repositories
 
         public IReadOnlyList<RunbookResource> GetAllRunbooks(ProjectResource project)
         {
-            if (project.PersistenceSettings is VersionControlSettingsResource)
-                throw new NotSupportedException(
-                    $"Version Controlled projects are still in Beta. Use {nameof(IProjectBetaRepository)}.");
-            
             return Client.ListAll<RunbookResource>(project.Link("Runbooks"));
         }
     }
@@ -140,7 +136,6 @@ namespace Octopus.Client.Repositories
         ResourceCollection<ChannelResource> GetChannels(ProjectResource projectResource, string gitRef = null);
         IReadOnlyList<ChannelResource> GetAllChannels(ProjectResource projectResource, string gitRef = null);
         ChannelResource GetChannel(ProjectResource projectResource, string gitRef, string idOrName);
-        IReadOnlyList<RunbookResource> GetAllRunbooks(ProjectResource projectResource, string gitRef = null);
     }
 
     internal class ProjectBetaRepository : IProjectBetaRepository
@@ -212,16 +207,6 @@ namespace Octopus.Client.Repositories
             var url = $"{branch.Link("Channels")}/{idOrName}";
 
             return client.Get<ChannelResource>(url);
-        }
-
-        public IReadOnlyList<RunbookResource> GetAllRunbooks(ProjectResource projectResource, string gitRef = null)
-        {
-            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
-                return repository.Projects.GetAllRunbooks(projectResource);
-            
-            gitRef = gitRef ?? settings.DefaultBranch;
-            
-            return client.ListAll<RunbookResource>(projectResource.Link("Runbooks"), new { gitRef });
         }
     }
 }


### PR DESCRIPTION
Runbooks are not yet version controlled, so the route for this operation has been removed. We'll re-add this in the future once we migrate Runbooks to version control.