### PR TITLE
Add IsStepUiFrameworkEnabled feature flag

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2963,6 +2963,7 @@ Octopus.Client.Model
     Boolean IsConfigurationAsCodeEnabled { get; set; }
     Boolean IsHelpSidebarEnabled { get; set; }
     Boolean IsKubernetesEnabled { get; set; }
+    Boolean IsStepUiFrameworkEnabled { get; set; }
   }
   class FeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2979,6 +2979,7 @@ Octopus.Client.Model
     Boolean IsConfigurationAsCodeEnabled { get; set; }
     Boolean IsHelpSidebarEnabled { get; set; }
     Boolean IsKubernetesEnabled { get; set; }
+    Boolean IsStepUiFrameworkEnabled { get; set; }
   }
   class FeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Server.Client/Model/FeaturesConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/FeaturesConfigurationResource.cs
@@ -24,5 +24,8 @@ namespace Octopus.Client.Model
 
         [Writeable]
         public bool IsConfigurationAsCodeEnabled { get; set; }
+        
+        [Writeable]
+        public bool IsStepUiFrameworkEnabled { get; set; }
     }
 }


### PR DESCRIPTION
`IsStepUiFrameworkEnabled` feature flag is missing from `FeaturesConfigurationResource`, which resets it to default every time the feature flags are updated (ex. `await repository.FeaturesConfiguration.ModifyFeaturesConfiguration(featuresConfiguration);`)

This PR adds `IsStepUiFrameworkEnabled` property to `FeaturesConfigurationResource`.