### PR TITLE
Make Octopus.TinyTypes.* internal again when ILMerging.

### DIFF
--- a/source/Octopus.Client.E2ETests/InlinedDependenciesFixture.cs
+++ b/source/Octopus.Client.E2ETests/InlinedDependenciesFixture.cs
@@ -1,9 +1,12 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions;
 using NUnit.Framework;
+
+// ReSharper disable ReplaceWithSingleCallToFirstOrDefault
 
 namespace Octopus.Client.E2ETests
 {
@@ -23,21 +26,14 @@ namespace Octopus.Client.E2ETests
             var runtime = TestHelpers.GetRuntime();
             var package = TestHelpers.GetNuGetPackage();
 
-            using (var zipFile = ZipFile.OpenRead(package))
-            {
-                var zipArchiveEntry =
-                    zipFile.Entries.FirstOrDefault(x => x.FullName.Contains("lib/" + runtime + "/Octopus.Client.dll"));
-                using (var stream = zipArchiveEntry.Open())
-                {
-                    using (var ms = new MemoryStream())
-                    {
-                        stream.CopyTo(ms);
+            using var zipFile = ZipFile.OpenRead(package);
+            var zipArchiveEntry = zipFile.Entries.First(x => x.FullName.Contains("lib/" + runtime + "/Octopus.Client.dll"));
+            using var stream = zipArchiveEntry.Open();
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
 
-                        var rawAssembly = ms.ToArray();
-                        assembly = Assembly.Load(rawAssembly);
-                    }
-                }
-            }
+            var rawAssembly = ms.ToArray();
+            assembly = Assembly.Load(rawAssembly);
         }
 
         [OneTimeTearDown]
@@ -48,23 +44,42 @@ namespace Octopus.Client.E2ETests
         private Assembly assembly;
 
         [Test]
-        [TestCase("Newtonsoft.Json", "Newtonsoft.Json.JsonConvert")]
-        [TestCase("Octodiff", "Octodiff.Core.DeltaBuilder")]
-        [TestCase("Octopus.TinyTypes", "Octopus.TinyTypes.TinyType`1")]
-        [TestCase("Octopus.TinyTypes.Json", "Octopus.TinyTypes.Json.TinyTypeJsonConverter")]
-        [TestCase("Octopus.TinyTypes.TypeConverters", "Octopus.TinyTypes.TypeConverters.TinyTypeConverter`1")]
-        public void HasInlinedDependency(string library, string typeName)
+        [TestCase("Newtonsoft.Json", "Newtonsoft.Json.JsonConvert", Visibility.Internal)]
+        [TestCase("Octodiff", "Octodiff.Core.DeltaBuilder", Visibility.Internal)]
+        [TestCase("Octopus.TinyTypes", "Octopus.TinyTypes.TinyType`1", Visibility.Internal)]
+        [TestCase("Octopus.TinyTypes.Json", "Octopus.TinyTypes.Json.TinyTypeJsonConverter", Visibility.Internal)]
+        [TestCase("Octopus.TinyTypes.TypeConverters", "Octopus.TinyTypes.TypeConverters.TinyTypeConverter`1", Visibility.Internal)]
+        [TestCase("Octopus.Server.MessageContracts.Base", "Octopus.Server.MessageContracts.Base.ICommand`2", Visibility.Public)]
+        [TestCase("Octopus.Server.MessageContracts.Base.HttpRoutes", "Octopus.Server.MessageContracts.Base.HttpRoutes.HttpRouteTemplateAttribute", Visibility.Public)]
+        public void HasInlinedDependency(string library, string typeName, Visibility expectedVisibility)
         {
-            var typeNames = assembly.GetTypes()
-                .Select(t => t.FullName)
-                .OrderBy(x => x)
-                .ToArray();
+            var type = assembly.GetTypes()
+                .Where(t => t.FullName == typeName)
+                .FirstOrDefault();
 
-            typeNames
-                .FirstOrDefault(x => x == typeName)
+            type
                 .Should()
                 .NotBeNull(
                     $"We should have ILMerged {library} in, so customers don't need to reference that separately.");
+
+            // Some of our dependencies should remain public. Some should be internalized when we do the il-repack step.
+            switch (expectedVisibility)
+            {
+                case Visibility.Internal:
+                    type!.IsPublic.Should().BeFalse();
+                    break;
+                case Visibility.Public:
+                    type!.IsPublic.Should().BeTrue();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(expectedVisibility), expectedVisibility, null);
+            }
+        }
+
+        public enum Visibility
+        {
+            Internal,
+            Public
         }
     }
 }


### PR DESCRIPTION
# Background

We recently adjusted ILMerge settings to ensure that types from `Octopus.Server.MessageContracts.Base` and `Octopus.Server.MessageContracts.Base.HttpRoutes` remained public after an ILMerge. We brought all of the Octopus.* types along with that change, only to discover that there are some usages where there is now a conflict with some users' references to `Octopus.TinyTypes.*`.

Ultimately, the single ILMerged client will need some more invasive surgery before it can support API vNext payloads. Until then, though, its knowledge of Octopus.TinyTypes.* can (and should) be kept internal.

