### PR TITLE
Adding event retention resource and API interfaces

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -99,6 +99,7 @@ Octopus.Client
   }
   interface IOctopusCommonAsyncRepository
   {
+    Octopus.Client.Repositories.Async.IArchivedEventFileRepository ArchivedEventFiles { get; }
     Octopus.Client.IOctopusAsyncClient Client { get; }
     Octopus.Client.Repositories.Async.ICommunityActionTemplateRepository CommunityActionTemplates { get; }
     Octopus.Client.Repositories.Async.IEventRepository Events { get; }
@@ -115,6 +116,7 @@ Octopus.Client
   }
   interface IOctopusCommonRepository
   {
+    Octopus.Client.Repositories.IArchivedEventFileRepository ArchivedEventFiles { get; }
     Octopus.Client.IOctopusClient Client { get; }
     Octopus.Client.Repositories.IEventRepository Events { get; }
     Octopus.Client.RepositoryScope Scope { get; }
@@ -308,6 +310,7 @@ Octopus.Client
     .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
     Octopus.Client.Repositories.Async.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.Async.IActionTemplateRepository ActionTemplates { get; }
+    Octopus.Client.Repositories.Async.IArchivedEventFileRepository ArchivedEventFiles { get; }
     Octopus.Client.Repositories.Async.IArtifactRepository Artifacts { get; }
     Octopus.Client.Repositories.Async.IBackupRepository Backups { get; }
     Octopus.Client.Repositories.Async.IBuildInformationRepository BuildInformationRepository { get; }
@@ -445,6 +448,7 @@ Octopus.Client
     .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope)
     Octopus.Client.Repositories.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.IActionTemplateRepository ActionTemplates { get; }
+    Octopus.Client.Repositories.IArchivedEventFileRepository ArchivedEventFiles { get; }
     Octopus.Client.Repositories.IArtifactRepository Artifacts { get; }
     Octopus.Client.Repositories.IBackupRepository Backups { get; }
     Octopus.Client.Repositories.IBuildInformationRepository BuildInformationRepository { get; }
@@ -6368,6 +6372,29 @@ Octopus.Client.Model.Endpoints
     String Thumbprint { get; set; }
   }
 }
+Octopus.Client.Model.EventRetention
+{
+  class ArchivedEventFileResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Nullable<DateTimeOffset> CreatedDate { get; set; }
+    Double FileBytes { get; set; }
+    Nullable<DateTimeOffset> ModifiedDate { get; set; }
+    String Name { get; set; }
+  }
+  class EventRetentionConfigurationResource
+    Octopus.Client.Extensibility.IResource
+  {
+    .ctor()
+    Int32 EventRetentionDays { get; set; }
+    String Id { get; set; }
+    Octopus.Client.Extensibility.LinkCollection Links { get; set; }
+  }
+}
 Octopus.Client.Model.Forms
 {
   class Button
@@ -6993,6 +7020,12 @@ Octopus.Client.Repositories
     List<ActionTemplateSearchResource> Search()
     void SetLogo(Octopus.Client.Model.ActionTemplateResource, String, Stream)
     Octopus.Client.Model.ActionUpdateResultResource[] UpdateActions(Octopus.Client.Model.ActionTemplateResource, Octopus.Client.Model.ActionsUpdateResource)
+  }
+  interface IArchivedEventFileRepository
+    Octopus.Client.Repositories.IDelete<ArchivedEventFileResource>
+  {
+    Stream GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
+    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32, Nullable<Int32>)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.IPaginate<ArtifactResource>
@@ -7703,6 +7736,12 @@ Octopus.Client.Repositories.Async
     Task<List<ActionTemplateSearchResource>> Search()
     Task SetLogo(Octopus.Client.Model.ActionTemplateResource, String, Stream)
     Task<ActionUpdateResultResource[]> UpdateActions(Octopus.Client.Model.ActionTemplateResource, Octopus.Client.Model.ActionsUpdateResource)
+  }
+  interface IArchivedEventFileRepository
+    Octopus.Client.Repositories.Async.IDelete<ArchivedEventFileResource>
+  {
+    Task<Stream> GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
+    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32, Nullable<Int32>)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.Async.IPaginate<ArtifactResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -99,6 +99,7 @@ Octopus.Client
   }
   interface IOctopusCommonAsyncRepository
   {
+    Octopus.Client.Repositories.Async.IArchivedEventFileRepository ArchivedEventFiles { get; }
     Octopus.Client.IOctopusAsyncClient Client { get; }
     Octopus.Client.Repositories.Async.ICommunityActionTemplateRepository CommunityActionTemplates { get; }
     Octopus.Client.Repositories.Async.IEventRepository Events { get; }
@@ -115,6 +116,7 @@ Octopus.Client
   }
   interface IOctopusCommonRepository
   {
+    Octopus.Client.Repositories.IArchivedEventFileRepository ArchivedEventFiles { get; }
     Octopus.Client.IOctopusClient Client { get; }
     Octopus.Client.Repositories.IEventRepository Events { get; }
     Octopus.Client.RepositoryScope Scope { get; }
@@ -308,6 +310,7 @@ Octopus.Client
     .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
     Octopus.Client.Repositories.Async.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.Async.IActionTemplateRepository ActionTemplates { get; }
+    Octopus.Client.Repositories.Async.IArchivedEventFileRepository ArchivedEventFiles { get; }
     Octopus.Client.Repositories.Async.IArtifactRepository Artifacts { get; }
     Octopus.Client.Repositories.Async.IBackupRepository Backups { get; }
     Octopus.Client.Repositories.Async.IBuildInformationRepository BuildInformationRepository { get; }
@@ -443,6 +446,7 @@ Octopus.Client
     .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope)
     Octopus.Client.Repositories.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.IActionTemplateRepository ActionTemplates { get; }
+    Octopus.Client.Repositories.IArchivedEventFileRepository ArchivedEventFiles { get; }
     Octopus.Client.Repositories.IArtifactRepository Artifacts { get; }
     Octopus.Client.Repositories.IBackupRepository Backups { get; }
     Octopus.Client.Repositories.IBuildInformationRepository BuildInformationRepository { get; }
@@ -6392,6 +6396,29 @@ Octopus.Client.Model.Endpoints
     String Thumbprint { get; set; }
   }
 }
+Octopus.Client.Model.EventRetention
+{
+  class ArchivedEventFileResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Model.Resource
+  {
+    .ctor()
+    Nullable<DateTimeOffset> CreatedDate { get; set; }
+    Double FileBytes { get; set; }
+    Nullable<DateTimeOffset> ModifiedDate { get; set; }
+    String Name { get; set; }
+  }
+  class EventRetentionConfigurationResource
+    Octopus.Client.Extensibility.IResource
+  {
+    .ctor()
+    Int32 EventRetentionDays { get; set; }
+    String Id { get; set; }
+    Octopus.Client.Extensibility.LinkCollection Links { get; set; }
+  }
+}
 Octopus.Client.Model.Forms
 {
   class Button
@@ -7018,6 +7045,12 @@ Octopus.Client.Repositories
     List<ActionTemplateSearchResource> Search()
     void SetLogo(Octopus.Client.Model.ActionTemplateResource, String, Stream)
     Octopus.Client.Model.ActionUpdateResultResource[] UpdateActions(Octopus.Client.Model.ActionTemplateResource, Octopus.Client.Model.ActionsUpdateResource)
+  }
+  interface IArchivedEventFileRepository
+    Octopus.Client.Repositories.IDelete<ArchivedEventFileResource>
+  {
+    Stream GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
+    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32, Nullable<Int32>)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.IPaginate<ArtifactResource>
@@ -7728,6 +7761,12 @@ Octopus.Client.Repositories.Async
     Task<List<ActionTemplateSearchResource>> Search()
     Task SetLogo(Octopus.Client.Model.ActionTemplateResource, String, Stream)
     Task<ActionUpdateResultResource[]> UpdateActions(Octopus.Client.Model.ActionTemplateResource, Octopus.Client.Model.ActionsUpdateResource)
+  }
+  interface IArchivedEventFileRepository
+    Octopus.Client.Repositories.Async.IDelete<ArchivedEventFileResource>
+  {
+    Task<Stream> GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
+    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32, Nullable<Int32>)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.Async.IPaginate<ArtifactResource>

--- a/source/Octopus.Server.Client/IOctopusCommonAsyncRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusCommonAsyncRepository.cs
@@ -6,6 +6,7 @@ namespace Octopus.Client
     public interface IOctopusCommonAsyncRepository
     {
         IEventRepository Events { get; }
+        IArchivedEventFileRepository ArchivedEventFiles { get; }
         ITaskRepository Tasks { get; }
         ITeamsRepository Teams { get; }
         IScopedUserRoleRepository ScopedUserRoles { get; }

--- a/source/Octopus.Server.Client/IOctopusCommonRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusCommonRepository.cs
@@ -5,6 +5,7 @@ namespace Octopus.Client
     public interface IOctopusCommonRepository
     {
         IEventRepository Events { get; }
+        IArchivedEventFileRepository ArchivedEventFiles { get; }
         ITaskRepository Tasks { get; }
         ITeamsRepository Teams { get; }
         IScopedUserRoleRepository ScopedUserRoles { get; }

--- a/source/Octopus.Server.Client/Model/EventRetention/ArchivedEventFileResource.cs
+++ b/source/Octopus.Server.Client/Model/EventRetention/ArchivedEventFileResource.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Octopus.Client.Extensibility;
+
+namespace Octopus.Client.Model.EventRetention
+{
+    public class ArchivedEventFileResource : Resource, INamedResource
+    {
+        [Trim]
+        public string Name { get; set; }
+
+        public DateTimeOffset? ModifiedDate { get; set; }
+
+        public DateTimeOffset? CreatedDate { get; set; }
+
+        public double FileBytes { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/EventRetention/EventRetentionConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/EventRetention/EventRetentionConfigurationResource.cs
@@ -1,0 +1,21 @@
+﻿using Octopus.Client.Extensibility;
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.EventRetention
+{
+    public class EventRetentionConfigurationResource : IResource
+    {
+
+        public EventRetentionConfigurationResource()
+        {
+            Id = "eventretention";
+        }
+
+        public string Id { get; set; }
+        
+        [Writeable]
+        public int EventRetentionDays { get; set; } = 90;
+
+        public LinkCollection Links { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncRepository.cs
@@ -74,6 +74,7 @@ namespace Octopus.Client
             Deployments = new DeploymentRepository(this);
             Environments = new EnvironmentRepository(this);
             Events = new EventRepository(this);
+            ArchivedEventFiles = new ArchivedEventFileRepository(this);
             FeaturesConfiguration = new FeaturesConfigurationRepository(this);
             Feeds = new FeedRepository(this);
             GitCredentials = new GitCredentialRepository(this);
@@ -143,6 +144,7 @@ namespace Octopus.Client
         public IDeploymentRepository Deployments { get; }
         public IEnvironmentRepository Environments { get; }
         public IEventRepository Events { get; }
+        public IArchivedEventFileRepository ArchivedEventFiles { get; }
         public IFeaturesConfigurationRepository FeaturesConfiguration { get; }
         public IFeedRepository Feeds { get; }
         public IGitCredentialRepository GitCredentials { get; }

--- a/source/Octopus.Server.Client/OctopusRepository.cs
+++ b/source/Octopus.Server.Client/OctopusRepository.cs
@@ -72,6 +72,7 @@ namespace Octopus.Client
             Deployments = new DeploymentRepository(this);
             Environments = new EnvironmentRepository(this);
             Events = new EventRepository(this);
+            ArchivedEventFiles = new ArchivedEventFileRepository(this);
             FeaturesConfiguration = new FeaturesConfigurationRepository(this);
             Feeds = new FeedRepository(this);
             Interruptions = new InterruptionRepository(this);
@@ -139,6 +140,7 @@ namespace Octopus.Client
         public IDeploymentRepository Deployments { get; }
         public IEnvironmentRepository Environments { get; }
         public IEventRepository Events { get; }
+        public IArchivedEventFileRepository ArchivedEventFiles { get; }
         public IFeaturesConfigurationRepository FeaturesConfiguration { get; }
         public IFeedRepository Feeds { get; }
         public IInterruptionRepository Interruptions { get; }

--- a/source/Octopus.Server.Client/Repositories/ArchivedEventFileRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ArchivedEventFileRepository.cs
@@ -29,7 +29,7 @@ namespace Octopus.Client.Repositories
             ThrowIfServerVersionIsNotCompatible();
 
             return Client.List<ArchivedEventFileResource>(
-                Repository.Link("events/archives"),
+                Repository.Link(CollectionLinkName),
                 new
                 {
                     skip,

--- a/source/Octopus.Server.Client/Repositories/ArchivedEventFileRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ArchivedEventFileRepository.cs
@@ -14,7 +14,7 @@ namespace Octopus.Client.Repositories
     {
         public ArchivedEventFileRepository(IOctopusRepository repository) : base(repository, "ArchivedEventFiles")
         {
-            MinimumCompatibleVersion("2022.3.6072");
+            MinimumCompatibleVersion("2022.3.8575");
         }
 
         public Stream GetContent(ArchivedEventFileResource archiveEventFile)

--- a/source/Octopus.Server.Client/Repositories/ArchivedEventFileRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ArchivedEventFileRepository.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using Octopus.Client.Model;
+using Octopus.Client.Model.EventRetention;
+
+namespace Octopus.Client.Repositories
+{
+    public interface IArchivedEventFileRepository : IDelete<ArchivedEventFileResource>
+    {
+        Stream GetContent(ArchivedEventFileResource archiveEventFile);
+        ResourceCollection<ArchivedEventFileResource> List(int skip = 0, int? take = null);
+    }
+
+    class ArchivedEventFileRepository : BasicRepository<ArchivedEventFileResource>, IArchivedEventFileRepository
+    {
+        public ArchivedEventFileRepository(IOctopusRepository repository) : base(repository, "ArchivedEventFiles")
+        {
+            MinimumCompatibleVersion("2022.3.6072");
+        }
+
+        public Stream GetContent(ArchivedEventFileResource archiveEventFile)
+        {
+            ThrowIfServerVersionIsNotCompatible();
+
+            return Client.GetContent(archiveEventFile.Link("Self"));
+        }
+
+        public ResourceCollection<ArchivedEventFileResource> List(int skip = 0, int? take = null)
+        {
+            ThrowIfServerVersionIsNotCompatible();
+
+            return Client.List<ArchivedEventFileResource>(
+                Repository.Link("events/archives"),
+                new
+                {
+                    skip,
+                    take
+                });
+        }
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/Async/ArchivedEventFileRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ArchivedEventFileRepository.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Octopus.Client.Model;
+using Octopus.Client.Model.Endpoints;
+using Octopus.Client.Model.EventRetention;
+
+namespace Octopus.Client.Repositories.Async
+{
+    public interface IArchivedEventFileRepository : 
+        IDelete<ArchivedEventFileResource>
+    {
+        Task<Stream> GetContent(ArchivedEventFileResource archiveEventFile);
+        Task<ResourceCollection<ArchivedEventFileResource>> List(int skip = 0, int? take = null);
+    }
+
+    class ArchivedEventFileRepository : BasicRepository<ArchivedEventFileResource>, IArchivedEventFileRepository
+    {
+        public ArchivedEventFileRepository(IOctopusAsyncRepository repository) : base(repository, "ArchivedEventFiles")
+        {
+            MinimumCompatibleVersion("2022.3.6072");
+        }
+
+        public async Task<Stream> GetContent(ArchivedEventFileResource archiveEventFile)
+        {
+            await ThrowIfServerVersionIsNotCompatible();
+
+            return await Client.GetContent(archiveEventFile.Link("Self"));
+        }
+
+        public async Task<ResourceCollection<ArchivedEventFileResource>> List(int skip = 0, int? take = null)
+        {
+            await ThrowIfServerVersionIsNotCompatible();
+
+            return await Client.List<ArchivedEventFileResource>(
+                await Repository.Link("events/archives").ConfigureAwait(false),
+                new
+                {
+                    skip,
+                    take
+                }).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/Async/ArchivedEventFileRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ArchivedEventFileRepository.cs
@@ -34,7 +34,7 @@ namespace Octopus.Client.Repositories.Async
             await ThrowIfServerVersionIsNotCompatible();
 
             return await Client.List<ArchivedEventFileResource>(
-                await Repository.Link("events/archives").ConfigureAwait(false),
+                await Repository.Link(CollectionLinkName).ConfigureAwait(false),
                 new
                 {
                     skip,

--- a/source/Octopus.Server.Client/Repositories/Async/ArchivedEventFileRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ArchivedEventFileRepository.cs
@@ -19,7 +19,7 @@ namespace Octopus.Client.Repositories.Async
     {
         public ArchivedEventFileRepository(IOctopusAsyncRepository repository) : base(repository, "ArchivedEventFiles")
         {
-            MinimumCompatibleVersion("2022.3.6072");
+            MinimumCompatibleVersion("2022.3.8575");
         }
 
         public async Task<Stream> GetContent(ArchivedEventFileResource archiveEventFile)


### PR DESCRIPTION
# Background
The new Event Retention feature was added to Octopus Server. We now want to update the Octopus.Client to reflect the enhancements made.

# Results
We now support the 3 endpoints for managing archived event files in the Octopus.Client.

The configuration resource was also added to support using the configuration endpoint with this new feature.

## Testing
Octopus Server was updated using the NuGet Package of this PR, and enhanced to use the new methods.

The PR can be found [here](https://github.com/OctopusDeploy/OctopusDeploy/pull/13135)

Is this considered an acceptable level of testing for this change?

# How to Review this PR
This is the first time I have made a change to Octopus.Client. Please make sure I have not overlooked something that needs to be set.

# Before we Merge
The minimum version required has not been built yet. So this PR cannot be merged until this has been determined and this PR has updated the `ArchivedEventFileRepository` (both sync and async) with this version.