### PR TITLE
Fix null reference exception when passing null as options in async client

### DIFF
--- a/source/Octopus.Server.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncClient.cs
@@ -61,10 +61,10 @@ namespace Octopus.Client
             }
 
 #if HTTP_CLIENT_SUPPORTS_SSL_OPTIONS
-            handler.SslProtocols = options.SslProtocols;
+            handler.SslProtocols = clientOptions.SslProtocols;
             if(addCertificateCallback)
             {
-                ignoreSslErrors = options.IgnoreSslErrors;
+                ignoreSslErrors = clientOptions.IgnoreSslErrors;
                 handler.ServerCertificateCustomValidationCallback = IgnoreServerCertificateCallback;
             }
 #endif


### PR DESCRIPTION
`options` (not validated against null) instead of `clientOptions` is used in `OctopusAsyncClient` constructor, which will lead to `NullReferenceException` if passed `options` was null.