### PR TITLE
Return VariableSetPreviewResource from GetVariablePreview

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5532,6 +5532,15 @@ Octopus.Client.Model
       Variables = 0
       ScriptModule = 1
   }
+  class VariableSetPreviewResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.VariableSetResource
+  {
+    .ctor()
+    List<String> UnresolvedValues { get; set; }
+  }
   class VariableSetResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -8320,7 +8329,7 @@ Octopus.Client.Repositories.Async
   interface IVariableSetBetaRepository
   {
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String)
-    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
+    Task<VariableSetPreviewResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
   }
   interface IVariableSetRepository
     Octopus.Client.Repositories.Async.IGet<VariableSetResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5557,6 +5557,15 @@ Octopus.Client.Model
       Variables = 0
       ScriptModule = 1
   }
+  class VariableSetPreviewResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.VariableSetResource
+  {
+    .ctor()
+    List<String> UnresolvedValues { get; set; }
+  }
   class VariableSetResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -8347,7 +8356,7 @@ Octopus.Client.Repositories.Async
   interface IVariableSetBetaRepository
   {
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String)
-    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
+    Task<VariableSetPreviewResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
   }
   interface IVariableSetRepository
     Octopus.Client.Repositories.Async.IGet<VariableSetResource>

--- a/source/Octopus.Server.Client/Model/VariableSetPreviewResource.cs
+++ b/source/Octopus.Server.Client/Model/VariableSetPreviewResource.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model
+{
+    /// <summary>
+    /// Represents a collection of variables that will be resolved for a given deployment scenario
+    /// </summary>
+    public class VariableSetPreviewResource : VariableSetResource
+    {
+        public List<string> UnresolvedValues { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/Async/VariableSetBetaRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/VariableSetBetaRepository.cs
@@ -6,7 +6,7 @@ namespace Octopus.Client.Repositories.Async
     public interface IVariableSetBetaRepository
     {
         Task<VariableSetResource> Get(ProjectResource projectResource, string gitRef = null);
-        Task<VariableSetResource> GetVariablePreview(ProjectResource projectResource, string channel = null, string tenant = null, string runbook = null, string action = null, string environment = null, string machine = null, string role = null, string gitRef = null);
+        Task<VariableSetPreviewResource> GetVariablePreview(ProjectResource projectResource, string channel = null, string tenant = null, string runbook = null, string action = null, string environment = null, string machine = null, string role = null, string gitRef = null);
     }
 
     class VariableSetBetaRepository : IVariableSetBetaRepository
@@ -35,10 +35,10 @@ namespace Octopus.Client.Repositories.Async
             return await client.Get<VariableSetResource>(projectResource.Link("Variables"));
         }
 
-        public async Task<VariableSetResource> GetVariablePreview(ProjectResource projectResource, string channel = null, string tenant = null, string runbook = null, string action = null, string environment = null, string machine = null, string role = null, string gitRef = null)
+        public async Task<VariableSetPreviewResource> GetVariablePreview(ProjectResource projectResource, string channel = null, string tenant = null, string runbook = null, string action = null, string environment = null, string machine = null, string role = null, string gitRef = null)
         {
             var project = projectResource.Id;
-            return await client.Get<VariableSetResource>(await repository.Link("VariablePreview"), new { project, channel, tenant, runbook, action, environment, machine, role, gitRef });
+            return await client.Get<VariableSetPreviewResource>(await repository.Link("VariablePreview"), new { project, channel, tenant, runbook, action, environment, machine, role, gitRef });
         }
 
         bool ProjectHasVariablesInGit(ProjectResource projectResource)


### PR DESCRIPTION
Change `GetVariablePreview` on `VariableSetBetaRepository` to return `VariableSetPreviewResource` that has additional field for unresolved values.

## Overview
We're now returning a list of unresolved values in addition to the preview variable set. These represent variables that are in the complete variable set for the project, but don't resolve to any specific value for the current scenario.

This should make it easier to find variables that are missing values for a specific scenario.