### PR TITLE
Add cancellation token support for IDeploymentProcessRepository

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7931,9 +7931,13 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<DeploymentProcessResource>
   {
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource)
+    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
+    Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource, CancellationToken)
     Task<DeploymentProcessResource> Modify(Octopus.Client.Model.DeploymentProcessResource, String)
+    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.DeploymentProcessResource, String, CancellationToken)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7956,9 +7956,13 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<DeploymentProcessResource>
   {
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource)
+    Task<DeploymentProcessResource> Get(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource)
+    Task<ReleaseTemplateResource> GetTemplate(Octopus.Client.Model.DeploymentProcessResource, Octopus.Client.Model.ChannelResource, CancellationToken)
     Task<DeploymentProcessResource> Modify(Octopus.Client.Model.DeploymentProcessResource, String)
+    Task<DeploymentProcessResource> Modify(Octopus.Client.Model.DeploymentProcessResource, String, CancellationToken)
   }
   interface IDeploymentRepository
     Octopus.Client.Repositories.Async.IGet<DeploymentResource>

--- a/source/Octopus.Server.Client/Repositories/Async/DeploymentProcessRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/DeploymentProcessRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Serialization;
@@ -7,11 +8,21 @@ namespace Octopus.Client.Repositories.Async
 {
     public interface IDeploymentProcessRepository : IGet<DeploymentProcessResource>, IModify<DeploymentProcessResource>
     {
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<ReleaseTemplateResource> GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel);
+        Task<ReleaseTemplateResource> GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel, CancellationToken cancellationToken);
 
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitRef);
+        Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitRef, CancellationToken cancellationToken);
+        
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<DeploymentProcessResource> Get(ProjectResource projectResource);
+        Task<DeploymentProcessResource> Get(ProjectResource projectResource, CancellationToken cancellationToken);
+        
+        [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<DeploymentProcessResource> Modify(DeploymentProcessResource deploymentSettings, string commitMessage);
+        Task<DeploymentProcessResource> Modify(DeploymentProcessResource deploymentSettings, string commitMessage, CancellationToken cancellationToken);
     }
 
     class DeploymentProcessRepository : BasicRepository<DeploymentProcessResource>, IDeploymentProcessRepository
@@ -22,13 +33,22 @@ namespace Octopus.Client.Repositories.Async
         {
         }
 
-        public Task<ReleaseTemplateResource> GetTemplate(DeploymentProcessResource deploymentProcess,
-            ChannelResource channel)
+        public Task<ReleaseTemplateResource> GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel)
         {
-            return Client.Get<ReleaseTemplateResource>(deploymentProcess.Link("Template"), new {channel = channel?.Id});
+            return GetTemplate(deploymentProcess, channel, CancellationToken.None);
+        }
+        
+        public Task<ReleaseTemplateResource> GetTemplate(DeploymentProcessResource deploymentProcess, ChannelResource channel, CancellationToken cancellationToken)
+        {
+            return Client.Get<ReleaseTemplateResource>(deploymentProcess.Link("Template"), new {channel = channel?.Id}, cancellationToken);
         }
 
         public Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitRef)
+        {
+            return Get(projectResource, gitRef, CancellationToken.None);
+        }
+        
+        public Task<DeploymentProcessResource> Get(ProjectResource projectResource, string gitRef, CancellationToken cancellationToken)
         {
             if (!projectResource.IsVersionControlled)
             {
@@ -36,26 +56,37 @@ namespace Octopus.Client.Repositories.Async
                     $"Database backed projects require using the overload that does not include a gitRef parameter.");
             }
 
-            return Client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"), new {gitRef});
+            return Client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"), new {gitRef}, cancellationToken);
         }
 
         public Task<DeploymentProcessResource> Get(ProjectResource projectResource)
         {
+            return Get(projectResource, CancellationToken.None);
+        }
+        
+        public Task<DeploymentProcessResource> Get(ProjectResource projectResource, CancellationToken cancellationToken)
+        {
             if (projectResource.PersistenceSettings is GitPersistenceSettingsResource vcsResource)
             {
-                return Get(projectResource, vcsResource.DefaultBranch);
+                return Get(projectResource, vcsResource.DefaultBranch, cancellationToken);
             }
 
-            return Client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"));
+            return Client.Get<DeploymentProcessResource>(projectResource.Link("DeploymentProcess"), cancellationToken);
         }
 
-        public async Task<DeploymentProcessResource> Modify(DeploymentProcessResource deploymentSettings,
-            string commitMessage)
+        public async Task<DeploymentProcessResource> Modify(DeploymentProcessResource deploymentSettings, string commitMessage)
+        {
+            return await Modify(deploymentSettings, CancellationToken.None);
+        }
+        
+        public async Task<DeploymentProcessResource> Modify(DeploymentProcessResource deploymentSettings, string commitMessage, CancellationToken cancellationToken)
         {
             var firstCaCVersion = new SemanticVersion(2021, 3, 2066);
             await EnsureServerIsMinimumVersion(
                 firstCaCVersion,
-                currentServerVersion => $"The version of the Octopus Server ('{currentServerVersion}') you are connecting to is not compatible with this version of Octopus.Client for this API call. Please upgrade your Octopus Server to a version greater than '{firstCaCVersion}'");
+                currentServerVersion => $"The version of the Octopus Server ('{currentServerVersion}') you are connecting to is not compatible with this version of Octopus.Client for this API call. Please upgrade your Octopus Server to a version greater than '{firstCaCVersion}'",
+                cancellationToken
+            );
             
             
             // TODO: revisit/obsolete this API when we have converters
@@ -65,7 +96,7 @@ namespace Octopus.Client.Repositories.Async
 
             command.ChangeDescription = commitMessage;
 
-            return await Modify(command);
+            return await Modify(command, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
This is a continued effort on initial initiative completed in this [PR](https://github.com/OctopusDeploy/OctopusClients/pull/681).

For this stream, the cancellation token support is added on `IDeploymentProcessRepository`.

All existing methods that doesn't take cancellation token are marked with `Obsolete`

The guidance on adding cancellation token overload is to maintain compliance with **[CA1068: CancellationToken parameters must come last](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1068)**