### PR TITLE
Don't overwrite genuine cancellation exceptions with timeout exceptions in DispatchRequest

### DIFF
--- a/source/Octopus.Client.Tests/Integration/OctopusClient/TimeoutTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/TimeoutTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
-using Octopus.Client.Exceptions;
 
 namespace Octopus.Client.Tests.Integration.OctopusClient
 {
@@ -36,5 +35,20 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
         }
 
+        [Test]
+        public void CancellationThrowsOperationCanceledException()
+        {
+            var sw = Stopwatch.StartNew();
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            var getTask = AsyncClient.Get<string>("~/", cancellationTokenSource.Token);
+            cancellationTokenSource.Cancel();
+
+            var get = () => getTask;
+            get.ShouldThrow<OperationCanceledException>()
+                .Where(ex => ex.CancellationToken == cancellationTokenSource.Token);
+
+            sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
+        }
     }
 }

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/TimeoutTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/TimeoutTests.cs
@@ -44,7 +44,7 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             var getTask = AsyncClient.Get<string>("~/", cancellationTokenSource.Token);
             cancellationTokenSource.Cancel();
 
-            var get = () => getTask;
+            Func<Task> get = () => getTask;
             get.ShouldThrow<OperationCanceledException>()
                 .Where(ex => ex.CancellationToken == cancellationTokenSource.Token);
 

--- a/source/Octopus.Server.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -633,7 +633,9 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                         return octopusResponse;
                     }
                 }
-                catch (TaskCanceledException)
+                catch (TaskCanceledException exception) when (
+                    exception.CancellationToken != cancellationToken &&
+                    exception.InnerException is TimeoutException)
                 {
                     throw new TimeoutException($"Timeout getting response from {request.Uri} (client timeout is set to {client.Timeout}).");
                 }

--- a/source/Octopus.Server.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncClient.cs
@@ -637,7 +637,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                     exception.CancellationToken != cancellationToken &&
                     exception.InnerException is TimeoutException)
                 {
-                    throw new TimeoutException($"Timeout getting response from {request.Uri} (client timeout is set to {client.Timeout}).");
+                    throw new TimeoutException($"Timeout getting response from {request.Uri} (client timeout is set to {client.Timeout}).", exception);
                 }
             }
         }


### PR DESCRIPTION
Regardless of what the actual cause of cancellation was, `DispatchRequest` squashes any cancellation exception in favour of a `TimeoutException`. This means if your own code makes a request and then cancels it immediately for whatever reason, you get the following misleading error:

```
System.TimeoutException: Timeout getting response from [...] (client timeout is set to 00:04:00).
```

This also means that user code that wants to squash a cancellation exception caused by their own token (e.g. during application shutdown, when cancellation should happen silently and not throw) cannot do so.

This PR:  
* Fixes that issue by specifically replacing the exception when it was genuinely caused by a timeout
* Keeps the original exception around as an inner exception as a matter of best practice
* Confirms the fix with a test