### PR TITLE
Make naming consistent with async repo

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6941,18 +6941,18 @@ Octopus.Client.Repositories
   {
     void Delete(Octopus.Client.Repositories.TResource)
   }
-  interface IDeploymentProcessRepository
-    Octopus.Client.Repositories.IGet<DeploymentProcessResource>
-    Octopus.Client.Repositories.IModify<DeploymentProcessResource>
-  {
-    Octopus.Client.Repositories.IDeploymentProcessRepositoryBeta Beta()
-    Octopus.Client.Model.ReleaseTemplateResource GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
-  }
-  interface IDeploymentProcessRepositoryBeta
+  interface IDeploymentProcessBetaRepository
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
     Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentProcessCommand)
+  }
+  interface IDeploymentProcessRepository
+    Octopus.Client.Repositories.IGet<DeploymentProcessResource>
+    Octopus.Client.Repositories.IModify<DeploymentProcessResource>
+  {
+    Octopus.Client.Repositories.IDeploymentProcessBetaRepository Beta()
+    Octopus.Client.Model.ReleaseTemplateResource GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6967,18 +6967,18 @@ Octopus.Client.Repositories
   {
     void Delete(Octopus.Client.Repositories.TResource)
   }
-  interface IDeploymentProcessRepository
-    Octopus.Client.Repositories.IGet<DeploymentProcessResource>
-    Octopus.Client.Repositories.IModify<DeploymentProcessResource>
-  {
-    Octopus.Client.Repositories.IDeploymentProcessRepositoryBeta Beta()
-    Octopus.Client.Model.ReleaseTemplateResource GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
-  }
-  interface IDeploymentProcessRepositoryBeta
+  interface IDeploymentProcessBetaRepository
   {
     Octopus.Client.Model.DeploymentProcessResource Get(Octopus.Client.Model.ProjectResource, String)
     Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.DeploymentProcessResource, String)
     Octopus.Client.Model.DeploymentProcessResource Modify(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.ModifyDeploymentProcessCommand)
+  }
+  interface IDeploymentProcessRepository
+    Octopus.Client.Repositories.IGet<DeploymentProcessResource>
+    Octopus.Client.Repositories.IModify<DeploymentProcessResource>
+  {
+    Octopus.Client.Repositories.IDeploymentProcessBetaRepository Beta()
+    Octopus.Client.Model.ReleaseTemplateResource GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.IGet<DeploymentResource>

--- a/source/Octopus.Server.Client/Repositories/DeploymentProcessRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/DeploymentProcessRepository.cs
@@ -5,21 +5,21 @@ namespace Octopus.Client.Repositories
 {
     public interface IDeploymentProcessRepository : IGet<DeploymentProcessResource>, IModify<DeploymentProcessResource>
     {
-        IDeploymentProcessRepositoryBeta Beta();
+        IDeploymentProcessBetaRepository Beta();
         ReleaseTemplateResource GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel);
     }
 
     class DeploymentProcessRepository : BasicRepository<DeploymentProcessResource>, IDeploymentProcessRepository
     {
-        private readonly DeploymentProcessRepositoryBeta beta;
+        private readonly DeploymentProcessBetaRepository beta;
 
         public DeploymentProcessRepository(IOctopusRepository repository)
             : base(repository, "DeploymentProcesses")
         {
-            beta = new DeploymentProcessRepositoryBeta(repository);
+            beta = new DeploymentProcessBetaRepository(repository);
         }
 
-        public IDeploymentProcessRepositoryBeta Beta()
+        public IDeploymentProcessBetaRepository Beta()
         {
             return beta;
         }
@@ -30,19 +30,19 @@ namespace Octopus.Client.Repositories
         }
     }
 
-    public interface IDeploymentProcessRepositoryBeta
+    public interface IDeploymentProcessBetaRepository
     {
         DeploymentProcessResource Get(ProjectResource projectResource, string gitRef = null);
         DeploymentProcessResource Modify(ProjectResource projectResource, DeploymentProcessResource resource, string commitMessage = null);
         DeploymentProcessResource Modify(ProjectResource projectResource, ModifyDeploymentProcessCommand command);
     }
 
-    class DeploymentProcessRepositoryBeta : IDeploymentProcessRepositoryBeta
+    class DeploymentProcessBetaRepository : IDeploymentProcessBetaRepository
     {
         private readonly IOctopusRepository repository;
         private readonly IOctopusClient client;
 
-        public DeploymentProcessRepositoryBeta(IOctopusRepository repository)
+        public DeploymentProcessBetaRepository(IOctopusRepository repository)
         {
             this.repository = repository;
             client = repository.Client;


### PR DESCRIPTION
Does what is says on the tin. Sync was `IDeploymentProcessRepositoryBeta`, async was `IDeploymentProcessBetaRepository`, now they're both `IDeploymentProcessBetaRepository`