### PR TITLE
Keep all Octopus types public when ILMerging

### DIFF
--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -25,6 +25,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+        <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="NUnit" Version="3.8.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />

--- a/source/Octopus.Client.E2ETests/OctopusClientsCanBeMockedFixture.cs
+++ b/source/Octopus.Client.E2ETests/OctopusClientsCanBeMockedFixture.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Octopus.Client.E2ETests
+{
+    public class OctopusClientsCanBeMockedFixture
+    {
+        [Test]
+        public void WeShouldBeAbleToCreateAMockAsyncClient()
+        {
+            var client = Substitute.For<IOctopusAsyncClient>();
+            client.Should().NotBeNull();
+        }
+
+        [Test]
+        public void WeShouldBeAbleToCreateAMockClient()
+        {
+            var client = Substitute.For<IOctopusClient>();
+            client.Should().NotBeNull();
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/OctopusClientsCanBeMockedFixture.cs
+++ b/source/Octopus.Client.Tests/OctopusClientsCanBeMockedFixture.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Octopus.Client.Tests
+{
+    public class OctopusClientsCanBeMockedFixture
+    {
+        [Test]
+        public void WeShouldBeAbleToCreateAMockAsyncClient()
+        {
+            var client = Substitute.For<IOctopusAsyncClient>();
+            client.Should().NotBeNull();
+        }
+
+        [Test]
+        public void WeShouldBeAbleToCreateAMockClient()
+        {
+            var client = Substitute.For<IOctopusClient>();
+            client.Should().NotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
# Background

Fixes #635.

# Results

This PR ensures that all relevant Octopus-defined types keep their existing visibility (i.e. `public`) when being ILMerged into a single `Octopus.Client.dll`.

It also works around an apparent bug in `il-repack` which ignores type name exclusions.

# Testing this PR

1. Run up a new C# solution. A simple console app is fine.
2. Restrict the package sources to nuget.org and `Install-Package Octopus.Client`
3. Observe that the `ICommand<,>` interface is marked as internal. (Try to define a type which implements it and it will go red pretty quickly.)
4. Remove the package reference.
5. Restrict the package sources to the Octopus internal NuGet feed and `Install-Package Octopus.Client -Pre -Version 11.4.3622-bug-ilmerging-internalises-public-interfaces`
6. Observe that the test code now compiles.
