### PR TITLE
Added new permission enums

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3937,6 +3937,8 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission EnvironmentEdit
     static Octopus.Client.Model.Permission EnvironmentView
     static Octopus.Client.Model.Permission EventView
+    static Octopus.Client.Model.Permission EventRetentionDelete
+    static Octopus.Client.Model.Permission EventRetentionView
     static Octopus.Client.Model.Permission FeedEdit
     static Octopus.Client.Model.Permission FeedView
     static Octopus.Client.Model.Permission GitCredentialEdit

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3936,9 +3936,9 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission EnvironmentDelete
     static Octopus.Client.Model.Permission EnvironmentEdit
     static Octopus.Client.Model.Permission EnvironmentView
-    static Octopus.Client.Model.Permission EventView
     static Octopus.Client.Model.Permission EventRetentionDelete
     static Octopus.Client.Model.Permission EventRetentionView
+    static Octopus.Client.Model.Permission EventView
     static Octopus.Client.Model.Permission FeedEdit
     static Octopus.Client.Model.Permission FeedView
     static Octopus.Client.Model.Permission GitCredentialEdit

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3957,9 +3957,9 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission EnvironmentDelete
     static Octopus.Client.Model.Permission EnvironmentEdit
     static Octopus.Client.Model.Permission EnvironmentView
-    static Octopus.Client.Model.Permission EventView
     static Octopus.Client.Model.Permission EventRetentionDelete
     static Octopus.Client.Model.Permission EventRetentionView
+    static Octopus.Client.Model.Permission EventView
     static Octopus.Client.Model.Permission FeedEdit
     static Octopus.Client.Model.Permission FeedView
     static Octopus.Client.Model.Permission GitCredentialEdit

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3958,6 +3958,8 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission EnvironmentEdit
     static Octopus.Client.Model.Permission EnvironmentView
     static Octopus.Client.Model.Permission EventView
+    static Octopus.Client.Model.Permission EventRetentionDelete
+    static Octopus.Client.Model.Permission EventRetentionView
     static Octopus.Client.Model.Permission FeedEdit
     static Octopus.Client.Model.Permission FeedView
     static Octopus.Client.Model.Permission GitCredentialEdit

--- a/source/Octopus.Server.Client/Model/Permission.cs
+++ b/source/Octopus.Server.Client/Model/Permission.cs
@@ -258,6 +258,10 @@ namespace Octopus.Client.Model
 
         [Description("Edit Git credentials")] public static readonly Permission GitCredentialEdit = new Permission("GitCredentialEdit");
 
+        [Description("Delete archived event files")] public static readonly Permission EventRetentionDelete = new Permission("EventRetentionDelete");
+        
+        [Description("View/list archived event files")] public static readonly Permission EventRetentionView = new Permission("EventRetentionView");
+
         public Permission(string id)
         {
             Id = id;


### PR DESCRIPTION
As part of the changes in https://github.com/OctopusDeploy/OctopusDeploy/pull/12325, we added two new enum for permissions. 

This PR update the client have matching resources.