### PR TITLE
Fix - Nightly build produces branch TAG

### DIFF
--- a/octoversion.json
+++ b/octoversion.json
@@ -1,3 +1,3 @@
 {
-  "NonPreReleaseTagsRegex": "refs/heads/(main|master|release/.*)"
+  "NonPreReleaseTagsRegex": "refs/heads/(main|master|release/.*)$"
 }


### PR DESCRIPTION
For the nightly build, the branch information is `refs/heads/main` and the existing expression is appending `-nightly`.
However, `refs/heads/main-nightly`, is matching the `NonPreReleaseTagsRegex` defined in `octoversion.json`
This results in **no pre-release** tag added for nightly build. 

The original regex captures any additional character / words beyond the condition (main|master...*), which is not correct.