### PR TITLE
Remove PrivateSpaceOwner property

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5103,7 +5103,6 @@ Octopus.Client.Model
     Boolean IsDefault { get; set; }
     Boolean IsPrivate { get; set; }
     String Name { get; set; }
-    String PrivateSpaceOwner { get; set; }
     String Slug { get; set; }
     Octopus.Client.Model.ReferenceCollection SpaceManagersTeamMembers { get; set; }
     Octopus.Client.Model.ReferenceCollection SpaceManagersTeams { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5122,7 +5122,6 @@ Octopus.Client.Model
     Boolean IsDefault { get; set; }
     Boolean IsPrivate { get; set; }
     String Name { get; set; }
-    String PrivateSpaceOwner { get; set; }
     String Slug { get; set; }
     Octopus.Client.Model.ReferenceCollection SpaceManagersTeamMembers { get; set; }
     Octopus.Client.Model.ReferenceCollection SpaceManagersTeams { get; set; }

--- a/source/Octopus.Server.Client/Model/SpaceResource.cs
+++ b/source/Octopus.Server.Client/Model/SpaceResource.cs
@@ -33,8 +33,6 @@ namespace Octopus.Client.Model
         [Writeable]
         public ReferenceCollection SpaceManagersTeamMembers { get; set; }
 		
-        public string PrivateSpaceOwner { get; set; }
-        
         public IconResource Icon { get; set; }
     }
 }


### PR DESCRIPTION
Private spaces [have been decommissioned](https://docs.google.com/document/d/1fTe8ea1bSrMKhCQdb6-NSytQYcubV_d9RNIbIAR4kuE). This PR removes `PrivateSpaceOwner` column, which is no longer used anywhere.