### PR TITLE
Changing Permission to not be an enum

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3876,128 +3876,134 @@ Octopus.Client.Model
     .ctor()
     Octopus.Client.Model.DashboardRenderMode DefaultDashboardRenderMode { get; set; }
   }
-  Permission
+  class Permission
+    IEquatable<Permission>
   {
-      AdministerSystem = 0
-      ProjectEdit = 1
-      ProjectView = 2
-      ProjectCreate = 3
-      ProjectDelete = 4
-      ProcessView = 5
-      ProcessEdit = 6
-      VariableEdit = 7
-      VariableEditUnscoped = 8
-      VariableView = 9
-      VariableViewUnscoped = 10
-      ReleaseCreate = 11
-      ReleaseView = 12
-      ReleaseEdit = 13
-      ReleaseDelete = 14
-      DefectReport = 15
-      DefectResolve = 16
-      DeploymentCreate = 17
-      DeploymentDelete = 18
-      DeploymentView = 19
-      EnvironmentView = 20
-      EnvironmentCreate = 21
-      EnvironmentEdit = 22
-      EnvironmentDelete = 23
-      MachineCreate = 24
-      MachineEdit = 25
-      MachineView = 26
-      MachineDelete = 27
-      ArtifactView = 28
-      ArtifactCreate = 29
-      ArtifactEdit = 30
-      ArtifactDelete = 31
-      FeedView = 32
-      EventView = 33
-      LibraryVariableSetView = 34
-      LibraryVariableSetCreate = 35
-      LibraryVariableSetEdit = 36
-      LibraryVariableSetDelete = 37
-      ProjectGroupView = 38
-      ProjectGroupCreate = 39
-      ProjectGroupEdit = 40
-      ProjectGroupDelete = 41
-      TeamCreate = 42
-      TeamView = 43
-      TeamEdit = 44
-      TeamDelete = 45
-      UserView = 46
-      UserInvite = 47
-      UserRoleView = 48
-      UserRoleEdit = 49
-      TaskView = 50
-      TaskViewLog = 51
-      TaskCreate = 52
-      TaskCancel = 53
-      TaskEdit = 54
-      InterruptionView = 55
-      InterruptionSubmit = 56
-      InterruptionViewSubmitResponsible = 57
-      BuiltInFeedPush = 58
-      BuiltInFeedAdminister = 59
-      BuiltInFeedDownload = 60
-      ActionTemplateView = 61
-      ActionTemplateCreate = 62
-      ActionTemplateEdit = 63
-      ActionTemplateDelete = 64
-      LifecycleCreate = 65
-      LifecycleView = 66
-      LifecycleEdit = 67
-      LifecycleDelete = 68
-      AccountView = 69
-      AccountEdit = 70
-      AccountCreate = 71
-      AccountDelete = 72
-      TenantCreate = 73
-      TenantEdit = 74
-      TenantView = 75
-      TenantDelete = 76
-      TagSetCreate = 77
-      TagSetEdit = 78
-      TagSetDelete = 79
-      TelemetryView = 80
-      MachinePolicyCreate = 81
-      MachinePolicyView = 82
-      MachinePolicyEdit = 83
-      MachinePolicyDelete = 84
-      ProxyCreate = 85
-      ProxyView = 86
-      ProxyEdit = 87
-      ProxyDelete = 88
-      SubscriptionCreate = 89
-      SubscriptionView = 90
-      SubscriptionEdit = 91
-      SubscriptionDelete = 92
-      TriggerCreate = 93
-      TriggerView = 94
-      TriggerEdit = 95
-      TriggerDelete = 96
-      CertificateView = 97
-      CertificateCreate = 98
-      CertificateEdit = 99
-      CertificateDelete = 100
-      CertificateExportPrivateKey = 101
-      UserEdit = 102
-      ConfigureServer = 103
-      FeedEdit = 104
-      WorkerView = 105
-      WorkerEdit = 106
-      SpaceEdit = 107
-      SpaceView = 108
-      SpaceDelete = 109
-      SpaceCreate = 110
-      BuildInformationPush = 111
-      BuildInformationAdminister = 112
-      RunbookView = 113
-      RunbookEdit = 114
-      RunbookRunView = 115
-      RunbookRunDelete = 116
-      RunbookRunCreate = 117
-      GitCredentialView = 118
-      GitCredentialEdit = 119
+    static Octopus.Client.Model.Permission AccountCreate
+    static Octopus.Client.Model.Permission AccountDelete
+    static Octopus.Client.Model.Permission AccountEdit
+    static Octopus.Client.Model.Permission AccountView
+    static Octopus.Client.Model.Permission ActionTemplateCreate
+    static Octopus.Client.Model.Permission ActionTemplateDelete
+    static Octopus.Client.Model.Permission ActionTemplateEdit
+    static Octopus.Client.Model.Permission ActionTemplateView
+    static Octopus.Client.Model.Permission AdministerSystem
+    static Octopus.Client.Model.Permission ArtifactCreate
+    static Octopus.Client.Model.Permission ArtifactDelete
+    static Octopus.Client.Model.Permission ArtifactEdit
+    static Octopus.Client.Model.Permission ArtifactView
+    static Octopus.Client.Model.Permission BuildInformationAdminister
+    static Octopus.Client.Model.Permission BuildInformationPush
+    static Octopus.Client.Model.Permission BuiltInFeedAdminister
+    static Octopus.Client.Model.Permission BuiltInFeedDownload
+    static Octopus.Client.Model.Permission BuiltInFeedPush
+    static Octopus.Client.Model.Permission CertificateCreate
+    static Octopus.Client.Model.Permission CertificateDelete
+    static Octopus.Client.Model.Permission CertificateEdit
+    static Octopus.Client.Model.Permission CertificateExportPrivateKey
+    static Octopus.Client.Model.Permission CertificateView
+    static Octopus.Client.Model.Permission ConfigureServer
+    static Octopus.Client.Model.Permission DefectReport
+    static Octopus.Client.Model.Permission DefectResolve
+    static Octopus.Client.Model.Permission DeploymentCreate
+    static Octopus.Client.Model.Permission DeploymentDelete
+    static Octopus.Client.Model.Permission DeploymentView
+    static Octopus.Client.Model.Permission EnvironmentCreate
+    static Octopus.Client.Model.Permission EnvironmentDelete
+    static Octopus.Client.Model.Permission EnvironmentEdit
+    static Octopus.Client.Model.Permission EnvironmentView
+    static Octopus.Client.Model.Permission EventView
+    static Octopus.Client.Model.Permission FeedEdit
+    static Octopus.Client.Model.Permission FeedView
+    static Octopus.Client.Model.Permission GitCredentialEdit
+    static Octopus.Client.Model.Permission GitCredentialView
+    static Octopus.Client.Model.Permission InterruptionSubmit
+    static Octopus.Client.Model.Permission InterruptionView
+    static Octopus.Client.Model.Permission InterruptionViewSubmitResponsible
+    static Octopus.Client.Model.Permission LibraryVariableSetCreate
+    static Octopus.Client.Model.Permission LibraryVariableSetDelete
+    static Octopus.Client.Model.Permission LibraryVariableSetEdit
+    static Octopus.Client.Model.Permission LibraryVariableSetView
+    static Octopus.Client.Model.Permission LifecycleCreate
+    static Octopus.Client.Model.Permission LifecycleDelete
+    static Octopus.Client.Model.Permission LifecycleEdit
+    static Octopus.Client.Model.Permission LifecycleView
+    static Octopus.Client.Model.Permission MachineCreate
+    static Octopus.Client.Model.Permission MachineDelete
+    static Octopus.Client.Model.Permission MachineEdit
+    static Octopus.Client.Model.Permission MachinePolicyCreate
+    static Octopus.Client.Model.Permission MachinePolicyDelete
+    static Octopus.Client.Model.Permission MachinePolicyEdit
+    static Octopus.Client.Model.Permission MachinePolicyView
+    static Octopus.Client.Model.Permission MachineView
+    static Octopus.Client.Model.Permission ProcessEdit
+    static Octopus.Client.Model.Permission ProcessView
+    static Octopus.Client.Model.Permission ProjectCreate
+    static Octopus.Client.Model.Permission ProjectDelete
+    static Octopus.Client.Model.Permission ProjectEdit
+    static Octopus.Client.Model.Permission ProjectGroupCreate
+    static Octopus.Client.Model.Permission ProjectGroupDelete
+    static Octopus.Client.Model.Permission ProjectGroupEdit
+    static Octopus.Client.Model.Permission ProjectGroupView
+    static Octopus.Client.Model.Permission ProjectView
+    static Octopus.Client.Model.Permission ProxyCreate
+    static Octopus.Client.Model.Permission ProxyDelete
+    static Octopus.Client.Model.Permission ProxyEdit
+    static Octopus.Client.Model.Permission ProxyView
+    static Octopus.Client.Model.Permission ReleaseCreate
+    static Octopus.Client.Model.Permission ReleaseDelete
+    static Octopus.Client.Model.Permission ReleaseEdit
+    static Octopus.Client.Model.Permission ReleaseView
+    static Octopus.Client.Model.Permission RunbookEdit
+    static Octopus.Client.Model.Permission RunbookRunCreate
+    static Octopus.Client.Model.Permission RunbookRunDelete
+    static Octopus.Client.Model.Permission RunbookRunView
+    static Octopus.Client.Model.Permission RunbookView
+    static Octopus.Client.Model.Permission SpaceCreate
+    static Octopus.Client.Model.Permission SpaceDelete
+    static Octopus.Client.Model.Permission SpaceEdit
+    static Octopus.Client.Model.Permission SpaceView
+    static Octopus.Client.Model.Permission SubscriptionCreate
+    static Octopus.Client.Model.Permission SubscriptionDelete
+    static Octopus.Client.Model.Permission SubscriptionEdit
+    static Octopus.Client.Model.Permission SubscriptionView
+    static Octopus.Client.Model.Permission TagSetCreate
+    static Octopus.Client.Model.Permission TagSetDelete
+    static Octopus.Client.Model.Permission TagSetEdit
+    static Octopus.Client.Model.Permission TaskCancel
+    static Octopus.Client.Model.Permission TaskCreate
+    static Octopus.Client.Model.Permission TaskEdit
+    static Octopus.Client.Model.Permission TaskView
+    static Octopus.Client.Model.Permission TaskViewLog
+    static Octopus.Client.Model.Permission TeamCreate
+    static Octopus.Client.Model.Permission TeamDelete
+    static Octopus.Client.Model.Permission TeamEdit
+    static Octopus.Client.Model.Permission TeamView
+    static Octopus.Client.Model.Permission TelemetryView
+    static Octopus.Client.Model.Permission TenantCreate
+    static Octopus.Client.Model.Permission TenantDelete
+    static Octopus.Client.Model.Permission TenantEdit
+    static Octopus.Client.Model.Permission TenantView
+    static Octopus.Client.Model.Permission TriggerCreate
+    static Octopus.Client.Model.Permission TriggerDelete
+    static Octopus.Client.Model.Permission TriggerEdit
+    static Octopus.Client.Model.Permission TriggerView
+    static Octopus.Client.Model.Permission UserEdit
+    static Octopus.Client.Model.Permission UserInvite
+    static Octopus.Client.Model.Permission UserRoleEdit
+    static Octopus.Client.Model.Permission UserRoleView
+    static Octopus.Client.Model.Permission UserView
+    static Octopus.Client.Model.Permission VariableEdit
+    static Octopus.Client.Model.Permission VariableEditUnscoped
+    static Octopus.Client.Model.Permission VariableView
+    static Octopus.Client.Model.Permission VariableViewUnscoped
+    static Octopus.Client.Model.Permission WorkerEdit
+    static Octopus.Client.Model.Permission WorkerView
+    .ctor(String)
+    Boolean Equals(Octopus.Client.Model.Permission)
+    Boolean Equals(Object)
+    Int32 GetHashCode()
+    String ToString()
   }
   class PermissionDescription
   {
@@ -8375,6 +8381,14 @@ Octopus.Client.Serialization
     JsonConverter
   {
     .ctor(String, String[])
+    Boolean CanConvert(Type)
+    Object ReadJson(JsonReader, Type, Object, JsonSerializer)
+    void WriteJson(JsonWriter, Object, JsonSerializer)
+  }
+  class PermissionConverter
+    JsonConverter
+  {
+    .ctor()
     Boolean CanConvert(Type)
     Object ReadJson(JsonReader, Type, Object, JsonSerializer)
     void WriteJson(JsonWriter, Object, JsonSerializer)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3896,128 +3896,134 @@ Octopus.Client.Model
     .ctor()
     Octopus.Client.Model.DashboardRenderMode DefaultDashboardRenderMode { get; set; }
   }
-  Permission
+  class Permission
+    IEquatable<Permission>
   {
-      AdministerSystem = 0
-      ProjectEdit = 1
-      ProjectView = 2
-      ProjectCreate = 3
-      ProjectDelete = 4
-      ProcessView = 5
-      ProcessEdit = 6
-      VariableEdit = 7
-      VariableEditUnscoped = 8
-      VariableView = 9
-      VariableViewUnscoped = 10
-      ReleaseCreate = 11
-      ReleaseView = 12
-      ReleaseEdit = 13
-      ReleaseDelete = 14
-      DefectReport = 15
-      DefectResolve = 16
-      DeploymentCreate = 17
-      DeploymentDelete = 18
-      DeploymentView = 19
-      EnvironmentView = 20
-      EnvironmentCreate = 21
-      EnvironmentEdit = 22
-      EnvironmentDelete = 23
-      MachineCreate = 24
-      MachineEdit = 25
-      MachineView = 26
-      MachineDelete = 27
-      ArtifactView = 28
-      ArtifactCreate = 29
-      ArtifactEdit = 30
-      ArtifactDelete = 31
-      FeedView = 32
-      EventView = 33
-      LibraryVariableSetView = 34
-      LibraryVariableSetCreate = 35
-      LibraryVariableSetEdit = 36
-      LibraryVariableSetDelete = 37
-      ProjectGroupView = 38
-      ProjectGroupCreate = 39
-      ProjectGroupEdit = 40
-      ProjectGroupDelete = 41
-      TeamCreate = 42
-      TeamView = 43
-      TeamEdit = 44
-      TeamDelete = 45
-      UserView = 46
-      UserInvite = 47
-      UserRoleView = 48
-      UserRoleEdit = 49
-      TaskView = 50
-      TaskViewLog = 51
-      TaskCreate = 52
-      TaskCancel = 53
-      TaskEdit = 54
-      InterruptionView = 55
-      InterruptionSubmit = 56
-      InterruptionViewSubmitResponsible = 57
-      BuiltInFeedPush = 58
-      BuiltInFeedAdminister = 59
-      BuiltInFeedDownload = 60
-      ActionTemplateView = 61
-      ActionTemplateCreate = 62
-      ActionTemplateEdit = 63
-      ActionTemplateDelete = 64
-      LifecycleCreate = 65
-      LifecycleView = 66
-      LifecycleEdit = 67
-      LifecycleDelete = 68
-      AccountView = 69
-      AccountEdit = 70
-      AccountCreate = 71
-      AccountDelete = 72
-      TenantCreate = 73
-      TenantEdit = 74
-      TenantView = 75
-      TenantDelete = 76
-      TagSetCreate = 77
-      TagSetEdit = 78
-      TagSetDelete = 79
-      TelemetryView = 80
-      MachinePolicyCreate = 81
-      MachinePolicyView = 82
-      MachinePolicyEdit = 83
-      MachinePolicyDelete = 84
-      ProxyCreate = 85
-      ProxyView = 86
-      ProxyEdit = 87
-      ProxyDelete = 88
-      SubscriptionCreate = 89
-      SubscriptionView = 90
-      SubscriptionEdit = 91
-      SubscriptionDelete = 92
-      TriggerCreate = 93
-      TriggerView = 94
-      TriggerEdit = 95
-      TriggerDelete = 96
-      CertificateView = 97
-      CertificateCreate = 98
-      CertificateEdit = 99
-      CertificateDelete = 100
-      CertificateExportPrivateKey = 101
-      UserEdit = 102
-      ConfigureServer = 103
-      FeedEdit = 104
-      WorkerView = 105
-      WorkerEdit = 106
-      SpaceEdit = 107
-      SpaceView = 108
-      SpaceDelete = 109
-      SpaceCreate = 110
-      BuildInformationPush = 111
-      BuildInformationAdminister = 112
-      RunbookView = 113
-      RunbookEdit = 114
-      RunbookRunView = 115
-      RunbookRunDelete = 116
-      RunbookRunCreate = 117
-      GitCredentialView = 118
-      GitCredentialEdit = 119
+    static Octopus.Client.Model.Permission AccountCreate
+    static Octopus.Client.Model.Permission AccountDelete
+    static Octopus.Client.Model.Permission AccountEdit
+    static Octopus.Client.Model.Permission AccountView
+    static Octopus.Client.Model.Permission ActionTemplateCreate
+    static Octopus.Client.Model.Permission ActionTemplateDelete
+    static Octopus.Client.Model.Permission ActionTemplateEdit
+    static Octopus.Client.Model.Permission ActionTemplateView
+    static Octopus.Client.Model.Permission AdministerSystem
+    static Octopus.Client.Model.Permission ArtifactCreate
+    static Octopus.Client.Model.Permission ArtifactDelete
+    static Octopus.Client.Model.Permission ArtifactEdit
+    static Octopus.Client.Model.Permission ArtifactView
+    static Octopus.Client.Model.Permission BuildInformationAdminister
+    static Octopus.Client.Model.Permission BuildInformationPush
+    static Octopus.Client.Model.Permission BuiltInFeedAdminister
+    static Octopus.Client.Model.Permission BuiltInFeedDownload
+    static Octopus.Client.Model.Permission BuiltInFeedPush
+    static Octopus.Client.Model.Permission CertificateCreate
+    static Octopus.Client.Model.Permission CertificateDelete
+    static Octopus.Client.Model.Permission CertificateEdit
+    static Octopus.Client.Model.Permission CertificateExportPrivateKey
+    static Octopus.Client.Model.Permission CertificateView
+    static Octopus.Client.Model.Permission ConfigureServer
+    static Octopus.Client.Model.Permission DefectReport
+    static Octopus.Client.Model.Permission DefectResolve
+    static Octopus.Client.Model.Permission DeploymentCreate
+    static Octopus.Client.Model.Permission DeploymentDelete
+    static Octopus.Client.Model.Permission DeploymentView
+    static Octopus.Client.Model.Permission EnvironmentCreate
+    static Octopus.Client.Model.Permission EnvironmentDelete
+    static Octopus.Client.Model.Permission EnvironmentEdit
+    static Octopus.Client.Model.Permission EnvironmentView
+    static Octopus.Client.Model.Permission EventView
+    static Octopus.Client.Model.Permission FeedEdit
+    static Octopus.Client.Model.Permission FeedView
+    static Octopus.Client.Model.Permission GitCredentialEdit
+    static Octopus.Client.Model.Permission GitCredentialView
+    static Octopus.Client.Model.Permission InterruptionSubmit
+    static Octopus.Client.Model.Permission InterruptionView
+    static Octopus.Client.Model.Permission InterruptionViewSubmitResponsible
+    static Octopus.Client.Model.Permission LibraryVariableSetCreate
+    static Octopus.Client.Model.Permission LibraryVariableSetDelete
+    static Octopus.Client.Model.Permission LibraryVariableSetEdit
+    static Octopus.Client.Model.Permission LibraryVariableSetView
+    static Octopus.Client.Model.Permission LifecycleCreate
+    static Octopus.Client.Model.Permission LifecycleDelete
+    static Octopus.Client.Model.Permission LifecycleEdit
+    static Octopus.Client.Model.Permission LifecycleView
+    static Octopus.Client.Model.Permission MachineCreate
+    static Octopus.Client.Model.Permission MachineDelete
+    static Octopus.Client.Model.Permission MachineEdit
+    static Octopus.Client.Model.Permission MachinePolicyCreate
+    static Octopus.Client.Model.Permission MachinePolicyDelete
+    static Octopus.Client.Model.Permission MachinePolicyEdit
+    static Octopus.Client.Model.Permission MachinePolicyView
+    static Octopus.Client.Model.Permission MachineView
+    static Octopus.Client.Model.Permission ProcessEdit
+    static Octopus.Client.Model.Permission ProcessView
+    static Octopus.Client.Model.Permission ProjectCreate
+    static Octopus.Client.Model.Permission ProjectDelete
+    static Octopus.Client.Model.Permission ProjectEdit
+    static Octopus.Client.Model.Permission ProjectGroupCreate
+    static Octopus.Client.Model.Permission ProjectGroupDelete
+    static Octopus.Client.Model.Permission ProjectGroupEdit
+    static Octopus.Client.Model.Permission ProjectGroupView
+    static Octopus.Client.Model.Permission ProjectView
+    static Octopus.Client.Model.Permission ProxyCreate
+    static Octopus.Client.Model.Permission ProxyDelete
+    static Octopus.Client.Model.Permission ProxyEdit
+    static Octopus.Client.Model.Permission ProxyView
+    static Octopus.Client.Model.Permission ReleaseCreate
+    static Octopus.Client.Model.Permission ReleaseDelete
+    static Octopus.Client.Model.Permission ReleaseEdit
+    static Octopus.Client.Model.Permission ReleaseView
+    static Octopus.Client.Model.Permission RunbookEdit
+    static Octopus.Client.Model.Permission RunbookRunCreate
+    static Octopus.Client.Model.Permission RunbookRunDelete
+    static Octopus.Client.Model.Permission RunbookRunView
+    static Octopus.Client.Model.Permission RunbookView
+    static Octopus.Client.Model.Permission SpaceCreate
+    static Octopus.Client.Model.Permission SpaceDelete
+    static Octopus.Client.Model.Permission SpaceEdit
+    static Octopus.Client.Model.Permission SpaceView
+    static Octopus.Client.Model.Permission SubscriptionCreate
+    static Octopus.Client.Model.Permission SubscriptionDelete
+    static Octopus.Client.Model.Permission SubscriptionEdit
+    static Octopus.Client.Model.Permission SubscriptionView
+    static Octopus.Client.Model.Permission TagSetCreate
+    static Octopus.Client.Model.Permission TagSetDelete
+    static Octopus.Client.Model.Permission TagSetEdit
+    static Octopus.Client.Model.Permission TaskCancel
+    static Octopus.Client.Model.Permission TaskCreate
+    static Octopus.Client.Model.Permission TaskEdit
+    static Octopus.Client.Model.Permission TaskView
+    static Octopus.Client.Model.Permission TaskViewLog
+    static Octopus.Client.Model.Permission TeamCreate
+    static Octopus.Client.Model.Permission TeamDelete
+    static Octopus.Client.Model.Permission TeamEdit
+    static Octopus.Client.Model.Permission TeamView
+    static Octopus.Client.Model.Permission TelemetryView
+    static Octopus.Client.Model.Permission TenantCreate
+    static Octopus.Client.Model.Permission TenantDelete
+    static Octopus.Client.Model.Permission TenantEdit
+    static Octopus.Client.Model.Permission TenantView
+    static Octopus.Client.Model.Permission TriggerCreate
+    static Octopus.Client.Model.Permission TriggerDelete
+    static Octopus.Client.Model.Permission TriggerEdit
+    static Octopus.Client.Model.Permission TriggerView
+    static Octopus.Client.Model.Permission UserEdit
+    static Octopus.Client.Model.Permission UserInvite
+    static Octopus.Client.Model.Permission UserRoleEdit
+    static Octopus.Client.Model.Permission UserRoleView
+    static Octopus.Client.Model.Permission UserView
+    static Octopus.Client.Model.Permission VariableEdit
+    static Octopus.Client.Model.Permission VariableEditUnscoped
+    static Octopus.Client.Model.Permission VariableView
+    static Octopus.Client.Model.Permission VariableViewUnscoped
+    static Octopus.Client.Model.Permission WorkerEdit
+    static Octopus.Client.Model.Permission WorkerView
+    .ctor(String)
+    Boolean Equals(Octopus.Client.Model.Permission)
+    Boolean Equals(Object)
+    Int32 GetHashCode()
+    String ToString()
   }
   class PermissionDescription
   {
@@ -8403,6 +8409,14 @@ Octopus.Client.Serialization
     JsonConverter
   {
     .ctor(String, String[])
+    Boolean CanConvert(Type)
+    Object ReadJson(JsonReader, Type, Object, JsonSerializer)
+    void WriteJson(JsonWriter, Object, JsonSerializer)
+  }
+  class PermissionConverter
+    JsonConverter
+  {
+    .ctor()
     Boolean CanConvert(Type)
     Object ReadJson(JsonReader, Type, Object, JsonSerializer)
     void WriteJson(JsonWriter, Object, JsonSerializer)

--- a/source/Octopus.Client.Tests/Serialization/PermissionSerializationFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/PermissionSerializationFixture.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Octopus.Client.Model;
+using Octopus.Client.Serialization;
+
+namespace Octopus.Client.Tests.Serialization
+{
+    [TestFixture]
+    public class PermissionSerializationFixture
+    {
+        private JsonSerializerSettings settings;
+
+        [SetUp]
+        public void SetUp()
+        {
+            settings = JsonSerialization.GetDefaultSerializerSettings();
+            settings.Formatting = Formatting.None;
+        }
+
+        [Test]
+        public void SerializesSinglePermissionCorrectly()
+        {
+            var testObject = new SinglePermissionTestStructure { Name = "Test", Permission = Permission.AdministerSystem };
+            var serializedText = JsonConvert.SerializeObject(testObject, settings);
+            Assert.AreEqual("{\"Name\":\"Test\",\"Permission\":\"AdministerSystem\"}", serializedText);
+        }
+
+        [Test]
+        public void SerializesMultiplePermissionsCorrectly()
+        {
+            var testObject = new PermissionListTestStructure { Name = "Test", Permissions = new List<Permission> { Permission.AccountView, Permission.AccountEdit } };
+            var serializedText = JsonConvert.SerializeObject(testObject, settings);
+            Assert.AreEqual("{\"Name\":\"Test\",\"Permissions\":[\"AccountView\",\"AccountEdit\"]}", serializedText);
+        }
+
+        [Test]
+        public void DeserializesSinglePermissionCorrectly()
+        {
+            var testObject = JsonConvert.DeserializeObject<SinglePermissionTestStructure>("{\"Name\":\"Test\",\"Permission\":\"AdministerSystem\"}", settings);
+            Assert.IsNotNull(testObject);
+            Assert.AreEqual(Permission.AdministerSystem, testObject.Permission);
+        }
+
+        [Test]
+        public void DeserializesMultiplePermissionsCorrectly()
+        {
+            var testObject = JsonConvert.DeserializeObject<PermissionListTestStructure>("{\"Name\":\"Test\",\"Permissions\":[\"AccountView\",\"AccountEdit\"]}", settings);
+            Assert.IsNotNull(testObject);
+            CollectionAssert.AreEquivalent(new List<Permission> { Permission.AccountView, Permission.AccountEdit }, testObject.Permissions);
+        }
+
+        [Test]
+        public void DeserializesPermissionsNotKnownToClientCorrectly()
+        {
+            var testObject = JsonConvert.DeserializeObject<PermissionListTestStructure>("{\"Name\":\"Test\",\"Permissions\":[\"AccountView\",\"AccountEdit\",\"SomeUnknownValue\"]}", settings);
+            Assert.IsNotNull(testObject);
+            CollectionAssert.AreEquivalent(new List<Permission> { Permission.AccountView, Permission.AccountEdit, new Permission("SomeUnknownValue") }, testObject.Permissions);
+        }
+
+        class SinglePermissionTestStructure
+        {
+            public string Name { get; set; }
+            public Permission Permission { get; set; }
+        }
+
+        class PermissionListTestStructure
+        {
+            public string Name { get; set; }
+            public List<Permission> Permissions { get; set; }
+        }
+    }
+}

--- a/source/Octopus.Server.Client/Model/Permission.cs
+++ b/source/Octopus.Server.Client/Model/Permission.cs
@@ -257,7 +257,6 @@ namespace Octopus.Client.Model
 
         [Description("Edit Git credentials")] public static readonly Permission GitCredentialEdit = new Permission("GitCredentialEdit");
 
-        [JsonConstructor]
         public Permission(string id)
         {
             Id = id;

--- a/source/Octopus.Server.Client/Model/Permission.cs
+++ b/source/Octopus.Server.Client/Model/Permission.cs
@@ -1,5 +1,8 @@
+#nullable enable
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
+using Newtonsoft.Json;
 
 namespace Octopus.Client.Model
 {
@@ -8,249 +11,285 @@ namespace Octopus.Client.Model
     /// included permissions are not. So, when permission sets are loaded we only set up restrictions
     /// that are supported by the permission type.
     /// </summary>
-    public enum Permission
+    [DebuggerDisplay("Id")]
+    public class Permission : IEquatable<Permission>
     {
-        [Description("Perform system-level functions like configuring HTTP web hosting, the public URL, server nodes, maintenance mode, and server diagnostics")] AdministerSystem,
+        [Description("Perform system-level functions like configuring HTTP web hosting, the public URL, server nodes, maintenance mode, and server diagnostics")]public static readonly Permission AdministerSystem = new Permission("AdministerSystem");
 
-        [Description("Edit project details")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] ProjectEdit,
+        [Description("Edit project details")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] public static readonly Permission ProjectEdit = new Permission("ProjectEdit");
 
-        [Description("View the details of projects")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] ProjectView,
+        [Description("View the details of projects")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] public static readonly Permission ProjectView = new Permission("ProjectView");
 
-        [Description("Create projects")] [SupportsRestriction(PermissionScope.ProjectGroups)] ProjectCreate,
+        [Description("Create projects")] [SupportsRestriction(PermissionScope.ProjectGroups)] public static readonly Permission ProjectCreate = new Permission("ProjectCreate");
 
-        [Description("Delete projects")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] ProjectDelete,
+        [Description("Delete projects")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] public static readonly Permission ProjectDelete = new Permission("ProjectDelete");
 
-        [Description("View the deployment process and channels associated with a project")] [SupportsRestriction(PermissionScope.Projects)] ProcessView,
+        [Description("View the deployment process and channels associated with a project")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission ProcessView = new Permission("ProcessView");
 
-        [Description("Edit the deployment process and channels associated with a project")] [SupportsRestriction(PermissionScope.Projects)] ProcessEdit,
+        [Description("Edit the deployment process and channels associated with a project")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission ProcessEdit = new Permission("ProcessEdit");
 
-        [Description("Edit variables belonging to a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments)] VariableEdit,
+        [Description("Edit variables belonging to a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments)] public static readonly Permission VariableEdit = new Permission("VariableEdit");
 
-        [Description("Edit non-environment scoped variables belonging to a project or library variable set")] [SupportsRestriction(PermissionScope.Projects)] VariableEditUnscoped,
+        [Description("Edit non-environment scoped variables belonging to a project or library variable set")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission VariableEditUnscoped = new Permission("VariableEditUnscoped");
 
-        [Description("View variables belonging to a project or library variable set")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments)] VariableView,
+        [Description("View variables belonging to a project or library variable set")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments)] public static readonly Permission VariableView = new Permission("VariableView");
 
-        [Description("View non-environment scoped variables belonging to a project or library variable set")] [SupportsRestriction(PermissionScope.Projects)] VariableViewUnscoped,
+        [Description("View non-environment scoped variables belonging to a project or library variable set")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission VariableViewUnscoped = new Permission("VariableViewUnscoped");
 
-        [Description("Create a release for a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] ReleaseCreate,
+        [Description("Create a release for a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] public static readonly Permission ReleaseCreate = new Permission("ReleaseCreate");
 
-        [Description("View a release of a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] ReleaseView,
+        [Description("View a release of a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] public static readonly Permission ReleaseView = new Permission("ReleaseView");
 
-        [Description("Edit a release of a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] ReleaseEdit,
+        [Description("Edit a release of a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] public static readonly Permission ReleaseEdit = new Permission("ReleaseEdit");
 
-        [Description("Delete a release of a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] ReleaseDelete,
+        [Description("Delete a release of a project")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Tenants)] public static readonly Permission ReleaseDelete = new Permission("ReleaseDelete");
 
-        [Description("Block a release from progressing to the next lifecycle phase")] [SupportsRestriction(PermissionScope.Projects)] DefectReport,
+        [Description("Block a release from progressing to the next lifecycle phase")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission DefectReport = new Permission("DefectReport");
 
-        [Description("Unblock a release so it can progress to the next phase")] [SupportsRestriction(PermissionScope.Projects)] DefectResolve,
+        [Description("Unblock a release so it can progress to the next phase")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission DefectResolve = new Permission("DefectResolve");
 
-        [Description("Deploy releases to target environments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] DeploymentCreate,
+        [Description("Deploy releases to target environments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission DeploymentCreate = new Permission("DeploymentCreate");
 
-        [Description("Delete deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] DeploymentDelete,
+        [Description("Delete deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission DeploymentDelete = new Permission("DeploymentDelete");
 
-        [Description("View deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] DeploymentView,
+        [Description("View deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission DeploymentView = new Permission("DeploymentView");
 
-        [Description("View environments")] [SupportsRestriction(PermissionScope.Environments)] EnvironmentView,
+        [Description("View environments")] [SupportsRestriction(PermissionScope.Environments)] public static readonly Permission EnvironmentView = new Permission("EnvironmentView");
 
-        [Description("Create environments")] [SupportsRestriction(PermissionScope.Environments)] EnvironmentCreate,
+        [Description("Create environments")] [SupportsRestriction(PermissionScope.Environments)] public static readonly Permission EnvironmentCreate = new Permission("EnvironmentCreate");
 
-        [Description("Edit environments")] [SupportsRestriction(PermissionScope.Environments)] EnvironmentEdit,
+        [Description("Edit environments")] [SupportsRestriction(PermissionScope.Environments)] public static readonly Permission EnvironmentEdit = new Permission("EnvironmentEdit");
 
-        [Description("Delete environments")] [SupportsRestriction(PermissionScope.Environments)] EnvironmentDelete,
+        [Description("Delete environments")] [SupportsRestriction(PermissionScope.Environments)] public static readonly Permission EnvironmentDelete = new Permission("EnvironmentDelete");
 
-        [Description("Create machines")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] MachineCreate,
+        [Description("Create machines")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission MachineCreate = new Permission("MachineCreate");
 
-        [Description("Edit machines")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] MachineEdit,
+        [Description("Edit machines")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission MachineEdit = new Permission("MachineEdit");
 
-        [Description("View machines")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] MachineView,
+        [Description("View machines")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission MachineView = new Permission("MachineView");
 
-        [Description("Delete machines")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] MachineDelete,
+        [Description("Delete machines")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission MachineDelete = new Permission("MachineDelete");
 
-        [Description("View the artifacts created manually and during deployment")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] ArtifactView,
+        [Description("View the artifacts created manually and during deployment")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission ArtifactView = new Permission("ArtifactView");
 
-        [Description("Manually create artifacts")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] ArtifactCreate,
+        [Description("Manually create artifacts")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission ArtifactCreate = new Permission("ArtifactCreate");
 
-        [Description("Edit the details describing artifacts")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] ArtifactEdit,
+        [Description("Edit the details describing artifacts")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission ArtifactEdit = new Permission("ArtifactEdit");
 
-        [Description("Delete artifacts")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] ArtifactDelete,
+        [Description("Delete artifacts")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission ArtifactDelete = new Permission("ArtifactDelete");
 
-        [Description("View package feeds and the packages in them")] FeedView,
+        [Description("View package feeds and the packages in them")] public static readonly Permission FeedView = new Permission("FeedView");
 
-        [Description("View release and deployment events")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] EventView,
+        [Description("View release and deployment events")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission EventView = new Permission("EventView");
 
-        [Description("View library variable sets")] LibraryVariableSetView,
+        [Description("View library variable sets")] public static readonly Permission LibraryVariableSetView = new Permission("LibraryVariableSetView");
 
-        [Description("Create library variable sets")] LibraryVariableSetCreate,
+        [Description("Create library variable sets")] public static readonly Permission LibraryVariableSetCreate = new Permission("LibraryVariableSetCreate");
 
-        [Description("Edit library variable sets")] LibraryVariableSetEdit,
+        [Description("Edit library variable sets")] public static readonly Permission LibraryVariableSetEdit = new Permission("LibraryVariableSetEdit");
 
-        [Description("Delete library variable sets")] LibraryVariableSetDelete,
+        [Description("Delete library variable sets")] public static readonly Permission LibraryVariableSetDelete = new Permission("LibraryVariableSetDelete");
 
-        [Description("View project groups")] [SupportsRestriction(PermissionScope.ProjectGroups)] ProjectGroupView,
+        [Description("View project groups")] [SupportsRestriction(PermissionScope.ProjectGroups)] public static readonly Permission ProjectGroupView = new Permission("ProjectGroupView");
 
-        [Description("Create project groups")] [SupportsRestriction(PermissionScope.ProjectGroups)] ProjectGroupCreate,
+        [Description("Create project groups")] [SupportsRestriction(PermissionScope.ProjectGroups)] public static readonly Permission ProjectGroupCreate = new Permission("ProjectGroupCreate");
 
-        [Description("Edit project groups")] [SupportsRestriction(PermissionScope.ProjectGroups)] ProjectGroupEdit,
+        [Description("Edit project groups")] [SupportsRestriction(PermissionScope.ProjectGroups)] public static readonly Permission ProjectGroupEdit = new Permission("ProjectGroupEdit");
 
-        [Description("Delete project groups")] [SupportsRestriction(PermissionScope.ProjectGroups)] ProjectGroupDelete,
+        [Description("Delete project groups")] [SupportsRestriction(PermissionScope.ProjectGroups)] public static readonly Permission ProjectGroupDelete = new Permission("ProjectGroupDelete");
 
-        [Description("Create teams")] TeamCreate,
+        [Description("Create teams")] public static readonly Permission TeamCreate = new Permission("TeamCreate");
 
-        [Description("View teams")] TeamView,
+        [Description("View teams")] public static readonly Permission TeamView = new Permission("TeamView");
 
-        [Description("Edit teams")] TeamEdit,
+        [Description("Edit teams")] public static readonly Permission TeamEdit = new Permission("TeamEdit");
 
-        [Description("Delete teams")] TeamDelete,
+        [Description("Delete teams")] public static readonly Permission TeamDelete = new Permission("TeamDelete");
 
-        [Description("View users")] UserView,
+        [Description("View users")] public static readonly Permission UserView = new Permission("UserView");
 
-        [Description("Invite users to register accounts")] UserInvite,
+        [Description("Invite users to register accounts")] public static readonly Permission UserInvite = new Permission("UserInvite");
 
-        [Description("View other user's roles")] UserRoleView,
+        [Description("View other user's roles")] public static readonly Permission UserRoleView = new Permission("UserRoleView");
 
-        [Description("Edit user role definitions")] UserRoleEdit,
+        [Description("Edit user role definitions")] public static readonly Permission UserRoleEdit = new Permission("UserRoleEdit");
 
 
-        [Description("View summary-level information associated with a task")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] TaskView,
+        [Description("View summary-level information associated with a task")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission TaskView = new Permission("TaskView");
 
         [Obsolete("TaskViewLog is no longer supported by Octopus Server. Instead use the TaskView permission, which also grants access to Task logs", false)]
-        [Description("View detailed information about the execution of a task, including the task log output")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] TaskViewLog,
+        [Description("View detailed information about the execution of a task, including the task log output")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission TaskViewLog = new Permission("TaskViewLog");
 
-        [Description("Explicitly create (run) server tasks")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] TaskCreate,
+        [Description("Explicitly create (run) server tasks")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission TaskCreate = new Permission("TaskCreate");
 
-        [Description("Cancel server tasks")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] TaskCancel,
+        [Description("Cancel server tasks")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission TaskCancel = new Permission("TaskCancel");
 
-        [Description("Edit server tasks")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] TaskEdit,
+        [Description("Edit server tasks")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission TaskEdit = new Permission("TaskEdit");
 
 
-        [Description("View interruptions generated during deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] InterruptionView,
+        [Description("View interruptions generated during deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission InterruptionView = new Permission("InterruptionView");
 
-        [Description("Take responsibility for and submit interruptions generated during deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] InterruptionSubmit,
+        [Description("Take responsibility for and submit interruptions generated during deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission InterruptionSubmit = new Permission("InterruptionSubmit");
 
-        [Description("Take responsibility for and submit interruptions generated during deployments when the user is in a designated responsible team")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] InterruptionViewSubmitResponsible,
+        [Description("Take responsibility for and submit interruptions generated during deployments when the user is in a designated responsible team")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission InterruptionViewSubmitResponsible = new Permission("InterruptionViewSubmitResponsible");
 
-        [Description("Push new packages to the built-in package repository")] [SupportsRestriction(PermissionScope.Projects)] BuiltInFeedPush,
+        [Description("Push new packages to the built-in package repository")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission BuiltInFeedPush = new Permission("BuiltInFeedPush");
 
-        [Description("Replace or delete packages in the built-in package repository")] [SupportsRestriction(PermissionScope.Projects)] BuiltInFeedAdminister,
+        [Description("Replace or delete packages in the built-in package repository")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission BuiltInFeedAdminister = new Permission("BuiltInFeedAdminister");
 
-        [Description("Retrieve the contents of packages in the built-in package repository")] [SupportsRestriction(PermissionScope.Projects)] BuiltInFeedDownload,
+        [Description("Retrieve the contents of packages in the built-in package repository")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission BuiltInFeedDownload = new Permission("BuiltInFeedDownload");
 
-        [Description("View step templates")] ActionTemplateView,
+        [Description("View step templates")] public static readonly Permission ActionTemplateView = new Permission("ActionTemplateView");
 
-        [Description("Create step templates")] ActionTemplateCreate,
+        [Description("Create step templates")] public static readonly Permission ActionTemplateCreate = new Permission("ActionTemplateCreate");
 
-        [Description("Edit step templates")] ActionTemplateEdit,
+        [Description("Edit step templates")] public static readonly Permission ActionTemplateEdit = new Permission("ActionTemplateEdit");
 
-        [Description("Delete step templates")] ActionTemplateDelete,
+        [Description("Delete step templates")] public static readonly Permission ActionTemplateDelete = new Permission("ActionTemplateDelete");
 
-        [Description("Create lifecycles")] LifecycleCreate,
+        [Description("Create lifecycles")] public static readonly Permission LifecycleCreate = new Permission("LifecycleCreate");
 
-        [Description("View lifecycles")] LifecycleView,
+        [Description("View lifecycles")] public static readonly Permission LifecycleView = new Permission("LifecycleView");
 
-        [Description("Edit lifecycles")] LifecycleEdit,
+        [Description("Edit lifecycles")] public static readonly Permission LifecycleEdit = new Permission("LifecycleEdit");
 
-        [Description("Delete lifecycles")] LifecycleDelete,
+        [Description("Delete lifecycles")] public static readonly Permission LifecycleDelete = new Permission("LifecycleDelete");
 
-        [Description("View accounts")] [SupportsRestriction(PermissionScope.Environments)] AccountView,
+        [Description("View accounts")] [SupportsRestriction(PermissionScope.Environments)] public static readonly Permission AccountView = new Permission("AccountView");
 
-        [Description("Edit accounts")] [SupportsRestriction(PermissionScope.Environments)] AccountEdit,
+        [Description("Edit accounts")] [SupportsRestriction(PermissionScope.Environments)] public static readonly Permission AccountEdit = new Permission("AccountEdit");
 
-        [Description("Create accounts")] [SupportsRestriction(PermissionScope.Environments)] AccountCreate,
+        [Description("Create accounts")] [SupportsRestriction(PermissionScope.Environments)] public static readonly Permission AccountCreate = new Permission("AccountCreate");
 
-        [Description("Delete accounts")] [SupportsRestriction(PermissionScope.Environments)] AccountDelete,
+        [Description("Delete accounts")] [SupportsRestriction(PermissionScope.Environments)] public static readonly Permission AccountDelete = new Permission("AccountDelete");
 
-        [Description("Create tenants")] [SupportsRestriction(PermissionScope.Tenants)] TenantCreate,
+        [Description("Create tenants")] [SupportsRestriction(PermissionScope.Tenants)] public static readonly Permission TenantCreate = new Permission("TenantCreate");
 
-        [Description("Edit tenants")] [SupportsRestriction(PermissionScope.Tenants)] TenantEdit,
+        [Description("Edit tenants")] [SupportsRestriction(PermissionScope.Tenants)] public static readonly Permission TenantEdit = new Permission("TenantEdit");
 
-        [Description("View tenants")] [SupportsRestriction(PermissionScope.Tenants)] TenantView,
+        [Description("View tenants")] [SupportsRestriction(PermissionScope.Tenants)] public static readonly Permission TenantView = new Permission("TenantView");
 
-        [Description("Delete tenants")] [SupportsRestriction(PermissionScope.Tenants)] TenantDelete,
+        [Description("Delete tenants")] [SupportsRestriction(PermissionScope.Tenants)] public static readonly Permission TenantDelete = new Permission("TenantDelete");
 
-        [Description("Create tag sets")] TagSetCreate,
+        [Description("Create tag sets")] public static readonly Permission TagSetCreate = new Permission("TagSetCreate");
 
-        [Description("Edit tag sets")] TagSetEdit,
+        [Description("Edit tag sets")] public static readonly Permission TagSetEdit = new Permission("TagSetEdit");
 
-        [Description("Delete tag sets")] TagSetDelete,
-        
-        [Description("View telemetry data")] TelemetryView,
+        [Description("Delete tag sets")] public static readonly Permission TagSetDelete = new Permission("TagSetDelete");
 
-        [Description("Create health check policies")] MachinePolicyCreate,
+        [Description("View telemetry data")] public static readonly Permission TelemetryView = new Permission("TelemetryView");
 
-        [Description("View health check policies")] MachinePolicyView,
+        [Description("Create health check policies")] public static readonly Permission MachinePolicyCreate = new Permission("MachinePolicyCreate");
 
-        [Description("Edit health check policies")] MachinePolicyEdit,
+        [Description("View health check policies")] public static readonly Permission MachinePolicyView = new Permission("MachinePolicyView");
 
-        [Description("Delete health check policies")] MachinePolicyDelete,
+        [Description("Edit health check policies")] public static readonly Permission MachinePolicyEdit = new Permission("MachinePolicyEdit");
 
-        [Description("Create proxies")] ProxyCreate,
+        [Description("Delete health check policies")] public static readonly Permission MachinePolicyDelete = new Permission("MachinePolicyDelete");
 
-        [Description("View proxies")] ProxyView,
+        [Description("Create proxies")] public static readonly Permission ProxyCreate = new Permission("ProxyCreate");
 
-        [Description("Edit proxies")] ProxyEdit,
+        [Description("View proxies")] public static readonly Permission ProxyView = new Permission("ProxyView");
 
-        [Description("Delete proxies")] ProxyDelete,
+        [Description("Edit proxies")] public static readonly Permission ProxyEdit = new Permission("ProxyEdit");
 
-        [Description("Create subscriptions")] SubscriptionCreate,
+        [Description("Delete proxies")] public static readonly Permission ProxyDelete = new Permission("ProxyDelete");
 
-        [Description("View subscriptions")] SubscriptionView,
+        [Description("Create subscriptions")] public static readonly Permission SubscriptionCreate = new Permission("SubscriptionCreate");
 
-        [Description("Edit subscriptions")] SubscriptionEdit,
+        [Description("View subscriptions")] public static readonly Permission SubscriptionView = new Permission("SubscriptionView");
 
-        [Description("Delete subscriptions")] SubscriptionDelete,
+        [Description("Edit subscriptions")] public static readonly Permission SubscriptionEdit = new Permission("SubscriptionEdit");
 
-        [Description("Create triggers")] [SupportsRestriction(PermissionScope.Projects)] TriggerCreate,
+        [Description("Delete subscriptions")] public static readonly Permission SubscriptionDelete = new Permission("SubscriptionDelete");
 
-        [Description("View triggers")] [SupportsRestriction(PermissionScope.Projects)] TriggerView,
+        [Description("Create triggers")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission TriggerCreate = new Permission("TriggerCreate");
 
-        [Description("Edit triggers")] [SupportsRestriction(PermissionScope.Projects)] TriggerEdit,
+        [Description("View triggers")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission TriggerView = new Permission("TriggerView");
 
-        [Description("Delete triggers")] [SupportsRestriction(PermissionScope.Projects)] TriggerDelete,
+        [Description("Edit triggers")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission TriggerEdit = new Permission("TriggerEdit");
 
-        [Description("View certificates")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] CertificateView,
+        [Description("Delete triggers")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission TriggerDelete = new Permission("TriggerDelete");
 
-        [Description("Create certificates")] CertificateCreate,
+        [Description("View certificates")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission CertificateView = new Permission("CertificateView");
 
-        [Description("Edit certificates")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] CertificateEdit,
+        [Description("Create certificates")] public static readonly Permission CertificateCreate = new Permission("CertificateCreate");
 
-        [Description("Delete certificates")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] CertificateDelete,
+        [Description("Edit certificates")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission CertificateEdit = new Permission("CertificateEdit");
 
-        [Description("Export certificate private-keys")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] CertificateExportPrivateKey,
+        [Description("Delete certificates")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission CertificateDelete = new Permission("CertificateDelete");
 
-        [Description("Edit users")] UserEdit,
-        
-        [Description("Configure server settings like Authentication, SMTP, and HTTP Security Headers")] ConfigureServer,
+        [Description("Export certificate private-keys")] [SupportsRestriction(PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission CertificateExportPrivateKey = new Permission("CertificateExportPrivateKey");
 
-        [Description("Edit feeds")] FeedEdit,
+        [Description("Edit users")] public static readonly Permission UserEdit = new Permission("UserEdit");
 
-        [Description("View the workers in worker pools")] WorkerView,
+        [Description("Configure server settings like Authentication, SMTP, and HTTP Security Headers")] public static readonly Permission ConfigureServer = new Permission("ConfigureServer");
 
-        [Description("Edit workers and worker pools")] WorkerEdit,
+        [Description("Edit feeds")] public static readonly Permission FeedEdit = new Permission("FeedEdit");
 
-        [Description("Edit spaces")] SpaceEdit,
-        
-        [Description("View spaces")] SpaceView,
-        
-        [Description("Delete spaces")] SpaceDelete,
-        
-        [Description("Create spaces")] SpaceCreate,
+        [Description("View the workers in worker pools")] public static readonly Permission WorkerView = new Permission("WorkerView");
 
-        [Description("Create/update build information")] BuildInformationPush,
-        
-        [Description("Replace or delete build information")] BuildInformationAdminister,
+        [Description("Edit workers and worker pools")] public static readonly Permission WorkerEdit = new Permission("WorkerEdit");
 
-        [Description("View runbooks")] [SupportsRestriction(PermissionScope.Projects)] RunbookView,
+        [Description("Edit spaces")] public static readonly Permission SpaceEdit = new Permission("SpaceEdit");
 
-        [Description("Edit runbooks")] [SupportsRestriction(PermissionScope.Projects)] RunbookEdit,
+        [Description("View spaces")] public static readonly Permission SpaceView = new Permission("SpaceView");
 
-        [Description("View runbook runs")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] RunbookRunView,
+        [Description("Delete spaces")] public static readonly Permission SpaceDelete = new Permission("SpaceDelete");
 
-        [Description("Delete runbook runs")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] RunbookRunDelete,
+        [Description("Create spaces")] public static readonly Permission SpaceCreate = new Permission("SpaceCreate");
 
-        [Description("Create runbook runs")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] RunbookRunCreate,
+        [Description("Create/update build information")] public static readonly Permission BuildInformationPush = new Permission("BuildInformationPush");
 
-        [Description("View Git credentials")] GitCredentialView,
+        [Description("Replace or delete build information")] public static readonly Permission BuildInformationAdminister = new Permission("BuildInformationAdminister");
 
-        [Description("Edit Git credentials")] GitCredentialEdit
+        [Description("View runbooks")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission RunbookView = new Permission("RunbookView");
+
+        [Description("Edit runbooks")] [SupportsRestriction(PermissionScope.Projects)] public static readonly Permission RunbookEdit = new Permission("RunbookEdit");
+
+        [Description("View runbook runs")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission RunbookRunView = new Permission("RunbookRunView");
+
+        [Description("Delete runbook runs")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission RunbookRunDelete = new Permission("RunbookRunDelete");
+
+        [Description("Create runbook runs")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission RunbookRunCreate = new Permission("RunbookRunCreate");
+
+        [Description("View Git credentials")] public static readonly Permission GitCredentialView = new Permission("GitCredentialView");
+
+        [Description("Edit Git credentials")] public static readonly Permission GitCredentialEdit = new Permission("GitCredentialEdit");
+
+        [JsonConstructor]
+        public Permission(string id)
+        {
+            Id = id;
+        }
+
+        private string Id { get; }
+
+        public bool Equals(Permission? other)
+        {
+            if ((object?) other == null)
+                return false;
+            return (object) this == (object) other || string.Equals(this.Id, other.Id, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj == null)
+                return false;
+            if ((object) this == obj)
+                return true;
+            return !(obj.GetType() != this.GetType()) && this.Equals((Permission) obj);
+        }
+
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(this.Id);
+
+        public static bool operator ==(Permission left, Permission right) => object.Equals((object) left, (object) right);
+
+        public static bool operator !=(Permission left, Permission right) => !object.Equals((object) left, (object) right);
+
+        public override string ToString()
+        {
+            return Id;
+        }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/UserRolesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/UserRolesRepository.cs
@@ -20,7 +20,7 @@ namespace Octopus.Client.Repositories.Async
         public override async Task<UserRoleResource> Create(UserRoleResource resource, object pathParameters = null)
         {
             await ThrowIfServerVersionIsNotCompatible();
-            
+
             await RemoveInvalidPermissions(resource).ConfigureAwait(false);
             return await base.Create(resource, pathParameters).ConfigureAwait(false);
         }
@@ -28,25 +28,25 @@ namespace Octopus.Client.Repositories.Async
         public override async Task<UserRoleResource> Modify(UserRoleResource resource)
         {
             await ThrowIfServerVersionIsNotCompatible();
-            
+
             await RemoveInvalidPermissions(resource).ConfigureAwait(false);
             return await base.Modify(resource).ConfigureAwait(false);
         }
 
+#pragma warning disable 618
+        static readonly Permission TaskViewLogPermission = Permission.TaskViewLog;
+#pragma warning restore 618
+
         private async Task RemoveInvalidPermissions(UserRoleResource resource)
         {
-#pragma warning disable 618
-            const Permission taskViewLogPermission = Permission.TaskViewLog;
-#pragma warning restore 618
-            
             var versionWhenTaskViewLogWasRemoved = SemanticVersion.Parse("2019.1.7");
             var rootDocument = await Repository.LoadRootDocument().ConfigureAwait(false);
             var serverSupportsTaskViewLog = SemanticVersion.Parse(rootDocument.Version) < versionWhenTaskViewLogWasRemoved;
 
             if (!serverSupportsTaskViewLog)
             {
-                resource.GrantedSpacePermissions = RemoveDeprecatedPermission(taskViewLogPermission, resource.GrantedSpacePermissions);
-                resource.GrantedSystemPermissions = RemoveDeprecatedPermission(taskViewLogPermission, resource.GrantedSystemPermissions);
+                resource.GrantedSpacePermissions = RemoveDeprecatedPermission(TaskViewLogPermission, resource.GrantedSpacePermissions);
+                resource.GrantedSystemPermissions = RemoveDeprecatedPermission(TaskViewLogPermission, resource.GrantedSystemPermissions);
             }
 
             List<Permission> RemoveDeprecatedPermission(Permission permissionToRemove, List<Permission> permissions)

--- a/source/Octopus.Server.Client/Repositories/UserRolesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/UserRolesRepository.cs
@@ -7,7 +7,7 @@ namespace Octopus.Client.Repositories
     public interface IUserRolesRepository : IFindByName<UserRoleResource>, IGet<UserRoleResource>, ICreate<UserRoleResource>, IModify<UserRoleResource>, IDelete<UserRoleResource>
     {
     }
-    
+
     class UserRolesRepository : BasicRepository<UserRoleResource>, IUserRolesRepository
     {
         public UserRolesRepository(IOctopusRepository repository)
@@ -19,7 +19,7 @@ namespace Octopus.Client.Repositories
         public override UserRoleResource Create(UserRoleResource resource, object pathParameters = null)
         {
             ThrowIfServerVersionIsNotCompatible();
-            
+
             RemoveInvalidPermissions(resource);
             return base.Create(resource, pathParameters);
         }
@@ -27,24 +27,24 @@ namespace Octopus.Client.Repositories
         public override UserRoleResource Modify(UserRoleResource resource)
         {
             ThrowIfServerVersionIsNotCompatible();
-            
+
             RemoveInvalidPermissions(resource);
             return base.Modify(resource);
         }
 
+#pragma warning disable 618
+        static readonly Permission TaskViewLogPermission = Permission.TaskViewLog;
+#pragma warning restore 618
+
         private void RemoveInvalidPermissions(UserRoleResource resource)
         {
-#pragma warning disable 618
-            const Permission taskViewLogPermission = Permission.TaskViewLog;
-#pragma warning restore 618
-            
             var versionWhenTaskViewLogWasRemoved = SemanticVersion.Parse("2019.1.7");
             var serverSupportsTaskViewLog = SemanticVersion.Parse(Repository.LoadRootDocument().Version) < versionWhenTaskViewLogWasRemoved;
 
             if (!serverSupportsTaskViewLog)
             {
-                resource.GrantedSpacePermissions = RemoveDeprecatedPermission(taskViewLogPermission, resource.GrantedSpacePermissions);
-                resource.GrantedSystemPermissions = RemoveDeprecatedPermission(taskViewLogPermission, resource.GrantedSystemPermissions);
+                resource.GrantedSpacePermissions = RemoveDeprecatedPermission(TaskViewLogPermission, resource.GrantedSpacePermissions);
+                resource.GrantedSystemPermissions = RemoveDeprecatedPermission(TaskViewLogPermission, resource.GrantedSystemPermissions);
             }
 
             List<Permission> RemoveDeprecatedPermission(Permission permissionToRemove, List<Permission> permissions)

--- a/source/Octopus.Server.Client/Serialization/JsonSerialization.cs
+++ b/source/Octopus.Server.Client/Serialization/JsonSerialization.cs
@@ -29,7 +29,8 @@ namespace Octopus.Client.Serialization
                 {
                     new TinyTypeJsonConverter(),
                     new StringEnumConverter(),
-                    new MultiIsoDateTimeFormatConverter("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffK", 
+                    new PermissionConverter(),
+                    new MultiIsoDateTimeFormatConverter("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffK",
                         "dddd, dd MMMM yyyy h:mm tt zzz", "f" ),
                     new ControlConverter(),
                     new EndpointConverter(),

--- a/source/Octopus.Server.Client/Serialization/PermissionConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/PermissionConverter.cs
@@ -1,0 +1,42 @@
+﻿#nullable enable
+using System;
+using Newtonsoft.Json;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Serialization
+{
+    public class PermissionConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Permission);
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            var v = value.ToString();
+            writer.WriteValue(v);
+        }
+
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonToken.String)
+            {
+                return new Permission(reader.Value!.ToString());
+            }
+
+            throw new Exception("Unable to parse token type " + reader.TokenType + " as permission string");
+        }
+    }
+}


### PR DESCRIPTION
The Permission enum causes us issues every time a new permission is added to server. Older versions of client talking to newer versions of server with new permissions cause the Json deserialization to throw an exception when it doesn't recognise an enum value. This is the nature of enums.

In Octopus server itself, and in our other client libraries, we have moved most things away from using enums now. The preferred option over enums is a class that represents the same value but internally is just the string value off the wire.

To show some examples, the AdministerSystem permission is now defined as follows on the permissions class.

```
public static readonly Permission AdministerSystem = new Permission("AdministerSystem");
```

The Permission class itself is implementing `IEquatable` and has a `ToString` override, so for all intents and purposes it should still act exactly like an enum when you're consuming it.

E.g. if you had any of the following pieces of code before this change they would still compile after it
```
if (someObject.Permission == Permission.AdministerSystem)
```
```
if (someObject.Permissions.Contains(Permission.AdministerSystem))
```
```
someObject.Permissions.Add(Permission.AdministerSystem);
```

A new PermissionConverter is included and is wired in by default. It simply does a `ToString` of the object instances to serialize them and creates a new instance with the string value to deserialize. This means that if server sends a new value that didn't exist at client's compile time then there'll just be an object instance that won't equate to any known Permission instances, but it won't throw any exceptions.

This PR is likely easier to review per commit.