### PR TITLE
Core/cancellation token basic repository

### DIFF
--- a/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
@@ -47,28 +47,17 @@ namespace Octopus.Client.Tests.Operations
                     .Add("CurrentUser", "/api/users/me")
                     .Add("SpaceHome", "/api/spaces")
             };
-            client.Get<RootResource>(Arg.Any<string>()).Returns(rootDocument);
-            client.Repository.LoadRootDocument().Returns(rootDocument);
-            client.Get<SpaceResource[]>(Arg.Any<string>())
-                .Returns(new[] {new SpaceResource() {Id = "Spaces-1", IsDefault = true}});
-            client.Get<UserResource>(Arg.Any<string>()).Returns(new UserResource()
-            {
-                Links =
-                {
-                    {"Spaces", ""}
-                }
-            });
+            
+            client.Get<RootResource>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(rootDocument);
             client.Repository.HasLink(Arg.Any<string>()).Returns(ci => rootDocument.HasLink(ci.Arg<string>()));
             client.Repository.Link(Arg.Any<string>()).Returns(ci => rootDocument.Link(ci.Arg<string>()));
 
-            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<EnvironmentResource>, bool>>()))
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<EnvironmentResource>, bool>>(), Arg.Any<CancellationToken>()))
                 .Do(ci => ci.Arg<Func<ResourceCollection<EnvironmentResource>, bool>>()(environments));
-            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachineResource>, bool>>()))
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachineResource>, bool>>(), Arg.Any<CancellationToken>()))
                 .Do(ci => ci.Arg<Func<ResourceCollection<MachineResource>, bool>>()(machines));
-            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachinePolicyResource>, bool>>()))
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachinePolicyResource>, bool>>(), Arg.Any<CancellationToken>()))
                 .Do(ci => ci.Arg<Func<ResourceCollection<MachinePolicyResource>, bool>>()(machinePolicies));
-
-            client.List<MachineResource>(Arg.Any<string>(), Arg.Any<object>()).Returns(machines);
         }
 
         [Test]

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -270,6 +270,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.Async.IUserRepository Users { get; }
     Task<RootResource> LoadRootDocument()
+    Task<RootResource> LoadRootDocument(CancellationToken)
   }
   interface IOctopusSystemRepository
     Octopus.Client.IOctopusCommonRepository
@@ -431,6 +432,7 @@ Octopus.Client
     Task<Boolean> HasLinkParameter(String, String)
     Task<String> Link(String)
     Task<RootResource> LoadRootDocument()
+    Task<RootResource> LoadRootDocument(CancellationToken)
     Task<SpaceRootResource> LoadSpaceRootDocument()
   }
   class OctopusClient
@@ -7922,6 +7924,7 @@ Octopus.Client.Repositories.Async
   interface IDelete`1
   {
     Task Delete(Octopus.Client.Repositories.Async.TResource)
+    Task Delete(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IDeploymentProcessRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
@@ -7993,22 +7996,31 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<FeedResource>
   {
     Task<List<PackageResource>> GetVersions(Octopus.Client.Model.FeedResource, String[])
+    Task<List<PackageResource>> GetVersions(Octopus.Client.Model.FeedResource, String[], CancellationToken)
   }
   interface IFindByName`1
     Octopus.Client.Repositories.Async.IPaginate<TResource>
   {
     Task<TResource> FindByName(String, String, Object)
+    Task<TResource> FindByName(String, CancellationToken)
+    Task<TResource> FindByName(String, String, Object, CancellationToken)
     Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, CancellationToken)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
   interface IGetAll`1
   {
     Task<List<TResource>> GetAll()
+    Task<List<TResource>> GetAll(CancellationToken)
   }
   interface IGet`1
   {
     Task<TResource> Get(String)
+    Task<TResource> Get(String, CancellationToken)
     Task<List<TResource>> Get(String[])
+    Task<List<TResource>> Get(CancellationToken, String[])
     Task<TResource> Refresh(Octopus.Client.Repositories.Async.TResource)
+    Task<TResource> Refresh(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IGitCredentialRepository
     Octopus.Client.Repositories.Async.IGet<GitCredentialResource>
@@ -8112,9 +8124,17 @@ Octopus.Client.Repositories.Async
   interface IPaginate`1
   {
     Task<List<TResource>> FindAll(String, Object)
+    Task<List<TResource>> FindAll(CancellationToken)
+    Task<List<TResource>> FindAll(String, Object, CancellationToken)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, CancellationToken)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object, CancellationToken)
     Task<TResource> FindOne(Func<TResource, Boolean>, String, Object)
+    Task<TResource> FindOne(Func<TResource, Boolean>, CancellationToken)
+    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object, CancellationToken)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object, CancellationToken)
   }
   interface IPerformanceConfigurationRepository
   {
@@ -8649,6 +8669,15 @@ Octopus.Client.Serialization
     Octopus.Client.Serialization.InheritedClassConverter<TriggerFilterResource, TriggerFilterType>
   {
     .ctor()
+  }
+}
+Octopus.Client.Tasks
+{
+  class AsyncLazy`1
+  {
+    .ctor(Func<CancellationToken, Task<T>>)
+    Boolean HasValue { get; }
+    Task<T> Value(CancellationToken)
   }
 }
 Octopus.Client.Util

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -270,6 +270,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IUserRolesRepository UserRoles { get; }
     Octopus.Client.Repositories.Async.IUserRepository Users { get; }
     Task<RootResource> LoadRootDocument()
+    Task<RootResource> LoadRootDocument(CancellationToken)
   }
   interface IOctopusSystemRepository
     Octopus.Client.IOctopusCommonRepository
@@ -431,6 +432,7 @@ Octopus.Client
     Task<Boolean> HasLinkParameter(String, String)
     Task<String> Link(String)
     Task<RootResource> LoadRootDocument()
+    Task<RootResource> LoadRootDocument(CancellationToken)
     Task<SpaceRootResource> LoadSpaceRootDocument()
   }
   class OctopusClient
@@ -7947,6 +7949,7 @@ Octopus.Client.Repositories.Async
   interface IDelete`1
   {
     Task Delete(Octopus.Client.Repositories.Async.TResource)
+    Task Delete(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IDeploymentProcessRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentProcessResource>
@@ -8018,22 +8021,31 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<FeedResource>
   {
     Task<List<PackageResource>> GetVersions(Octopus.Client.Model.FeedResource, String[])
+    Task<List<PackageResource>> GetVersions(Octopus.Client.Model.FeedResource, String[], CancellationToken)
   }
   interface IFindByName`1
     Octopus.Client.Repositories.Async.IPaginate<TResource>
   {
     Task<TResource> FindByName(String, String, Object)
+    Task<TResource> FindByName(String, CancellationToken)
+    Task<TResource> FindByName(String, String, Object, CancellationToken)
     Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, CancellationToken)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
   interface IGetAll`1
   {
     Task<List<TResource>> GetAll()
+    Task<List<TResource>> GetAll(CancellationToken)
   }
   interface IGet`1
   {
     Task<TResource> Get(String)
+    Task<TResource> Get(String, CancellationToken)
     Task<List<TResource>> Get(String[])
+    Task<List<TResource>> Get(CancellationToken, String[])
     Task<TResource> Refresh(Octopus.Client.Repositories.Async.TResource)
+    Task<TResource> Refresh(Octopus.Client.Repositories.Async.TResource, CancellationToken)
   }
   interface IGitCredentialRepository
     Octopus.Client.Repositories.Async.IGet<GitCredentialResource>
@@ -8137,9 +8149,17 @@ Octopus.Client.Repositories.Async
   interface IPaginate`1
   {
     Task<List<TResource>> FindAll(String, Object)
+    Task<List<TResource>> FindAll(CancellationToken)
+    Task<List<TResource>> FindAll(String, Object, CancellationToken)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, CancellationToken)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object, CancellationToken)
     Task<TResource> FindOne(Func<TResource, Boolean>, String, Object)
+    Task<TResource> FindOne(Func<TResource, Boolean>, CancellationToken)
+    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object, CancellationToken)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object, CancellationToken)
   }
   interface IPerformanceConfigurationRepository
   {
@@ -8675,6 +8695,15 @@ Octopus.Client.Serialization
     Octopus.Client.Serialization.InheritedClassConverter<TriggerFilterResource, TriggerFilterType>
   {
     .ctor()
+  }
+}
+Octopus.Client.Tasks
+{
+  class AsyncLazy`1
+  {
+    .ctor(Func<CancellationToken, Task<T>>)
+    Boolean HasValue { get; }
+    Task<T> Value(CancellationToken)
   }
 }
 Octopus.Client.Util

--- a/source/Octopus.Client.Tests/Repositories/Async/ProjectTriggerRepositoryTest.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/ProjectTriggerRepositoryTest.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using FluentAssertions;
+using System.Threading;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using Octopus.Client.Model;
 
@@ -33,7 +27,7 @@ namespace Octopus.Client.Tests.Repositories.Async
 
         void SetupAsyncClient(IOctopusAsyncClient client)
         {
-            client.Repository.LoadRootDocument().Returns(new RootResource()
+            client.Repository.LoadRootDocument(Arg.Any<CancellationToken>()).Returns(new RootResource()
             {
                 Version = NotSupportedOctopusVersion
             });

--- a/source/Octopus.Client.Tests/Spaces/SpaceIdAsyncTests.cs
+++ b/source/Octopus.Client.Tests/Spaces/SpaceIdAsyncTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
@@ -19,7 +20,7 @@ namespace Octopus.Client.Tests.Spaces
             client.Get<UserResource>(Arg.Any<string>()).Returns(new UserResource() { Links = { { "Spaces", "" } } });
             client.Get<SpaceResource[]>(Arg.Any<string>()).Returns(new[] { new SpaceResource { Id = "Spaces-1", IsDefault = true, Links = new LinkCollection{{"SpaceHome", String.Empty}}} });
             client.Get<SpaceRootResource>(Arg.Any<string>(), Arg.Any<object>()).Returns(new SpaceRootResource());
-            client.Get<RootResource>(Arg.Any<string>()).Returns(new RootResource()
+            client.Get<RootResource>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new RootResource()
             {
                 ApiVersion = "3.0.0",
                 Version = "2099.0.0",

--- a/source/Octopus.Server.Client/IOctopusSystemAsyncRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusSystemAsyncRepository.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Repositories.Async;
@@ -45,6 +47,11 @@ namespace Octopus.Client
         /// </exception>
         /// <exception cref="OctopusValidationException">HTTP 400: If there was a problem with the request provided by the user.</exception>
         /// <exception cref="OctopusResourceNotFoundException">HTTP 404: If the specified resource does not exist on the server.</exception>
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<RootResource> LoadRootDocument();
+        
+        /// <inheritdoc cref="IOctopusSystemAsyncRepository.LoadRootDocument()"/>
+        /// <param name="cancellationToken">Cancellation token for the request</param>
+        Task<RootResource> LoadRootDocument(CancellationToken cancellationToken);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/FeedRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/FeedRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,7 +8,9 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IFeedRepository : ICreate<FeedResource>, IModify<FeedResource>, IDelete<FeedResource>, IGet<FeedResource>, IFindByName<FeedResource>
     {
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds);
+        Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds, CancellationToken cancellationToken);
     }
 
     class FeedRepository : BasicRepository<FeedResource>, IFeedRepository
@@ -18,7 +21,12 @@ namespace Octopus.Client.Repositories.Async
 
         public Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds)
         {
-            return Client.Get<List<PackageResource>>(feed.Link("VersionsTemplate"), new { packageIds = packageIds });
+            return GetVersions(feed, packageIds, CancellationToken.None);
+        }
+        
+        public Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds, CancellationToken cancellationToken)
+        {
+            return Client.Get<List<PackageResource>>(feed.Link("VersionsTemplate"), new { packageIds = packageIds }, cancellationToken);
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/IDelete.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IDelete.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IDelete<in TResource>
     {
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task Delete(TResource resource);
+        Task Delete(TResource resource, CancellationToken cancellationToken);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/IFindByName.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IFindByName.cs
@@ -1,12 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IFindByName<TResource> : IPaginate<TResource>
     {
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<TResource> FindByName(string name, string path = null, object pathParameters = null);
+        Task<TResource> FindByName(string name, CancellationToken cancellationToken);
+        Task<TResource> FindByName(string name, string path, object pathParameters, CancellationToken cancellationToken);
+        
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<List<TResource>> FindByNames(IEnumerable<string> names, string path = null, object pathParameters = null);
+        Task<List<TResource>> FindByNames(IEnumerable<string> names, CancellationToken cancellationToken);
+        Task<List<TResource>> FindByNames(IEnumerable<string> names, string path, object pathParameters, CancellationToken cancellationToken);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/IGet.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IGet.cs
@@ -1,14 +1,22 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
-using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IGet<TResource>
     {
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<TResource> Get(string idOrHref);
+        Task<TResource> Get(string idOrHref, CancellationToken cancellationToken);
+        
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<List<TResource>> Get(params string[] ids);
+        Task<List<TResource>> Get(CancellationToken cancellationToken, params string[] ids);
+        
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<TResource> Refresh(TResource resource);
+        Task<TResource> Refresh(TResource resource, CancellationToken cancellationToken);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/IGetAll.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IGetAll.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IGetAll<TResource>
     {
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<List<TResource>> GetAll();
+        Task<List<TResource>> GetAll(CancellationToken cancellationToken);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/IPaginate.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IPaginate.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -7,9 +8,24 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IPaginate<TResource>
     {
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path = null, object pathParameters = null);
+        Task Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, CancellationToken cancellationToken);
+        Task Paginate(Func<ResourceCollection<TResource>, bool> getNextPage, string path, object pathParameters, CancellationToken cancellationToken);
+        
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<TResource> FindOne(Func<TResource, bool> search, string path = null, object pathParameters = null);
+        Task<TResource> FindOne(Func<TResource, bool> search, CancellationToken cancellationToken);
+        Task<TResource> FindOne(Func<TResource, bool> search, string path, object pathParameters, CancellationToken cancellationToken);
+        
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<List<TResource>> FindMany(Func<TResource, bool> search, string path = null, object pathParameters = null);
+        Task<List<TResource>> FindMany(Func<TResource, bool> search, CancellationToken cancellationToken);
+        Task<List<TResource>> FindMany(Func<TResource, bool> search, string path, object pathParameters, CancellationToken cancellationToken);
+        
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<List<TResource>> FindAll(string path = null, object pathParameters = null);
+        Task<List<TResource>> FindAll(CancellationToken cancellationToken);
+        Task<List<TResource>> FindAll(string path, object pathParameters, CancellationToken cancellationToken);
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/VariableSetRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/VariableSetRepository.cs
@@ -106,6 +106,11 @@ namespace Octopus.Client.Repositories.Async
             throw new NotSupportedException("VariableSet does not support this operation");
         }
 
+        public override Task<List<VariableSetResource>> Get(CancellationToken cancellationToken, params string[] ids)
+        {
+            throw new NotSupportedException("VariableSet does not support this operation");
+        }
+
         bool ProjectHasVariablesInGit(ProjectResource projectResource)
         {
             return projectResource.PersistenceSettings is GitPersistenceSettingsResource gitSettings && gitSettings.ConversionState.VariablesAreInGit;

--- a/source/Octopus.Server.Client/Tasks/AsyncLazy.cs
+++ b/source/Octopus.Server.Client/Tasks/AsyncLazy.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Octopus.Client.Tasks
+{
+    /// <summary>
+    /// The <see cref="Lazy{T}"/> implementation with <see cref="CancellationToken"/> support.
+    /// </summary>
+    public class AsyncLazy<T> where T : class
+    {
+        private readonly Func<CancellationToken, Task<T>> factoryFunc;
+
+        private readonly SemaphoreSlim semaphore = new(1, 1);
+        private T value;
+
+        public AsyncLazy(Func<CancellationToken, Task<T>> factoryFunc)
+        {
+            this.factoryFunc = factoryFunc;
+        }
+
+        public bool HasValue { get; private set; }
+
+        public async Task<T> Value(CancellationToken cancellationToken)
+        {
+            if (HasValue) return value;
+
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                if (HasValue) return value;
+                value = await factoryFunc(cancellationToken);
+                HasValue = true;
+                return value;
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a continuation effort on initial initiative completed in this [PR](https://github.com/OctopusDeploy/OctopusClients/pull/681).

For this stream, the cancellation token support is added on `IDelete`, `IFindByName`, `IGet`, `IGetAll`, `IPaginate`. The implementation resides in `BasicRepository`. This will take `BasicRepository` a lot closer on full support for cancellation token.

All existing methods that doesn't take cancellation token are marked with `Obsolete`

The guidance on adding cancellation token overload is to maintain compliance with **[CA1068: CancellationToken parameters must come last](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1068)**