### PR TITLE
Obsoleted `UserPermissionsRepository.GetConfiguration` and replaced it with `GetDescriptions` which returns the right type

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -102,7 +102,7 @@ class Build : NukeBuild
 
     Target Merge => _ => _
         .DependsOn(Compile)
-        .Executes(async () =>
+        .Executes(() =>
         {
             foreach (var target in new[] {"net462", "netstandard2.0"})
             {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4176,6 +4176,8 @@ Octopus.Client.Model
   class PermissionDescription
   {
     .ctor()
+    Boolean CanApplyAtSpaceLevel { get; set; }
+    Boolean CanApplyAtSystemLevel { get; set; }
     String Description { get; set; }
     String[] SupportedRestrictions { get; set; }
   }
@@ -8535,6 +8537,7 @@ Octopus.Client.Repositories.Async
     Task<Stream> Export(Octopus.Client.Model.UserPermissionSetResource)
     Task<UserPermissionSetResource> Get(Octopus.Client.Model.UserResource)
     Task<UserPermissionSetResource> GetConfiguration(Octopus.Client.Model.UserResource)
+    Task<IReadOnlyDictionary<Permission, PermissionDescription>> GetDescriptions(Octopus.Client.Model.UserResource)
   }
   interface IUserRepository
     Octopus.Client.Repositories.Async.IPaginate<UserResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4196,6 +4196,8 @@ Octopus.Client.Model
   class PermissionDescription
   {
     .ctor()
+    Boolean CanApplyAtSpaceLevel { get; set; }
+    Boolean CanApplyAtSystemLevel { get; set; }
     String Description { get; set; }
     String[] SupportedRestrictions { get; set; }
   }
@@ -8560,6 +8562,7 @@ Octopus.Client.Repositories.Async
     Task<Stream> Export(Octopus.Client.Model.UserPermissionSetResource)
     Task<UserPermissionSetResource> Get(Octopus.Client.Model.UserResource)
     Task<UserPermissionSetResource> GetConfiguration(Octopus.Client.Model.UserResource)
+    Task<IReadOnlyDictionary<Permission, PermissionDescription>> GetDescriptions(Octopus.Client.Model.UserResource)
   }
   interface IUserRepository
     Octopus.Client.Repositories.Async.IPaginate<UserResource>

--- a/source/Octopus.Server.Client/Model/PermissionDescription.cs
+++ b/source/Octopus.Server.Client/Model/PermissionDescription.cs
@@ -6,5 +6,7 @@ namespace Octopus.Client.Model
     {
         public string Description { get; set; }
         public string[] SupportedRestrictions { get; set; }
+        public bool CanApplyAtSystemLevel { get; set; }
+        public bool CanApplyAtSpaceLevel { get; set; }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/UserPermissionsRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/UserPermissionsRepository.cs
@@ -11,7 +11,9 @@ namespace Octopus.Client.Repositories.Async
         ICanExtendSpaceContext<IUserPermissionsRepository>
     {
         Task<UserPermissionSetResource> Get(UserResource user);
+        [Obsolete("Use GetDescriptions(UserResource) instead. This method only returns empty sets and is only kept for backwards compatibility.")]
         Task<UserPermissionSetResource> GetConfiguration(UserResource user);
+        Task<IReadOnlyDictionary<Permission, PermissionDescription>> GetDescriptions(UserResource user);
         Task<Stream> Export(UserPermissionSetResource userPermissions);
     }
     
@@ -33,10 +35,17 @@ namespace Octopus.Client.Repositories.Async
             return await Client.Get<UserPermissionSetResource>(user.Link("Permissions"), GetAdditionalQueryParameters()).ConfigureAwait(false);
         }
 
+        [Obsolete("Use GetDescriptions(UserResource) instead. This method only returns empty sets and is only kept for backwards compatibility.")]
         public async Task<UserPermissionSetResource> GetConfiguration(UserResource user)
         {
             if (user == null) throw new ArgumentNullException(nameof(user));
             return await Client.Get<UserPermissionSetResource>(user.Link("PermissionsConfiguration"), GetAdditionalQueryParameters()).ConfigureAwait(false);
+        }
+
+        public async Task<IReadOnlyDictionary<Permission, PermissionDescription>> GetDescriptions(UserResource user)
+        {
+            if (user == null) throw new ArgumentNullException(nameof(user));
+            return await Client.Get<IReadOnlyDictionary<Permission, PermissionDescription>>(user.Link("PermissionsConfiguration"), GetAdditionalQueryParameters()).ConfigureAwait(false);
         }
 
         public async Task<Stream> Export(UserPermissionSetResource userPermissions)


### PR DESCRIPTION
[The API controller is here](https://github.com/OctopusDeploy/OctopusDeploy/blob/431e99f2f127352dfc137eef376444ce7a72df98/source/Octopus.Server/Web/Api/Actions/PermissionDefinitionsResponder.cs#L22)

While porting the API to ASP.NET (https://github.com/OctopusDeploy/OctopusDeploy/pull/15443) I found that the method didn't actually return any data because the response was in a completely different shape.

I decided to obsolete it to keep compat, but I doubt anyone is actually using it.


[sc-32326]