### PR TITLE
Add type parameter to Machines.GetTasks

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5949,6 +5949,14 @@ Octopus.Client.Model.DeploymentProcess
       Target = 1
   }
 }
+Octopus.Client.Model.DeploymentTargets
+{
+  DeploymentTargetTaskType
+  {
+      Deployment = 0
+      RunbookRun = 1
+  }
+}
 Octopus.Client.Model.Endpoints
 {
   AzureServiceFabricCredentialType
@@ -7105,7 +7113,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.MachineResource Discover(Octopus.Client.Model.DiscoverMachineOptions)
     List<MachineResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.MachineResource)
-    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource)
+    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType>)
     IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Object)
     Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5974,6 +5974,14 @@ Octopus.Client.Model.DeploymentProcess
       Target = 1
   }
 }
+Octopus.Client.Model.DeploymentTargets
+{
+  DeploymentTargetTaskType
+  {
+      Deployment = 0
+      RunbookRun = 1
+  }
+}
 Octopus.Client.Model.Endpoints
 {
   AzureServiceFabricCredentialType
@@ -7131,7 +7139,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.MachineResource Discover(Octopus.Client.Model.DiscoverMachineOptions)
     List<MachineResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.MachineResource)
-    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource)
+    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType>)
     IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Object)
     Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
   }

--- a/source/Octopus.Server.Client/Model/DeploymentTargets/DeploymentTargetTaskType.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentTargets/DeploymentTargetTaskType.cs
@@ -1,0 +1,8 @@
+﻿namespace Octopus.Client.Model.DeploymentTargets
+{
+    public enum DeploymentTargetTaskType
+    {
+        Deployment,
+        RunbookRun
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/MachineRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/MachineRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Octopus.Client.Editors;
 using Octopus.Client.Model;
+using Octopus.Client.Model.DeploymentTargets;
 using Octopus.Client.Model.Endpoints;
 
 namespace Octopus.Client.Repositories
@@ -12,7 +13,7 @@ namespace Octopus.Client.Repositories
         MachineResource Discover(DiscoverMachineOptions options);
         MachineConnectionStatus GetConnectionStatus(MachineResource machine);
         List<MachineResource> FindByThumbprint(string thumbprint);
-        IReadOnlyList<TaskResource> GetTasks(MachineResource machine);
+        IReadOnlyList<TaskResource> GetTasks(MachineResource machine, DeploymentTargetTaskType? type = null);
         IReadOnlyList<TaskResource> GetTasks(MachineResource machine, object pathParameters);
 
 
@@ -80,16 +81,20 @@ namespace Octopus.Client.Repositories
         }
 
         /// <summary>
-        /// Gets all tasks involving the specified machine
+        /// Gets tasks involving the specified machine. If `type` is specified, only gets tasks of the specified type.
+        /// If `type` is not specified, gets tasks of all types.
         /// </summary>
         /// <param name="machine"></param>
+        /// <param name="type"></param>
         /// <returns></returns>
-        public IReadOnlyList<TaskResource> GetTasks(MachineResource machine) => GetTasks(machine, new {skip = 0});
+        public IReadOnlyList<TaskResource> GetTasks(MachineResource machine, DeploymentTargetTaskType? type = null) => GetTasks(machine, new {skip = 0, type});
 
         /// <summary>
-        /// Gets all tasks involving the specified machine
+        /// Gets tasks involving the specified machine. If `type` is specified, only gets tasks of the specified type.
+        /// If `type` is not specified, gets tasks of all types.
         /// 
-        /// The `take` pathParmeter is only respected in Octopus 4.0.6 and later
+        /// The `take` pathParameter is only respected in Octopus 4.0.6 and later
+        /// The `type` pathParameter is only respected in Octopus 2021.3 and later
         /// </summary>
         /// <param name="machine"></param>
         /// <param name="pathParameters"></param>


### PR DESCRIPTION
This PR is for exposing the new parameter `type` on `GET /machines/{id}/tasks` in Octopus.Client. See https://github.com/OctopusDeploy/OctopusDeploy/pull/9853 (internal) for details