### PR TITLE
Updated versio of MessageContracts.Base and MessageContracts.Base.HttpRoutes

### DIFF
--- a/source/Octopus.Server.Client/Octopus.Server.Client.csproj
+++ b/source/Octopus.Server.Client/Octopus.Server.Client.csproj
@@ -49,8 +49,8 @@ This package contains the non-ILmerged client library for the HTTP API in Octopu
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
     <PackageReference Include="Octodiff" Version="1.3.15" />
-    <PackageReference Include="Octopus.Server.MessageContracts.Base" Version="3.1.744" />
-    <PackageReference Include="Octopus.Server.MessageContracts.Base.HttpRoutes" Version="3.1.744" />
+    <PackageReference Include="Octopus.Server.MessageContracts.Base" Version="3.2.810" />
+    <PackageReference Include="Octopus.Server.MessageContracts.Base.HttpRoutes" Version="3.2.810" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1008" />
     <PackageReference Include="Octopus.TinyTypes.Json" Version="2.2.1008" />
     <PackageReference Include="Octopus.TinyTypes.TypeConverters" Version="2.2.1008" />


### PR DESCRIPTION
The previous version of the Client was targeting a version of Octopus.Server.MessageContracts.Base that was not publicly  accessible. Octopus.Client has the version of the message contracts merged so was not affected. But Octopus.Server.Client does not have it's dependencies merged so could not be used.