### PR TITLE
Update Octodiff to 2.0.100

### DIFF
--- a/source/Octopus.Server.Client/Octopus.Server.Client.csproj
+++ b/source/Octopus.Server.Client/Octopus.Server.Client.csproj
@@ -48,7 +48,7 @@ This package contains the non-ILmerged client library for the HTTP API in Octopu
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-    <PackageReference Include="Octodiff" Version="1.3.15" />
+    <PackageReference Include="Octopus.Octodiff" Version="2.0.100" />
     <PackageReference Include="Octopus.Server.MessageContracts.Base" Version="3.2.810" />
     <PackageReference Include="Octopus.Server.MessageContracts.Base.HttpRoutes" Version="3.2.810" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1008" />


### PR DESCRIPTION
I updated Octodiff to 2.0.100. See the lastest Octodiff PR [here](https://github.com/OctopusDeploy/Octodiff/pull/39).

I don't expect the mentioned PR to make much difference on OctopusClients since the fix targets Octopus Server and Calamari. However, I would like to keep Octodiff up to date here because I changed one public interface.

[sc-25897]