### PR TITLE
Fall back to ConvertToVcs link if there is no ConvertToGit link

### DIFF
--- a/source/Octopus.Client.Tests/Repositories/ProjectRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/ProjectRepositoryFixture.cs
@@ -1,0 +1,93 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Model.Git;
+
+namespace Octopus.Client.Tests.Repositories
+{
+    [TestFixture]
+    public class ProjectRepositoryFixture
+    {
+        OctopusAsyncRepository asyncRepository;
+        string asyncUrlUsed;
+        
+        OctopusRepository syncRepository;
+        string syncUrlUsed;
+
+        [SetUp]
+        public void Setup()
+        {
+            var asyncClient = Substitute.For<IOctopusAsyncClient>();
+            asyncRepository = new OctopusAsyncRepository(asyncClient);
+            asyncClient.Post<ConvertProjectToGitCommand, ConvertProjectToGitResponse>(Arg.Do<string>(x => asyncUrlUsed = x), Arg.Any<ConvertProjectToGitCommand>()).Returns(new ConvertProjectToGitResponse());
+
+            var syncClient = Substitute.For<IOctopusClient>();
+            syncRepository = new OctopusRepository(syncClient);
+            syncClient.Post<ConvertProjectToGitCommand, ConvertProjectToGitResponse>(Arg.Do<string>(x => syncUrlUsed = x), Arg.Any<ConvertProjectToGitCommand>()).Returns(new ConvertProjectToGitResponse());
+        }
+
+        [Test]
+        public async Task ConvertToGit_HasConvertToGitAndConvertToVcsLink_UsesConvertToGitLink()
+        {
+            // Arrange
+            var gitUrl = "/convert/to/git";
+            var project = new ProjectResource
+            {
+                Links = new LinkCollection
+                {
+                    {"ConvertToGit", new Href(gitUrl)},
+                    {"ConvertToVcs", new Href("/convert/to/vcs")}
+                }
+            };
+
+            // Act
+            await asyncRepository.Projects.ConvertToGit(project, new GitPersistenceSettingsResource(), string.Empty);
+            syncRepository.Projects.ConvertToGit(project, new GitPersistenceSettingsResource(), string.Empty);
+
+            // Assert
+            asyncUrlUsed.Should().Be(gitUrl);
+            syncUrlUsed.Should().Be(gitUrl);
+        }
+
+        [Test]
+        public async Task ConvertToGit_OnlyHasConvertToVcsLink_UsesConvertToVcsLink()
+        {
+            // Arrange
+            var vcsUrl = "/convert/to/vcs";
+            var project = new ProjectResource
+            {
+                Links = new LinkCollection {{"ConvertToVcs", new Href(vcsUrl)}}
+            };
+
+            // Act
+            await asyncRepository.Projects.ConvertToGit(project, new GitPersistenceSettingsResource(), string.Empty);
+            syncRepository.Projects.ConvertToGit(project, new GitPersistenceSettingsResource(), string.Empty);
+
+            // Assert
+            asyncUrlUsed.Should().Be(vcsUrl);
+            syncUrlUsed.Should().Be(vcsUrl);
+        }
+
+        [Test]
+        public async Task ConvertToGit_OnlyHasConvertToGitLink_UsesConvertToGitLink()
+        {
+            // Arrange
+            var gitUrl = "/convert/to/git";
+            var project = new ProjectResource
+            {
+                Links = new LinkCollection {{"ConvertToGit", new Href(gitUrl)}}
+            };
+
+            // Act
+            await asyncRepository.Projects.ConvertToGit(project, new GitPersistenceSettingsResource(), string.Empty);
+            syncRepository.Projects.ConvertToGit(project, new GitPersistenceSettingsResource(), string.Empty);
+
+            // Assert
+            asyncUrlUsed.Should().Be(gitUrl);
+            syncUrlUsed.Should().Be(gitUrl);
+        }
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
@@ -65,7 +65,7 @@ namespace Octopus.Client.Repositories.Async
                 CommitMessage = commitMessage
             };
 
-            var url = project.Link("ConvertToGit");
+            var url = project.HasLink("ConvertToGit") ? project.Link("ConvertToGit") : project.Link("ConvertToVcs");
             var response = await Client.Post<ConvertProjectToGitCommand,ConvertProjectToGitResponse>(url, payload);
             return response;
         }

--- a/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ProjectRepository.cs
@@ -64,7 +64,7 @@ namespace Octopus.Client.Repositories
                 CommitMessage = commitMessage
             };
 
-            var url = project.Link("ConvertToGit");
+            var url = project.HasLink("ConvertToGit") ? project.Link("ConvertToGit") : project.Link("ConvertToVcs");
             var response =
                 Client.Post<ConvertProjectToGitCommand, ConvertProjectToGitResponse>(url,
                     payload);


### PR DESCRIPTION
We changed the name of the link that's used when converting projects to Git (from `ConvertToVcs` to `ConvertToGit`). This is part of a longer term goal to change all of our usages of `Vcs` to `Git`.

To make this transition as smooth as possible, the projects links collection for a project contains both of these links for the time being, so older versions of client would continue to work with newer versions of Octopus.

But I didn't cater for using a newer version of client with an older version of Octopus. Client is looking for `ConvertToGit` but older versions of Octopus are only returning the `ConvertToVcs` link. This closes that loop, falling back to the old link if the new one is not there.