### PR TITLE
No need to use Branch endpoint to get channel route now project link is templated

### DIFF
--- a/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
@@ -180,10 +180,8 @@ namespace Octopus.Client.Repositories.Async
                 return await repository.Projects.GetChannels(projectResource);
             
             gitRef = gitRef ?? settings.DefaultBranch;
-            
-            var branch = await GetVersionControlledBranch(projectResource, gitRef);
 
-            return await client.List<ChannelResource>(branch.Link("Channels"), new { gitRef });
+            return await client.List<ChannelResource>(projectResource.Link("Channels"), new { gitRef });
         }
 
         public async Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource projectResource, string gitRef = null)
@@ -192,20 +190,14 @@ namespace Octopus.Client.Repositories.Async
                 return await repository.Projects.GetAllChannels(projectResource);
             
             gitRef = gitRef ?? settings.DefaultBranch;
-            
-            var branch = await GetVersionControlledBranch(projectResource, gitRef);
 
-            return await client.ListAll<ChannelResource>(branch.Link("Channels"), new { gitRef });
+            return await client.ListAll<ChannelResource>(projectResource.Link("Channels"), new { gitRef });
         }
 
         public async Task<ChannelResource> GetChannel(ProjectResource projectResource, string gitRef, string idOrName)
         {
             projectResource.EnsureVersionControlled();
-
-            var branch = await GetVersionControlledBranch(projectResource, gitRef);
-            var url = $"{branch.Link("Channels")}/{idOrName}";
-
-            return await client.Get<ChannelResource>(url);
+            return await client.Get<ChannelResource>(projectResource.Links["Channels"], new { gitRef, id = idOrName });
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
@@ -181,10 +181,8 @@ namespace Octopus.Client.Repositories
                 return repository.Projects.GetChannels(projectResource);
             
             gitRef = gitRef ?? settings.DefaultBranch;
-            
-            var branch = GetVersionControlledBranch(projectResource, gitRef);
 
-            return client.List<ChannelResource>(branch.Link("Channels"), new { gitRef });
+            return client.List<ChannelResource>(projectResource.Link("Channels"), new { gitRef });
         }
 
         public IReadOnlyList<ChannelResource> GetAllChannels(ProjectResource projectResource, string gitRef)
@@ -193,20 +191,14 @@ namespace Octopus.Client.Repositories
                 return repository.Projects.GetAllChannels(projectResource);
             
             gitRef = gitRef ?? settings.DefaultBranch;
-            
-            var branch = GetVersionControlledBranch(projectResource, gitRef);
 
-            return client.ListAll<ChannelResource>(branch.Link("Channels"), new { gitRef });
+            return client.ListAll<ChannelResource>(projectResource.Link("Channels"), new { gitRef });
         }
 
         public ChannelResource GetChannel(ProjectResource projectResource, string gitRef, string idOrName)
         {
             projectResource.EnsureVersionControlled();
-
-            VersionControlBranchResource branch = GetVersionControlledBranch(projectResource, gitRef);
-            var url = $"{branch.Link("Channels")}/{idOrName}";
-
-            return client.Get<ChannelResource>(url);
+            return client.Get<ChannelResource>(projectResource.Links["Channels"], new { gitRef, id = idOrName });
         }
     }
 }


### PR DESCRIPTION
## Before
Previously the project route would be pre-populated with the default gitref. As a result any of the channel requests would need to first go through the branches endpoint to get the appropriate route.

## After
Now that the project route is again non-version controlled, and the routes within a project are templated, we can simply use these routes directly.