### PR TITLE
Introduce telemetry configuration repository

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5249,7 +5249,6 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean AllowChecking { get; set; }
-    Boolean IncludeStatistics { get; set; }
     Octopus.Client.Model.UpgradeNotificationMode NotificationMode { get; set; }
   }
   UpgradeNotificationMode

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -356,6 +356,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.ITagSetRepository TagSets { get; }
     Octopus.Client.Repositories.Async.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.Async.ITeamsRepository Teams { get; }
+    Octopus.Client.Repositories.Async.ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
     Octopus.Client.Repositories.Async.ITenantRepository Tenants { get; }
     Octopus.Client.Repositories.Async.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.Async.IUpgradeConfigurationRepository UpgradeConfiguration { get; }
@@ -490,6 +491,7 @@ Octopus.Client
     Octopus.Client.Repositories.ITagSetRepository TagSets { get; }
     Octopus.Client.Repositories.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.ITeamsRepository Teams { get; }
+    Octopus.Client.Repositories.ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
     Octopus.Client.Repositories.ITenantRepository Tenants { get; }
     Octopus.Client.Repositories.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.IUpgradeConfigurationRepository UpgradeConfiguration { get; }
@@ -7402,6 +7404,13 @@ Octopus.Client.Repositories
   {
     List<ScopedUserRoleResource> GetScopedUserRoles(Octopus.Client.Model.TeamResource)
   }
+  interface ITelemetryConfigurationRepository
+  {
+    Octopus.Client.Model.TelemetryConfigurationResource DisableTelemetry()
+    Octopus.Client.Model.TelemetryConfigurationResource EnableTelemetry()
+    Octopus.Client.Model.TelemetryConfigurationResource GetTelemetryConfiguration()
+    Octopus.Client.Model.TelemetryConfigurationResource ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
+  }
   interface ITenantRepository
     Octopus.Client.Repositories.ICreate<TenantResource>
     Octopus.Client.Repositories.IModify<TenantResource>
@@ -7545,6 +7554,15 @@ Octopus.Client.Repositories
     .ctor(Octopus.Client.IOctopusRepository)
     Octopus.Client.Model.PerformanceConfigurationResource Get()
     Octopus.Client.Model.PerformanceConfigurationResource Modify(Octopus.Client.Model.PerformanceConfigurationResource)
+  }
+  class TelemetryConfigurationRepository
+    Octopus.Client.Repositories.ITelemetryConfigurationRepository
+  {
+    .ctor(Octopus.Client.IOctopusRepository)
+    Octopus.Client.Model.TelemetryConfigurationResource DisableTelemetry()
+    Octopus.Client.Model.TelemetryConfigurationResource EnableTelemetry()
+    Octopus.Client.Model.TelemetryConfigurationResource GetTelemetryConfiguration()
+    Octopus.Client.Model.TelemetryConfigurationResource ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
   }
   class VcsRunbookRepository
     Octopus.Client.Repositories.IVcsRunbookRepository
@@ -8171,6 +8189,13 @@ Octopus.Client.Repositories.Async
   {
     Task<List<ScopedUserRoleResource>> GetScopedUserRoles(Octopus.Client.Model.TeamResource)
   }
+  interface ITelemetryConfigurationRepository
+  {
+    Task<TelemetryConfigurationResource> DisableTelemetry()
+    Task<TelemetryConfigurationResource> EnableTelemetry()
+    Task<TelemetryConfigurationResource> GetTelemetryConfiguration()
+    Task<TelemetryConfigurationResource> ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
+  }
   interface ITenantRepository
     Octopus.Client.Repositories.Async.ICreate<TenantResource>
     Octopus.Client.Repositories.Async.IModify<TenantResource>
@@ -8305,6 +8330,15 @@ Octopus.Client.Repositories.Async
     Exception
   {
     .ctor(String, Octopus.Client.SpaceContext)
+  }
+  class TelemetryConfigurationRepository
+    Octopus.Client.Repositories.Async.ITelemetryConfigurationRepository
+  {
+    .ctor(Octopus.Client.IOctopusAsyncRepository)
+    Task<TelemetryConfigurationResource> DisableTelemetry()
+    Task<TelemetryConfigurationResource> EnableTelemetry()
+    Task<TelemetryConfigurationResource> GetTelemetryConfiguration()
+    Task<TelemetryConfigurationResource> ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
   }
   class VcsRunbookRepository
     Octopus.Client.Repositories.Async.IVcsRunbookRepository

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -235,6 +235,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.ISchedulerRepository Schedulers { get; }
     Octopus.Client.Repositories.Async.IServerStatusRepository ServerStatus { get; }
     Octopus.Client.Repositories.Async.ISpaceRepository Spaces { get; }
+    Octopus.Client.Repositories.Async.ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
     Octopus.Client.Repositories.Async.IUpgradeConfigurationRepository UpgradeConfiguration { get; }
     Octopus.Client.Repositories.Async.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.Async.IUserRepository Users { get; }
@@ -254,6 +255,7 @@ Octopus.Client
     Octopus.Client.Repositories.ISchedulerRepository Schedulers { get; }
     Octopus.Client.Repositories.IServerStatusRepository ServerStatus { get; }
     Octopus.Client.Repositories.ISpaceRepository Spaces { get; }
+    Octopus.Client.Repositories.ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
     Octopus.Client.Repositories.IUpgradeConfigurationRepository UpgradeConfiguration { get; }
     Octopus.Client.Repositories.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.IUserRepository Users { get; }
@@ -5118,6 +5120,15 @@ Octopus.Client.Model
     Octopus.Client.Model.ReferenceCollection MemberUserIds { get; set; }
     String Name { get; set; }
     String SpaceId { get; set; }
+  }
+  class TelemetryConfigurationResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Boolean Enabled { get; set; }
+    DateTimeOffset ShowAsNewUntil { get; set; }
   }
   TenantedDeploymentMode
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5262,6 +5262,7 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean AllowChecking { get; set; }
+    Boolean IncludeStatistics { get; set; }
     Octopus.Client.Model.UpgradeNotificationMode NotificationMode { get; set; }
   }
   UpgradeNotificationMode

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -356,6 +356,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.ITagSetRepository TagSets { get; }
     Octopus.Client.Repositories.Async.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.Async.ITeamsRepository Teams { get; }
+    Octopus.Client.Repositories.Async.ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
     Octopus.Client.Repositories.Async.ITenantRepository Tenants { get; }
     Octopus.Client.Repositories.Async.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.Async.IUpgradeConfigurationRepository UpgradeConfiguration { get; }
@@ -488,6 +489,7 @@ Octopus.Client
     Octopus.Client.Repositories.ITagSetRepository TagSets { get; }
     Octopus.Client.Repositories.ITaskRepository Tasks { get; }
     Octopus.Client.Repositories.ITeamsRepository Teams { get; }
+    Octopus.Client.Repositories.ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
     Octopus.Client.Repositories.ITenantRepository Tenants { get; }
     Octopus.Client.Repositories.ITenantVariablesRepository TenantVariables { get; }
     Octopus.Client.Repositories.IUpgradeConfigurationRepository UpgradeConfiguration { get; }
@@ -7428,6 +7430,13 @@ Octopus.Client.Repositories
   {
     List<ScopedUserRoleResource> GetScopedUserRoles(Octopus.Client.Model.TeamResource)
   }
+  interface ITelemetryConfigurationRepository
+  {
+    Octopus.Client.Model.TelemetryConfigurationResource DisableTelemetry()
+    Octopus.Client.Model.TelemetryConfigurationResource EnableTelemetry()
+    Octopus.Client.Model.TelemetryConfigurationResource GetTelemetryConfiguration()
+    Octopus.Client.Model.TelemetryConfigurationResource ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
+  }
   interface ITenantRepository
     Octopus.Client.Repositories.ICreate<TenantResource>
     Octopus.Client.Repositories.IModify<TenantResource>
@@ -7571,6 +7580,15 @@ Octopus.Client.Repositories
     .ctor(Octopus.Client.IOctopusRepository)
     Octopus.Client.Model.PerformanceConfigurationResource Get()
     Octopus.Client.Model.PerformanceConfigurationResource Modify(Octopus.Client.Model.PerformanceConfigurationResource)
+  }
+  class TelemetryConfigurationRepository
+    Octopus.Client.Repositories.ITelemetryConfigurationRepository
+  {
+    .ctor(Octopus.Client.IOctopusRepository)
+    Octopus.Client.Model.TelemetryConfigurationResource DisableTelemetry()
+    Octopus.Client.Model.TelemetryConfigurationResource EnableTelemetry()
+    Octopus.Client.Model.TelemetryConfigurationResource GetTelemetryConfiguration()
+    Octopus.Client.Model.TelemetryConfigurationResource ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
   }
   class VcsRunbookRepository
     Octopus.Client.Repositories.IVcsRunbookRepository
@@ -8197,6 +8215,13 @@ Octopus.Client.Repositories.Async
   {
     Task<List<ScopedUserRoleResource>> GetScopedUserRoles(Octopus.Client.Model.TeamResource)
   }
+  interface ITelemetryConfigurationRepository
+  {
+    Task<TelemetryConfigurationResource> DisableTelemetry()
+    Task<TelemetryConfigurationResource> EnableTelemetry()
+    Task<TelemetryConfigurationResource> GetTelemetryConfiguration()
+    Task<TelemetryConfigurationResource> ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
+  }
   interface ITenantRepository
     Octopus.Client.Repositories.Async.ICreate<TenantResource>
     Octopus.Client.Repositories.Async.IModify<TenantResource>
@@ -8332,6 +8357,15 @@ Octopus.Client.Repositories.Async
     Exception
   {
     .ctor(String, Octopus.Client.SpaceContext)
+  }
+  class TelemetryConfigurationRepository
+    Octopus.Client.Repositories.Async.ITelemetryConfigurationRepository
+  {
+    .ctor(Octopus.Client.IOctopusAsyncRepository)
+    Task<TelemetryConfigurationResource> DisableTelemetry()
+    Task<TelemetryConfigurationResource> EnableTelemetry()
+    Task<TelemetryConfigurationResource> GetTelemetryConfiguration()
+    Task<TelemetryConfigurationResource> ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
   }
   class VcsRunbookRepository
     Octopus.Client.Repositories.Async.IVcsRunbookRepository

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -235,6 +235,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.ISchedulerRepository Schedulers { get; }
     Octopus.Client.Repositories.Async.IServerStatusRepository ServerStatus { get; }
     Octopus.Client.Repositories.Async.ISpaceRepository Spaces { get; }
+    Octopus.Client.Repositories.Async.ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
     Octopus.Client.Repositories.Async.IUpgradeConfigurationRepository UpgradeConfiguration { get; }
     Octopus.Client.Repositories.Async.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.Async.IUserRepository Users { get; }
@@ -254,6 +255,7 @@ Octopus.Client
     Octopus.Client.Repositories.ISchedulerRepository Schedulers { get; }
     Octopus.Client.Repositories.IServerStatusRepository ServerStatus { get; }
     Octopus.Client.Repositories.ISpaceRepository Spaces { get; }
+    Octopus.Client.Repositories.ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
     Octopus.Client.Repositories.IUpgradeConfigurationRepository UpgradeConfiguration { get; }
     Octopus.Client.Repositories.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.IUserRepository Users { get; }
@@ -5140,6 +5142,15 @@ Octopus.Client.Model
     Octopus.Client.Model.ReferenceCollection MemberUserIds { get; set; }
     String Name { get; set; }
     String SpaceId { get; set; }
+  }
+  class TelemetryConfigurationResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Boolean Enabled { get; set; }
+    DateTimeOffset ShowAsNewUntil { get; set; }
   }
   TenantedDeploymentMode
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5273,7 +5273,6 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean AllowChecking { get; set; }
-    Boolean IncludeStatistics { get; set; }
     Octopus.Client.Model.UpgradeNotificationMode NotificationMode { get; set; }
   }
   UpgradeNotificationMode

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5286,6 +5286,7 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean AllowChecking { get; set; }
+    Boolean IncludeStatistics { get; set; }
     Octopus.Client.Model.UpgradeNotificationMode NotificationMode { get; set; }
   }
   UpgradeNotificationMode

--- a/source/Octopus.Server.Client/IOctopusSystemAsyncRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusSystemAsyncRepository.cs
@@ -26,6 +26,7 @@ namespace Octopus.Client
         IUserRepository Users { get; }
         IUserRolesRepository UserRoles { get; }
         IUpgradeConfigurationRepository UpgradeConfiguration { get; }
+        ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
 
         /// <summary>
         /// Gets a document that identifies the Octopus Server (from /api) and provides links to the resources available on the

--- a/source/Octopus.Server.Client/IOctopusSystemRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusSystemRepository.cs
@@ -25,6 +25,7 @@ namespace Octopus.Client
         IUserRepository Users { get; }
         IUserRolesRepository UserRoles { get; }
         IUpgradeConfigurationRepository UpgradeConfiguration { get; }
+        ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
 
         /// <summary>
         /// Gets a document that identifies the Octopus Server (from /api) and provides links to the resources available on the

--- a/source/Octopus.Server.Client/Model/TelemetryConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/TelemetryConfigurationResource.cs
@@ -1,0 +1,13 @@
+using System;
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model
+{
+    public class TelemetryConfigurationResource: Resource
+    {
+        [Writeable]
+        public bool Enabled { get; set; }
+
+        public DateTimeOffset ShowAsNewUntil { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/UpgradeConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/UpgradeConfigurationResource.cs
@@ -9,5 +9,9 @@ namespace Octopus.Client.Model
 
         [Writeable]
         public bool AllowChecking { get; set; }
+
+        [Writeable]
+        public bool IncludeStatistics { get; set; }
+
     }
 }

--- a/source/Octopus.Server.Client/Model/UpgradeConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/UpgradeConfigurationResource.cs
@@ -9,9 +9,5 @@ namespace Octopus.Client.Model
 
         [Writeable]
         public bool AllowChecking { get; set; }
-
-        [Writeable]
-        public bool IncludeStatistics { get; set; }
-
     }
 }

--- a/source/Octopus.Server.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncRepository.cs
@@ -105,6 +105,7 @@ namespace Octopus.Client
             TagSets = new TagSetRepository(this);
             Tasks = new TaskRepository(this);
             Teams = new TeamsRepository(this);
+            TelemetryConfigurationRepository = new TelemetryConfigurationRepository(this);
             Tenants = new TenantRepository(this);
             TenantVariables = new TenantVariablesRepository(this);
             UserInvites = new UserInvitesRepository(this);
@@ -186,6 +187,7 @@ namespace Octopus.Client
         public IUserPermissionsRepository UserPermissions { get; }
         public IUserTeamsRepository UserTeams { get; }
         public IUpgradeConfigurationRepository UpgradeConfiguration { get; }
+        public ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
 
         public async Task<bool> HasLink(string name)
         {

--- a/source/Octopus.Server.Client/OctopusRepository.cs
+++ b/source/Octopus.Server.Client/OctopusRepository.cs
@@ -103,6 +103,7 @@ namespace Octopus.Client
             TagSets = new TagSetRepository(this);
             Tasks = new TaskRepository(this);
             Teams = new TeamsRepository(this);
+            TelemetryConfigurationRepository = new TelemetryConfigurationRepository(this);
             Tenants = new TenantRepository(this);
             TenantVariables = new TenantVariablesRepository(this);
             UserRoles = new UserRolesRepository(this);
@@ -183,6 +184,7 @@ namespace Octopus.Client
         public IUserPermissionsRepository UserPermissions { get; }
         public IUserTeamsRepository UserTeams { get; }
         public IUpgradeConfigurationRepository UpgradeConfiguration { get; }
+        public ITelemetryConfigurationRepository TelemetryConfigurationRepository { get; }
 
         public bool HasLink(string name)
         {

--- a/source/Octopus.Server.Client/Repositories/Async/TelemetryConfigurationRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/TelemetryConfigurationRepository.cs
@@ -1,0 +1,50 @@
+using System.Threading.Tasks;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Repositories.Async
+{
+    public interface ITelemetryConfigurationRepository
+    {
+        Task<TelemetryConfigurationResource> GetTelemetryConfiguration();
+        Task<TelemetryConfigurationResource> ModifyTelemetryConfiguration(TelemetryConfigurationResource resource);
+        Task<TelemetryConfigurationResource> EnableTelemetry();
+        Task<TelemetryConfigurationResource> DisableTelemetry();
+    }
+    
+    public class TelemetryConfigurationRepository : ITelemetryConfigurationRepository
+    {
+        private readonly IOctopusAsyncRepository repository;
+        private const string LinkName = "TelemetryConfiguration";
+
+        public TelemetryConfigurationRepository(IOctopusAsyncRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public async Task<TelemetryConfigurationResource> GetTelemetryConfiguration()
+        {
+            return await repository.Client.Get<TelemetryConfigurationResource>(await repository.Link(LinkName).ConfigureAwait(false)).ConfigureAwait(false);
+        }
+
+        public async Task<TelemetryConfigurationResource> ModifyTelemetryConfiguration(TelemetryConfigurationResource resource)
+        {
+            return await repository.Client.Update(await repository.Link(LinkName).ConfigureAwait(false), resource).ConfigureAwait(false);
+        }
+
+        public async Task<TelemetryConfigurationResource> EnableTelemetry()
+        {
+            return await repository.Client.Update(await repository.Link(LinkName).ConfigureAwait(false), new TelemetryConfigurationResource
+            {
+                Enabled = true
+            }).ConfigureAwait(false);
+        }
+
+        public async Task<TelemetryConfigurationResource> DisableTelemetry()
+        {
+            return await repository.Client.Update(await repository.Link(LinkName).ConfigureAwait(false), new TelemetryConfigurationResource
+            {
+                Enabled = false
+            }).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/Async/TelemetryConfigurationRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/TelemetryConfigurationRepository.cs
@@ -33,18 +33,18 @@ namespace Octopus.Client.Repositories.Async
 
         public async Task<TelemetryConfigurationResource> EnableTelemetry()
         {
-            return await repository.Client.Update(await repository.Link(LinkName).ConfigureAwait(false), new TelemetryConfigurationResource
+            return await ModifyTelemetryConfiguration(new TelemetryConfigurationResource
             {
                 Enabled = true
-            }).ConfigureAwait(false);
+            });
         }
 
         public async Task<TelemetryConfigurationResource> DisableTelemetry()
         {
-            return await repository.Client.Update(await repository.Link(LinkName).ConfigureAwait(false), new TelemetryConfigurationResource
+            return await ModifyTelemetryConfiguration(new TelemetryConfigurationResource
             {
                 Enabled = false
-            }).ConfigureAwait(false);
+            });
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/TelemetryConfigurationRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/TelemetryConfigurationRepository.cs
@@ -33,7 +33,7 @@ namespace Octopus.Client.Repositories
 
         public TelemetryConfigurationResource EnableTelemetry()
         {
-            return repository.Client.Update(repository.Link(LinkName), new TelemetryConfigurationResource
+            return ModifyTelemetryConfiguration(new TelemetryConfigurationResource
             {
                 Enabled = true
             });
@@ -41,7 +41,7 @@ namespace Octopus.Client.Repositories
 
         public TelemetryConfigurationResource DisableTelemetry()
         {
-            return repository.Client.Update(repository.Link(LinkName), new TelemetryConfigurationResource
+            return ModifyTelemetryConfiguration(new TelemetryConfigurationResource
             {
                 Enabled = false
             });

--- a/source/Octopus.Server.Client/Repositories/TelemetryConfigurationRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/TelemetryConfigurationRepository.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Repositories
+{
+    public interface ITelemetryConfigurationRepository
+    {
+        TelemetryConfigurationResource GetTelemetryConfiguration();
+        TelemetryConfigurationResource ModifyTelemetryConfiguration(TelemetryConfigurationResource resource);
+        TelemetryConfigurationResource EnableTelemetry();
+        TelemetryConfigurationResource DisableTelemetry();
+    }
+    
+    public class TelemetryConfigurationRepository : ITelemetryConfigurationRepository
+    {
+        private readonly IOctopusRepository repository;
+        private const string LinkName = "TelemetryConfiguration";
+
+        public TelemetryConfigurationRepository(IOctopusRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public TelemetryConfigurationResource GetTelemetryConfiguration()
+        {
+            return repository.Client.Get<TelemetryConfigurationResource>(repository.Link(LinkName));
+        }
+
+        public TelemetryConfigurationResource ModifyTelemetryConfiguration(TelemetryConfigurationResource resource)
+        {
+            return repository.Client.Update(repository.Link(LinkName), resource);
+        }
+
+        public TelemetryConfigurationResource EnableTelemetry()
+        {
+            return repository.Client.Update(repository.Link(LinkName), new TelemetryConfigurationResource
+            {
+                Enabled = true
+            });
+        }
+
+        public TelemetryConfigurationResource DisableTelemetry()
+        {
+            return repository.Client.Update(repository.Link(LinkName), new TelemetryConfigurationResource
+            {
+                Enabled = false
+            });
+        }
+    }
+}


### PR DESCRIPTION
We've changed the way how Octopus Deploy collects and sends telemetry, for better transparency and visibility.

This PR introduces a telemetry configuration repository to easily enable/disable telemetry