### PR TITLE
Add UnmetPreconditions to TaskResource

### DIFF
--- a/source/Octopus.Server.Client/Model/PreconditionStatus.cs
+++ b/source/Octopus.Server.Client/Model/PreconditionStatus.cs
@@ -1,0 +1,24 @@
+
+namespace Octopus.Client.Model
+{
+    public class PreconditionStatus
+    {
+        /// <summary>
+        /// The human-readable name of the precondition which has raised
+        /// this message/status
+        /// </summary>
+        public string PreconditionName { get; set; }
+
+        /// <summary>
+        /// A human-readable statement indicating the status of the
+        /// Precondition
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// True if this precondition will outright fail the task (terminal)
+        /// False if this precondition will delay the task's execution
+        /// </summary>
+        public bool WillFailTask { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/TaskResource.cs
+++ b/source/Octopus.Server.Client/Model/TaskResource.cs
@@ -163,6 +163,14 @@ namespace Octopus.Client.Model
         [JsonProperty(Order = 34)]
         public bool HasWarningsOrErrors { get; set; }
 
+        /// <summary>
+        /// Contains a list of all Preconditions which must be
+        /// satisfied prior to this task executing. An empty list
+        /// implies the task is able to run at its scheduled time
+        /// </summary>
+        [JsonProperty(Order = 35)]
+        public List<PreconditionStatus> UnmetPreconditions { get; set; }
+        
         public string SpaceId { get; set; }
     }
 }

--- a/source/Octopus.Server.Client/Octopus.Server.Client.csproj
+++ b/source/Octopus.Server.Client/Octopus.Server.Client.csproj
@@ -17,19 +17,19 @@ This package contains the non-ILmerged client library for the HTTP API in Octopu
 	  <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DebugType>embedded</DebugType>
     <DefineConstants>$(DefineConstants);FULL_FRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS;LIBLOG_PORTABLE</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Net.Http" />

--- a/source/Octopus.Server.Client/Octopus.Server.Client.csproj
+++ b/source/Octopus.Server.Client/Octopus.Server.Client.csproj
@@ -17,19 +17,19 @@ This package contains the non-ILmerged client library for the HTTP API in Octopu
 	  <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <DebugType>embedded</DebugType>
     <DefineConstants>$(DefineConstants);FULL_FRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS;LIBLOG_PORTABLE</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
MessageContracts were updated to include the UnmetPrecondition, which can be used to determine if a task resource is able to execute at it scheduled time.