### PR TITLE
Add modify commands for version-controlled resources

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2300,6 +2300,18 @@ Octopus.Client.Model
     static System.String StepName
     static Dictionary<String, String> AsDisplaySettings(String)
   }
+  class CreateChannelCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveProject
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.ChannelResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
   class DashboardConfigurationResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -6869,8 +6881,10 @@ Octopus.Client.Repositories
   interface IChannelBetaRepository
   {
     Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
-    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
+    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.CreateChannelCommand, String)
     Octopus.Client.Model.ChannelResource Get(Octopus.Client.Model.ProjectResource, String, String)
+    Octopus.Client.Model.ChannelResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
+    Octopus.Client.Model.ChannelResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.ICreate<ChannelResource>
@@ -7643,8 +7657,10 @@ Octopus.Client.Repositories.Async
   interface IChannelBetaRepository
   {
     Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
-    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
+    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.CreateChannelCommand, String)
     Task<ChannelResource> Get(Octopus.Client.Model.ProjectResource, String, String)
+    Task<ChannelResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
+    Task<ChannelResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.Async.ICreate<ChannelResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3048,6 +3048,10 @@ Octopus.Client.Model
     String LastModifiedBy { get; set; }
     Nullable<DateTimeOffset> LastModifiedOn { get; set; }
   }
+  interface ICommitCommand
+  {
+    String ChangeDescription { get; set; }
+  }
   class IdentityClaimResource
   {
     .ctor()
@@ -3547,6 +3551,39 @@ Octopus.Client.Model
     String ProjectId { get; set; }
     String VariableTemplateId { get; set; }
     String VariableTemplateName { get; set; }
+  }
+  class ModifyChannelCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveProject
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.ChannelResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
+  class ModifyDeploymentProcessCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IProcessResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.DeploymentProcessResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
+  class ModifyDeploymentSettingsCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.DeploymentSettingsResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
   }
   MultipleAccountType
   {
@@ -6832,6 +6869,8 @@ Octopus.Client.Repositories
   interface IChannelBetaRepository
   {
     Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
+    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
+    Octopus.Client.Model.ChannelResource Get(Octopus.Client.Model.ProjectResource, String, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.ICreate<ChannelResource>
@@ -6899,6 +6938,7 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
+    Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentProcessCommand)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>
@@ -6916,6 +6956,7 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Model.DeploymentSettingsResource Get(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource, String)
+    Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentSettingsCommand)
   }
   interface IDeploymentSettingsRepository
   {
@@ -7602,6 +7643,7 @@ Octopus.Client.Repositories.Async
   interface IChannelBetaRepository
   {
     Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
+    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
     Task<ChannelResource> Get(Octopus.Client.Model.ProjectResource, String, String)
   }
   interface IChannelRepository
@@ -7665,6 +7707,7 @@ Octopus.Client.Repositories.Async
   {
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
     Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
+    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentProcessCommand)
   }
   interface IDeploymentProcessRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
@@ -7689,6 +7732,7 @@ Octopus.Client.Repositories.Async
   {
     Task<DeploymentSettingsResource> Get(Octopus.Client.Model.ProjectResource, String)
     Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource, String)
+    Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentSettingsCommand)
   }
   interface IDeploymentSettingsRepository
   {
@@ -8313,7 +8357,7 @@ Octopus.Client.Serialization
   }
   abstract class Serializer
   {
-    static Object Deserialize(String)
+    static Octopus.Client.Serialization.T Deserialize(String)
     static String Serialize(Object, Octopus.Client.Serialization.T)
     static String Serialize(Object)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2316,6 +2316,18 @@ Octopus.Client.Model
     static System.String StepName
     static Dictionary<String, String> AsDisplaySettings(String)
   }
+  class CreateChannelCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveProject
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.ChannelResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
   class DashboardConfigurationResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -6895,8 +6907,10 @@ Octopus.Client.Repositories
   interface IChannelBetaRepository
   {
     Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
-    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
+    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.CreateChannelCommand, String)
     Octopus.Client.Model.ChannelResource Get(Octopus.Client.Model.ProjectResource, String, String)
+    Octopus.Client.Model.ChannelResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
+    Octopus.Client.Model.ChannelResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.ICreate<ChannelResource>
@@ -7669,8 +7683,10 @@ Octopus.Client.Repositories.Async
   interface IChannelBetaRepository
   {
     Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
-    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
+    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.CreateChannelCommand, String)
     Task<ChannelResource> Get(Octopus.Client.Model.ProjectResource, String, String)
+    Task<ChannelResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
+    Task<ChannelResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.Async.ICreate<ChannelResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3064,6 +3064,10 @@ Octopus.Client.Model
     String LastModifiedBy { get; set; }
     Nullable<DateTimeOffset> LastModifiedOn { get; set; }
   }
+  interface ICommitCommand
+  {
+    String ChangeDescription { get; set; }
+  }
   class IdentityClaimResource
   {
     .ctor()
@@ -3563,6 +3567,39 @@ Octopus.Client.Model
     String ProjectId { get; set; }
     String VariableTemplateId { get; set; }
     String VariableTemplateName { get; set; }
+  }
+  class ModifyChannelCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveProject
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.ChannelResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
+  class ModifyDeploymentProcessCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IProcessResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.DeploymentProcessResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
+  class ModifyDeploymentSettingsCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.DeploymentSettingsResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
   }
   MultipleAccountType
   {
@@ -6858,6 +6895,8 @@ Octopus.Client.Repositories
   interface IChannelBetaRepository
   {
     Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
+    Octopus.Client.Model.ChannelResource Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
+    Octopus.Client.Model.ChannelResource Get(Octopus.Client.Model.ProjectResource, String, String)
   }
   interface IChannelRepository
     Octopus.Client.Repositories.ICreate<ChannelResource>
@@ -6925,6 +6964,7 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
+    Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentProcessCommand)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>
@@ -6942,6 +6982,7 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Model.DeploymentSettingsResource Get(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource, String)
+    Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentSettingsCommand)
   }
   interface IDeploymentSettingsRepository
   {
@@ -7628,6 +7669,7 @@ Octopus.Client.Repositories.Async
   interface IChannelBetaRepository
   {
     Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ChannelResource, String, String)
+    Task<ChannelResource> Create(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyChannelCommand, String)
     Task<ChannelResource> Get(Octopus.Client.Model.ProjectResource, String, String)
   }
   interface IChannelRepository
@@ -7691,6 +7733,7 @@ Octopus.Client.Repositories.Async
   {
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
     Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
+    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentProcessCommand)
   }
   interface IDeploymentProcessRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
@@ -7715,6 +7758,7 @@ Octopus.Client.Repositories.Async
   {
     Task<DeploymentSettingsResource> Get(Octopus.Client.Model.ProjectResource, String)
     Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentSettingsResource, String)
+    Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentSettingsCommand)
   }
   interface IDeploymentSettingsRepository
   {
@@ -8340,7 +8384,7 @@ Octopus.Client.Serialization
   }
   abstract class Serializer
   {
-    static Object Deserialize(String)
+    static Octopus.Client.Serialization.T Deserialize(String)
     static String Serialize(Object, Octopus.Client.Serialization.T)
     static String Serialize(Object)
   }

--- a/source/Octopus.Server.Client/Model/CreateChannelCommand.cs
+++ b/source/Octopus.Server.Client/Model/CreateChannelCommand.cs
@@ -1,0 +1,7 @@
+﻿namespace Octopus.Client.Model
+{
+    public class CreateChannelCommand : ChannelResource, ICommitCommand
+    {
+        public string ChangeDescription { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/ICommitCommand.cs
+++ b/source/Octopus.Server.Client/Model/ICommitCommand.cs
@@ -1,0 +1,7 @@
+﻿namespace Octopus.Client.Model
+{
+    public interface ICommitCommand
+    {
+        string ChangeDescription { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/ModifyChannelCommand.cs
+++ b/source/Octopus.Server.Client/Model/ModifyChannelCommand.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model
+{
+    public class ModifyChannelCommand : ChannelResource, ICommitCommand
+    {
+        public string ChangeDescription { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/ModifyDeploymentProcessCommand.cs
+++ b/source/Octopus.Server.Client/Model/ModifyDeploymentProcessCommand.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model
+{
+    public class ModifyDeploymentProcessCommand : DeploymentProcessResource, ICommitCommand
+    {
+        public string ChangeDescription { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/ModifyDeploymentSettingsCommand.cs
+++ b/source/Octopus.Server.Client/Model/ModifyDeploymentSettingsCommand.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model
+{
+    public class ModifyDeploymentSettingsCommand : DeploymentSettingsResource, ICommitCommand
+    {
+        public string ChangeDescription { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/ChannelRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ChannelRepository.cs
@@ -42,7 +42,9 @@ namespace Octopus.Client.Repositories
     {
         ChannelResource Get(ProjectResource projectResource, string idOrHref, string gitRef = null);
         ChannelResource Create(ProjectResource projectResource, ChannelResource channelResource, string gitRef = null, string commitMessage = null);
-        ChannelResource Create(ProjectResource projectResource, ModifyChannelCommand command, string gitRef = null);
+        ChannelResource Create(ProjectResource projectResource, CreateChannelCommand command, string gitRef = null);
+        ChannelResource Modify(ProjectResource projectResource, ChannelResource channelResource, string gitRef = null, string commitMessage = null);
+        ChannelResource Modify(ProjectResource projectResource, ModifyChannelCommand command, string gitRef = null);
     }
 
     internal class ChannelBetaRepository : IChannelBetaRepository
@@ -76,14 +78,14 @@ namespace Octopus.Client.Repositories
             // TODO: revisit/obsolete this API when we have converters
             // until then we need a way to re-use the response from previous client calls
             var json = Serializer.Serialize(channelResource);
-            var command = Serializer.Deserialize<ModifyChannelCommand>(json);
+            var command = Serializer.Deserialize<CreateChannelCommand>(json);
             
             command.ChangeDescription = commitMessage;
             
             return Create(projectResource, command, gitRef);
         }
 
-        public ChannelResource Create(ProjectResource projectResource, ModifyChannelCommand command, string gitRef = null)
+        public ChannelResource Create(ProjectResource projectResource, CreateChannelCommand command, string gitRef = null)
         {
             if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
                 return repository.Channels.Create(projectResource, command);
@@ -92,6 +94,30 @@ namespace Octopus.Client.Repositories
             
             var link = projectResource.Link("Channels");
             return client.Create(link, command, new { gitRef });
+        }
+
+        public ChannelResource Modify(ProjectResource projectResource, ChannelResource channelResource, string gitRef = null,
+            string commitMessage = null)
+        {
+            // TODO: revisit/obsolete this API when we have converters
+            // until then we need a way to re-use the response from previous client calls
+            var json = Serializer.Serialize(channelResource);
+            var command = Serializer.Deserialize<ModifyChannelCommand>(json);
+            
+            command.ChangeDescription = commitMessage;
+            
+            return Modify(projectResource, command, gitRef);
+        }
+
+        public ChannelResource Modify(ProjectResource projectResource, ModifyChannelCommand command, string gitRef = null)
+        {
+            if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
+                return repository.Channels.Modify(command);
+            
+            gitRef = gitRef ?? settings.DefaultBranch;
+            
+            var link = command.Link("Self");
+            return client.Update(link, command, new { gitRef });
         }
     }
 }

--- a/source/Octopus.Server.Client/Serialization/Serializer.cs
+++ b/source/Octopus.Server.Client/Serialization/Serializer.cs
@@ -27,7 +27,7 @@ namespace Octopus.Client.Serialization
             return serializedObject;
         }
         
-        public static object Deserialize<T>(string input)
+        public static T Deserialize<T>(string input)
         {
             return JsonConvert.DeserializeObject<T>(input, JsonSerialization.GetDefaultSerializerSettings());
         }


### PR DESCRIPTION
and consolidate commit/non-commit requests into the same resource/command. 

This improves the migration story for anyone converting to source control, and lowers our maintenance burden by getting us one step closer to having consolidated endpoints for project-scoped routes that may or may not include a `{gitRef}`.

# Background

[Trello card](https://trello.com/c/vbcFEmA5/359-commit-message-middleware) (internal link), relates to https://github.com/OctopusDeploy/OctopusDeploy/pull/9735

# Results

These changes are backwards-compatible with our existing DB routes, but are a breaking change for our `{gitRef}`'d routes, because they remove the need for a `CommitResource` wrapper around Create and Modify requests.

## Before

API consumers would need to a branching code-path to deal with commit messages based on if `projectResource.IsVersionControlled`:

```csharp
public async Task<DeploymentProcessResource> Modify(ProjectResource projectResource, DeploymentProcessResource resource, string commitMessage = null)
{
    if (!projectResource.IsVersionControlled)
    {
        // DB requests get sent as a resource
        return await client.Update(projectResource.Link("DeploymentProcess"), resource);
    }

    // we change the shape of requests for Git resources
    var commitResource = new CommitResource<DeploymentProcessResource>
    {
        Resource = resource,
        CommitMessage = commitMessage
    };
    await client.Update(resource.Link("Self"), commitResource);
    return await client.Get<DeploymentProcessResource>(resource.Link("Self"));
}
```

## After

The same Modify/Create command can be used regardless of whether the resource is stored in got or not:

```csharp
public async Task<ChannelResource> Create(ProjectResource projectResource, ModifyChannelCommand command, string gitRef = null)
{
    if (!(projectResource.PersistenceSettings is VersionControlSettingsResource settings))
        // we send a command for DB
        return await repository.Channels.Create(projectResource, command);

    gitRef = gitRef ?? settings.DefaultBranch;

    var link = projectResource.Link("Channels");

    // same command for Git
    return await client.Create(link, command, new { gitRef });
}
```