### PR TITLE
Fix DLL signing after we dropped .NET Core 2.1

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -20,6 +20,9 @@
         "AzureKeyVaultCertificateName": {
           "type": "string"
         },
+        "AzureKeyVaultTenantId": {
+          "type": "string"
+        },
         "AzureKeyVaultUrl": {
           "type": "string"
         },

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -6,6 +6,7 @@ using Nuke.Common;
 using Nuke.Common.CI.TeamCity;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
+using Nuke.Common.Tools.AzureSignTool;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.ILRepack;
 using Nuke.Common.Tools.OctoVersion;
@@ -23,6 +24,7 @@ class Build : NukeBuild
     const string CiBranchNameEnvVariable = "OCTOVERSION_CurrentBranch";
 
     public static int Main() => Execute<Build>(x => x.Default);
+
     //////////////////////////////////////////////////////////////////////
     // ARGUMENTS
     //////////////////////////////////////////////////////////////////////
@@ -34,6 +36,8 @@ class Build : NukeBuild
     [Parameter] string AzureKeyVaultAppId = "";
     [Parameter, Secret] string AzureKeyVaultAppSecret = "";
     [Parameter] string AzureKeyVaultCertificateName = "";
+    [Parameter] string AzureKeyVaultTenantId = "";
+
     ///////////////////////////////////////////////////////////////////////////////
     // GLOBAL VARIABLES
     ///////////////////////////////////////////////////////////////////////////////
@@ -53,13 +57,9 @@ class Build : NukeBuild
     [OctoVersion(BranchParameter = nameof(BranchName), AutoDetectBranchParameter = nameof(AutoDetectBranch))]
     public OctoVersionInfo OctoVersionInfo;
 
-    [PackageExecutable(
-        packageId: "azuresigntool",
-        packageExecutable: "azuresigntool.dll")]
-    readonly Tool AzureSignTool = null!;
-
     // Keep this list in order by most likely to succeed
-    string[] SigningTimestampUrls => new[] {
+    string[] SigningTimestampUrls => new[]
+    {
         "http://timestamp.digicert.com?alg=sha256",
         "http://timestamp.comodoca.com",
         "http://tsa.starfieldtech.com",
@@ -258,7 +258,8 @@ class Build : NukeBuild
         var useSignTool = string.IsNullOrEmpty(AzureKeyVaultUrl)
                           && string.IsNullOrEmpty(AzureKeyVaultAppId)
                           && string.IsNullOrEmpty(AzureKeyVaultAppSecret)
-                          && string.IsNullOrEmpty(AzureKeyVaultCertificateName);
+                          && string.IsNullOrEmpty(AzureKeyVaultCertificateName)
+                          && string.IsNullOrEmpty(AzureKeyVaultTenantId);
         var lastException = default(Exception);
         foreach (var url in SigningTimestampUrls)
         {
@@ -275,6 +276,7 @@ class Build : NukeBuild
             {
                 lastException = ex;
             }
+
             TeamCity.Instance?.CloseBlock("Signing and timestamping with server " + url);
             if (lastException == null)
                 break;
@@ -290,21 +292,18 @@ class Build : NukeBuild
     {
         Log.Information("Signing files using azuresigntool and the production code signing certificate.");
 
-        var arguments = "sign " +
-                        $"--azure-key-vault-url \"{AzureKeyVaultUrl}\" " +
-                        $"--azure-key-vault-client-id \"{AzureKeyVaultAppId}\" " +
-                        $"--azure-key-vault-client-secret \"{AzureKeyVaultAppSecret}\" " +
-                        $"--azure-key-vault-certificate \"{AzureKeyVaultCertificateName}\" " +
-                        "--file-digest sha256 " +
-                        "--description \"Octopus Client Library\" " +
-                        "--description-url \"https://octopus.com\" " +
-                        $"--timestamp-rfc3161 {timestampUrl} " +
-                        "--timestamp-digest sha256 ";
-
-        foreach (var file in files)
-            arguments += $"\"{file}\" ";
-
-        AzureSignTool(arguments, customLogger: LogStdErrAsWarning);
+        AzureSignToolTasks.AzureSignTool(settings => settings
+            .SetKeyVaultUrl(AzureKeyVaultUrl)
+            .SetKeyVaultClientId(AzureKeyVaultAppId)
+            .SetKeyVaultClientSecret(AzureKeyVaultAppSecret)
+            .SetKeyVaultCertificateName(AzureKeyVaultCertificateName)
+            .SetKeyVaultTenantId(AzureKeyVaultTenantId)
+            .SetDescription("Octopus Client Library")
+            .SetDescriptionUrl("https://octopus.com")
+            .SetFileDigest(AzureSignToolDigestAlgorithm.sha256)
+            .SetTimestampRfc3161Url(timestampUrl)
+            .SetTimestampDigest(AzureSignToolDigestAlgorithm.sha256)
+            .SetFiles(files.Select(x => x.ToString())));
     }
 
     void SignWithSignTool(AbsolutePath[] files, string url)
@@ -338,5 +337,4 @@ class Build : NukeBuild
         fileText = fileText.Replace(oldValue, newValue);
         File.WriteAllText(path, fileText);
     }
-
 }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageDownload Include="AzureSignTool" Version="[2.0.17]" />
+    <PackageDownload Include="AzureSignTool" Version="[3.0.0]" />
     <PackageDownload Include="OctoVersion.Tool" Version="[0.2.951]" />
   </ItemGroup>
 


### PR DESCRIPTION
Code signing stopped working after EngProd removed .NET Core 2.1 from our build system.

This PR updates AzureSignTool to version 3.0.0 and adds the `AzureKeyVaultTenantId` parameter. I also added the `AzureKeyVaultTenantId` to the [build parameters](https://build.octopushq.com/admin/editBuildParams.html?id=buildType:OctopusDeploy_OctopusClients_BuildOctopusClients).

These changes are based on these other ones:

* https://github.com/OctopusDeploy/OctopusDeploy/pull/11997/commits/b7f55e6c0d0d6776d52dfb58bdf25f9b2e32b4d2
* https://github.com/OctopusDeploy/OctopusDeploy/pull/11997/commits/1757bcd80e0fad023f1dba90e077ef1493101615