### PR TITLE
Remove IsJiraServiceManagementIntegrationEnabled flag

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2999,7 +2999,6 @@ Octopus.Client.Model
     Boolean IsCommunityActionTemplatesEnabled { get; set; }
     Boolean IsConfigurationAsCodeEnabled { get; set; }
     Boolean IsHelpSidebarEnabled { get; set; }
-    Boolean IsJiraServiceManagementIntegrationEnabled { get; set; }
     Boolean IsKubernetesEnabled { get; set; }
     Boolean IsServiceNowIntegrationEnabled { get; set; }
     Boolean IsStepUiFrameworkEnabled { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3016,7 +3016,6 @@ Octopus.Client.Model
     Boolean IsCommunityActionTemplatesEnabled { get; set; }
     Boolean IsConfigurationAsCodeEnabled { get; set; }
     Boolean IsHelpSidebarEnabled { get; set; }
-    Boolean IsJiraServiceManagementIntegrationEnabled { get; set; }
     Boolean IsKubernetesEnabled { get; set; }
     Boolean IsServiceNowIntegrationEnabled { get; set; }
     Boolean IsStepUiFrameworkEnabled { get; set; }

--- a/source/Octopus.Server.Client/Model/FeaturesConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/FeaturesConfigurationResource.cs
@@ -30,8 +30,5 @@ namespace Octopus.Client.Model
 
         [Writeable]
         public bool IsServiceNowIntegrationEnabled { get; set; }
-
-        [Writeable]
-        public bool IsJiraServiceManagementIntegrationEnabled { get; set; }
     }
 }


### PR DESCRIPTION
The JSM Deployment Blocking Integration is now protected via a licence flag, and no longer requires a feature flag - as such, the flag is being removed.