### PR TITLE
Adds new step package fields to action templates

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1594,11 +1594,13 @@ Octopus.Client.Model
     String ActionType { get; set; }
     String CommunityActionTemplateId { get; set; }
     String Description { get; set; }
+    Object Inputs { get; set; }
     String Name { get; set; }
     Octopus.Client.Model.PackageReferenceCollection Packages { get; }
     IList<ActionTemplateParameterResource> Parameters { get; }
     IDictionary<String, PropertyValueResource> Properties { get; }
     String SpaceId { get; set; }
+    String StepPackageVersion { get; set; }
     Int32 Version { get; set; }
   }
   class ActionTemplateSearchResource
@@ -2262,10 +2264,12 @@ Octopus.Client.Model
     String Description { get; set; }
     String HistoryUrl { get; set; }
     String Id { get; set; }
+    Object Inputs { get; set; }
     Octopus.Client.Extensibility.LinkCollection Links { get; set; }
     String Name { get; set; }
     IList<ActionTemplateParameterResource> Parameters { get; }
     IDictionary<String, PropertyValueResource> Properties { get; }
+    String StepPackageVersion { get; set; }
     String Type { get; set; }
     Int32 Version { get; set; }
     String Website { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1609,11 +1609,13 @@ Octopus.Client.Model
     String ActionType { get; set; }
     String CommunityActionTemplateId { get; set; }
     String Description { get; set; }
+    Object Inputs { get; set; }
     String Name { get; set; }
     Octopus.Client.Model.PackageReferenceCollection Packages { get; }
     IList<ActionTemplateParameterResource> Parameters { get; }
     IDictionary<String, PropertyValueResource> Properties { get; }
     String SpaceId { get; set; }
+    String StepPackageVersion { get; set; }
     Int32 Version { get; set; }
   }
   class ActionTemplateSearchResource
@@ -2278,10 +2280,12 @@ Octopus.Client.Model
     String Description { get; set; }
     String HistoryUrl { get; set; }
     String Id { get; set; }
+    Object Inputs { get; set; }
     Octopus.Client.Extensibility.LinkCollection Links { get; set; }
     String Name { get; set; }
     IList<ActionTemplateParameterResource> Parameters { get; }
     IDictionary<String, PropertyValueResource> Properties { get; }
+    String StepPackageVersion { get; set; }
     String Type { get; set; }
     Int32 Version { get; set; }
     String Website { get; set; }

--- a/source/Octopus.Server.Client/Model/ActionTemplateResource.cs
+++ b/source/Octopus.Server.Client/Model/ActionTemplateResource.cs
@@ -33,6 +33,12 @@ namespace Octopus.Client.Model
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]
         public IList<ActionTemplateParameterResource> Parameters { get; } = new List<ActionTemplateParameterResource>();
 
-        public string SpaceId { get; set; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string StepPackageVersion { get; set; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public object Inputs { get; set; }
+
+        public string SpaceId { get; set; }        
     }
 }

--- a/source/Octopus.Server.Client/Model/CommunityActionTemplateResource.cs
+++ b/source/Octopus.Server.Client/Model/CommunityActionTemplateResource.cs
@@ -22,6 +22,12 @@ namespace Octopus.Client.Model
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]
         public IList<ActionTemplateParameterResource> Parameters { get; } = new List<ActionTemplateParameterResource>();
 
-        public LinkCollection Links { get; set; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string StepPackageVersion { get; set; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public object Inputs { get; set; }
+
+        public LinkCollection Links { get; set; }        
     }
 }


### PR DESCRIPTION
This PR adds new fields for step packages to `ActionTemplateResource` and `CommunityActionTemplateResource`. See https://github.com/OctopusDeploy/OctopusClients/pull/610 for more context on the same fields being added to steps and deployment targets.