### PR TITLE
Added depends on tests to build, made framework approved public surface file match core version

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -257,10 +257,10 @@ class Build : NukeBuild
         var files = path.GlobDirectories("**").SelectMany(x => x.GlobFiles("Octopus.*.dll")).ToArray();
 
         var useSignTool = string.IsNullOrEmpty(AzureKeyVaultUrl)
-                        && string.IsNullOrEmpty(AzureKeyVaultAppId)
-                        && string.IsNullOrEmpty(AzureKeyVaultAppSecret)
-                        && string.IsNullOrEmpty(AzureKeyVaultCertificateName)
-                        && string.IsNullOrEmpty(AzureKeyVaultTenantId);
+                          && string.IsNullOrEmpty(AzureKeyVaultAppId)
+                          && string.IsNullOrEmpty(AzureKeyVaultAppSecret)
+                          && string.IsNullOrEmpty(AzureKeyVaultCertificateName)
+                          && string.IsNullOrEmpty(AzureKeyVaultTenantId);
         var lastException = default(Exception);
         foreach (var url in SigningTimestampUrls)
         {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -165,7 +165,7 @@ class Build : NukeBuild
         .DependsOn(Merge)   // IMPORTANT: Tests must be run _after_ the merge so that we're confident that we're testing the ILMerged code.  -andrewh 14/2/2022.
         .Executes(() =>
     {
-        RootDirectory.GlobFiles("**/**/*.Tests.csproj").ForEach(testProjectFile =>
+    RootDirectory.GlobFiles("**/**/*.Tests.csproj").ForEach(testProjectFile =>
         {
             DotNetTest(_ => _
                 .SetProjectFile(testProjectFile)
@@ -248,7 +248,9 @@ class Build : NukeBuild
         .DependsOn(CopyToLocalPackages)
         .DependsOn(PackNormalClientNuget)
         .DependsOn(PackMergedClientNuget)
+        .DependsOn(Test)
         .DependsOn(TestClientNugetPackage);
+        
 
     void SignBinaries(AbsolutePath path)
     {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -257,10 +257,10 @@ class Build : NukeBuild
         var files = path.GlobDirectories("**").SelectMany(x => x.GlobFiles("Octopus.*.dll")).ToArray();
 
         var useSignTool = string.IsNullOrEmpty(AzureKeyVaultUrl)
-                      && string.IsNullOrEmpty(AzureKeyVaultAppId)
-                      && string.IsNullOrEmpty(AzureKeyVaultAppSecret)
-                      && string.IsNullOrEmpty(AzureKeyVaultCertificateName)
-                      && string.IsNullOrEmpty(AzureKeyVaultTenantId);
+                        && string.IsNullOrEmpty(AzureKeyVaultAppId)
+                        && string.IsNullOrEmpty(AzureKeyVaultAppSecret)
+                        && string.IsNullOrEmpty(AzureKeyVaultCertificateName)
+                        && string.IsNullOrEmpty(AzureKeyVaultTenantId);
         var lastException = default(Exception);
         foreach (var url in SigningTimestampUrls)
         {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -34,6 +34,8 @@ class Build : NukeBuild
     [Parameter] string AzureKeyVaultAppId = "";
     [Parameter, Secret] string AzureKeyVaultAppSecret = "";
     [Parameter] string AzureKeyVaultCertificateName = "";
+    [Parameter] string AzureKeyVaultTenantId = "";
+
     ///////////////////////////////////////////////////////////////////////////////
     // GLOBAL VARIABLES
     ///////////////////////////////////////////////////////////////////////////////
@@ -259,7 +261,9 @@ class Build : NukeBuild
         var useSignTool = string.IsNullOrEmpty(AzureKeyVaultUrl)
                           && string.IsNullOrEmpty(AzureKeyVaultAppId)
                           && string.IsNullOrEmpty(AzureKeyVaultAppSecret)
-                          && string.IsNullOrEmpty(AzureKeyVaultCertificateName);
+                          && string.IsNullOrEmpty(AzureKeyVaultCertificateName)
+                          && string.IsNullOrEmpty(AzureKeyVaultTenantId);
+
         var lastException = default(Exception);
         foreach (var url in SigningTimestampUrls)
         {
@@ -296,6 +300,7 @@ class Build : NukeBuild
                         $"--azure-key-vault-client-id \"{AzureKeyVaultAppId}\" " +
                         $"--azure-key-vault-client-secret \"{AzureKeyVaultAppSecret}\" " +
                         $"--azure-key-vault-certificate \"{AzureKeyVaultCertificateName}\" " +
+                        $"--azure-key-vault-tenant-id \"{AzureKeyVaultTenantId}\" " +
                         "--file-digest sha256 " +
                         "--description \"Octopus Client Library\" " +
                         "--description-url \"https://octopus.com\" " +

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -165,7 +165,7 @@ class Build : NukeBuild
         .DependsOn(Merge)   // IMPORTANT: Tests must be run _after_ the merge so that we're confident that we're testing the ILMerged code.  -andrewh 14/2/2022.
         .Executes(() =>
     {
-    RootDirectory.GlobFiles("**/**/*.Tests.csproj").ForEach(testProjectFile =>
+        RootDirectory.GlobFiles("**/**/*.Tests.csproj").ForEach(testProjectFile =>
         {
             DotNetTest(_ => _
                 .SetProjectFile(testProjectFile)
@@ -250,7 +250,6 @@ class Build : NukeBuild
         .DependsOn(PackMergedClientNuget)
         .DependsOn(Test)
         .DependsOn(TestClientNugetPackage);
-        
 
     void SignBinaries(AbsolutePath path)
     {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -257,11 +257,10 @@ class Build : NukeBuild
         var files = path.GlobDirectories("**").SelectMany(x => x.GlobFiles("Octopus.*.dll")).ToArray();
 
         var useSignTool = string.IsNullOrEmpty(AzureKeyVaultUrl)
-                          && string.IsNullOrEmpty(AzureKeyVaultAppId)
-                          && string.IsNullOrEmpty(AzureKeyVaultAppSecret)
-                          && string.IsNullOrEmpty(AzureKeyVaultCertificateName)
-                          && string.IsNullOrEmpty(AzureKeyVaultTenantId);
-
+                      && string.IsNullOrEmpty(AzureKeyVaultAppId)
+                      && string.IsNullOrEmpty(AzureKeyVaultAppSecret)
+                      && string.IsNullOrEmpty(AzureKeyVaultCertificateName)
+                      && string.IsNullOrEmpty(AzureKeyVaultTenantId);
         var lastException = default(Exception);
         foreach (var url in SigningTimestampUrls)
         {

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageDownload Include="AzureSignTool" Version="[2.0.17]" />
+    <PackageDownload Include="AzureSignTool" Version="[3.0.0]" />
     <PackageDownload Include="OctoVersion.Tool" Version="[0.2.951]" />
   </ItemGroup>
 

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -36,8 +36,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Assent" Version="1.5.0" />

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3090,7 +3090,6 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.ValidatedGitReferenceResource
   {
-    .ctor(String, String)
     .ctor(String)
   }
   GuidedFailureMode
@@ -4413,6 +4412,7 @@ Octopus.Client.Model
     String NuGetPackageId { get; set; }
     String PackageId { get; set; }
     String PackageReferenceName { get; set; }
+    Nullable<DateTimeOffset> SelectedPackagePublished { get; set; }
     String StepName { get; set; }
     String VersionSelectedLastRelease { get; set; }
   }


### PR DESCRIPTION
While doing preparation work for the .Net 6 migration it was discover we have a failing unit test (ThePublicSurfaceAreaShouldNotRegress) when testing .Net Framework. The failing test was investigated to discover how the build pipeline was functioning if this was not succeeding.

Discoveries
* The unit tests can only run against .Net Framework in a Windows environment
* The units tests were not being called in the Windows environment
* The unit tests were being called in various Linux environments and passing
* Changes that had been made to the Approved Public Surface for .Net Core had not been made to .Net Framework

This PR seeks to solve the problem by
* Including the unit tests in the Build process, to ensure they are run in the build environment(Windows)
* Updated the Approved Public Surface for .Net Framework to include the required updates, these changes are already present in the .Net Core version of the Approved Public Surface.