### PR TITLE
Add missing scheduled project triggers

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6803,10 +6803,12 @@ Octopus.Client.Model.Triggers
   TriggerFilterType
   {
       MachineFilter = 0
-      OnceDailySchedule = 1
-      ContinuousDailySchedule = 2
-      DaysPerMonthSchedule = 3
-      CronExpressionSchedule = 4
+      DailySchedule = 1
+      OnceDailySchedule = 2
+      ContinuousDailySchedule = 3
+      DaysPerMonthSchedule = 4
+      DaysPerWeekSchedule = 5
+      CronExpressionSchedule = 6
   }
 }
 Octopus.Client.Model.Triggers.ScheduledTriggers
@@ -6834,10 +6836,24 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     String CronExpression { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
   }
+  class DailyScheduledTriggerFilterResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Triggers.ScheduledTriggers.ScheduledTriggerFilterResource
+  {
+    .ctor()
+    Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
+    Nullable<Int16> HourInterval { get; set; }
+    Octopus.Client.Model.Triggers.ScheduledTriggers.DailyScheduledTriggerInterval Interval { get; set; }
+    Nullable<Int16> MinuteInterval { get; set; }
+    Octopus.Client.Model.Triggers.ScheduledTriggers.ScheduledTriggerFilterRunType RunType { get; set; }
+    Nullable<DateTime> StartTime { get; set; }
+  }
   DailyScheduledTriggerInterval
   {
-      OnceHourly = 0
-      OnceEveryMinute = 1
+      OnceDaily = 0
+      OnceHourly = 1
+      OnceEveryMinute = 2
   }
   DayOfWeek
   {
@@ -6861,6 +6877,21 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
     Octopus.Client.Model.Triggers.ScheduledTriggers.MonthlyScheduleType MonthlyScheduleType { get; set; }
     DateTime StartTime { get; set; }
+  }
+  class DaysPerWeekScheduledTriggerFilterResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Triggers.ScheduledTriggers.DailyScheduledTriggerFilterResource
+  {
+    .ctor()
+    Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
+    Boolean Friday { get; set; }
+    Boolean Monday { get; set; }
+    Boolean Saturday { get; set; }
+    Boolean Sunday { get; set; }
+    Boolean Thursday { get; set; }
+    Boolean Tuesday { get; set; }
+    Boolean Wednesday { get; set; }
   }
   class DeployLatestReleaseActionResource
     Octopus.Client.Extensibility.IResource
@@ -6906,6 +6937,11 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.TriggerFilterResource
   {
     String Timezone { get; set; }
+  }
+  ScheduledTriggerFilterRunType
+  {
+      ScheduledTime = 0
+      Continuously = 1
   }
 }
 Octopus.Client.Model.Versioning

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6803,12 +6803,12 @@ Octopus.Client.Model.Triggers
   TriggerFilterType
   {
       MachineFilter = 0
-      DailySchedule = 1
-      OnceDailySchedule = 2
-      ContinuousDailySchedule = 3
-      DaysPerMonthSchedule = 4
-      DaysPerWeekSchedule = 5
-      CronExpressionSchedule = 6
+      OnceDailySchedule = 1
+      ContinuousDailySchedule = 2
+      DaysPerMonthSchedule = 3
+      CronExpressionSchedule = 4
+      DailySchedule = 5
+      DaysPerWeekSchedule = 6
   }
 }
 Octopus.Client.Model.Triggers.ScheduledTriggers
@@ -6851,9 +6851,9 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
   }
   DailyScheduledTriggerInterval
   {
-      OnceDaily = 0
-      OnceHourly = 1
-      OnceEveryMinute = 2
+      OnceHourly = 0
+      OnceEveryMinute = 1
+      OnceDaily = 2
   }
   DayOfWeek
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6826,11 +6826,13 @@ Octopus.Client.Model.Triggers
   }
   TriggerFilterType
   {
-      MachineFilter = 0
-      OnceDailySchedule = 1
-      ContinuousDailySchedule = 2
-      DaysPerMonthSchedule = 3
-      CronExpressionSchedule = 4
+    MachineFilter = 0
+    DailySchedule = 1
+    OnceDailySchedule = 2
+    ContinuousDailySchedule = 3
+    DaysPerMonthSchedule = 4
+    DaysPerWeekSchedule = 5
+    CronExpressionSchedule = 6
   }
 }
 Octopus.Client.Model.Triggers.ScheduledTriggers
@@ -6858,10 +6860,24 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     String CronExpression { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
   }
+  class DailyScheduledTriggerFilterResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Triggers.ScheduledTriggers.ScheduledTriggerFilterResource
+  {
+    .ctor()
+    Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
+    Nullable<Int16> HourInterval { get; set; }
+    Octopus.Client.Model.Triggers.ScheduledTriggers.DailyScheduledTriggerInterval Interval { get; set; }
+    Nullable<Int16> MinuteInterval { get; set; }
+    Octopus.Client.Model.Triggers.ScheduledTriggers.ScheduledTriggerFilterRunType RunType { get; set; }
+    Nullable<DateTime> StartTime { get; set; }
+  }
   DailyScheduledTriggerInterval
   {
-      OnceHourly = 0
-      OnceEveryMinute = 1
+      OnceDaily = 0
+      OnceHourly = 1
+      OnceEveryMinute = 2
   }
   DayOfWeek
   {
@@ -6885,6 +6901,21 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
     Octopus.Client.Model.Triggers.ScheduledTriggers.MonthlyScheduleType MonthlyScheduleType { get; set; }
     DateTime StartTime { get; set; }
+  }
+  class DaysPerWeekScheduledTriggerFilterResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Triggers.ScheduledTriggers.DailyScheduledTriggerFilterResource
+  {
+    .ctor()
+    Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
+    Boolean Friday { get; set; }
+    Boolean Monday { get; set; }
+    Boolean Saturday { get; set; }
+    Boolean Sunday { get; set; }
+    Boolean Thursday { get; set; }
+    Boolean Tuesday { get; set; }
+    Boolean Wednesday { get; set; }
   }
   class DeployLatestReleaseActionResource
     Octopus.Client.Extensibility.IResource
@@ -6930,6 +6961,11 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
     Octopus.Client.Model.Triggers.TriggerFilterResource
   {
     String Timezone { get; set; }
+  }
+  ScheduledTriggerFilterRunType
+  {
+    ScheduledTime = 0
+    Continuously = 1
   }
 }
 Octopus.Client.Model.Versioning

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6964,8 +6964,8 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
   }
   ScheduledTriggerFilterRunType
   {
-    ScheduledTime = 0
-    Continuously = 1
+      ScheduledTime = 0
+      Continuously = 1
   }
 }
 Octopus.Client.Model.Versioning

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6964,8 +6964,8 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
   }
   ScheduledTriggerFilterRunType
   {
-      ScheduledTime = 0
-      Continuously = 1
+   ScheduledTime = 0
+   Continuously = 1
   }
 }
 Octopus.Client.Model.Versioning

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6826,13 +6826,13 @@ Octopus.Client.Model.Triggers
   }
   TriggerFilterType
   {
-    MachineFilter = 0
-    DailySchedule = 1
-    OnceDailySchedule = 2
-    ContinuousDailySchedule = 3
-    DaysPerMonthSchedule = 4
-    DaysPerWeekSchedule = 5
-    CronExpressionSchedule = 6
+      MachineFilter = 0
+      OnceDailySchedule = 1
+      ContinuousDailySchedule = 2
+      DaysPerMonthSchedule = 3
+      CronExpressionSchedule = 4
+      DailySchedule = 5
+      DaysPerWeekSchedule = 6
   }
 }
 Octopus.Client.Model.Triggers.ScheduledTriggers
@@ -6875,9 +6875,9 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
   }
   DailyScheduledTriggerInterval
   {
-      OnceDaily = 0
-      OnceHourly = 1
-      OnceEveryMinute = 2
+      OnceHourly = 0
+      OnceEveryMinute = 1
+      OnceDaily = 2
   }
   DayOfWeek
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6964,8 +6964,8 @@ Octopus.Client.Model.Triggers.ScheduledTriggers
   }
   ScheduledTriggerFilterRunType
   {
-   ScheduledTime = 0
-   Continuously = 1
+    ScheduledTime = 0
+    Continuously = 1
   }
 }
 Octopus.Client.Model.Versioning

--- a/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DailyScheduledTriggerFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DailyScheduledTriggerFilterResource.cs
@@ -1,0 +1,24 @@
+using System;
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.Triggers.ScheduledTriggers;
+
+public class DailyScheduledTriggerFilterResource : ScheduledTriggerFilterResource
+{
+    public override TriggerFilterType FilterType => TriggerFilterType.DailySchedule;
+
+    [Writeable]
+    public DateTime? StartTime { get; set; }
+
+    [Writeable]
+    public ScheduledTriggerFilterRunType RunType { get; set; }
+
+    [Writeable]
+    public DailyScheduledTriggerInterval Interval { get; set; }
+
+    [Writeable]
+    public short? HourInterval { get; set; }
+
+    [Writeable]
+    public short? MinuteInterval { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DailyScheduledTriggerInterval.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DailyScheduledTriggerInterval.cs
@@ -2,8 +2,8 @@
 {
     public enum DailyScheduledTriggerInterval
     {
-        OnceDaily,
         OnceHourly,
-        OnceEveryMinute
+        OnceEveryMinute,
+        OnceDaily,
     }
 }

--- a/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DailyScheduledTriggerInterval.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DailyScheduledTriggerInterval.cs
@@ -2,6 +2,7 @@
 {
     public enum DailyScheduledTriggerInterval
     {
+        OnceDaily,
         OnceHourly,
         OnceEveryMinute
     }

--- a/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DaysPerWeekScheduledTriggerFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/DaysPerWeekScheduledTriggerFilterResource.cs
@@ -1,0 +1,29 @@
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.Triggers.ScheduledTriggers;
+
+public class DaysPerWeekScheduledTriggerFilterResource : DailyScheduledTriggerFilterResource
+{
+    public override TriggerFilterType FilterType => TriggerFilterType.DaysPerWeekSchedule;
+
+    [Writeable]
+    public bool Monday { get; set; }
+
+    [Writeable]
+    public bool Tuesday { get; set; }
+
+    [Writeable]
+    public bool Wednesday { get; set; }
+
+    [Writeable]
+    public bool Thursday { get; set; }
+
+    [Writeable]
+    public bool Friday { get; set; }
+
+    [Writeable]
+    public bool Saturday { get; set; }
+
+    [Writeable]
+    public bool Sunday { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/ScheduledTriggerFilterRunType.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/ScheduledTriggers/ScheduledTriggerFilterRunType.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model.Triggers.ScheduledTriggers;
+
+public enum ScheduledTriggerFilterRunType
+{
+    ScheduledTime,
+    Continuously
+}

--- a/source/Octopus.Server.Client/Model/Triggers/TriggerFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/TriggerFilterResource.cs
@@ -6,9 +6,11 @@ namespace Octopus.Client.Model.Triggers
     public enum TriggerFilterType
     {
         MachineFilter,
+        DailySchedule,
         OnceDailySchedule,
         ContinuousDailySchedule,
         DaysPerMonthSchedule,
+        DaysPerWeekSchedule,
         CronExpressionSchedule
     }
 

--- a/source/Octopus.Server.Client/Model/Triggers/TriggerFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/TriggerFilterResource.cs
@@ -6,12 +6,12 @@ namespace Octopus.Client.Model.Triggers
     public enum TriggerFilterType
     {
         MachineFilter,
-        DailySchedule,
         OnceDailySchedule,
         ContinuousDailySchedule,
         DaysPerMonthSchedule,
-        DaysPerWeekSchedule,
-        CronExpressionSchedule
+        CronExpressionSchedule,
+        DailySchedule,
+        DaysPerWeekSchedule
     }
 
     public abstract class TriggerFilterResource : Resource

--- a/source/Octopus.Server.Client/Serialization/TriggerFilterConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/TriggerFilterConverter.cs
@@ -11,9 +11,11 @@ namespace Octopus.Client.Serialization
           new Dictionary<TriggerFilterType, Type>
           {
               { TriggerFilterType.MachineFilter, typeof (MachineFilterResource)},
+              { TriggerFilterType.DailySchedule, typeof (DailyScheduledTriggerFilterResource)},
               { TriggerFilterType.OnceDailySchedule, typeof (OnceDailyScheduledTriggerFilterResource)},
               { TriggerFilterType.ContinuousDailySchedule, typeof (ContinuousDailyScheduledTriggerFilterResource)},
               { TriggerFilterType.DaysPerMonthSchedule, typeof (DaysPerMonthScheduledTriggerFilterResource)},
+              { TriggerFilterType.DaysPerWeekSchedule, typeof (DaysPerWeekScheduledTriggerFilterResource)},
               { TriggerFilterType.CronExpressionSchedule, typeof (CronScheduledTriggerFilterResource)}
           };
 


### PR DESCRIPTION
We had some scheduled triggers and enums present in our core model but not in our client models

This PR looks to match up the two! 