### PR TITLE
Fix datetime serialization tests

### DIFF
--- a/source/Octopus.Client.Tests/Serialization/CrossPlatformDateTimeZoneJsonConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/CrossPlatformDateTimeZoneJsonConverterFixture.cs
@@ -26,15 +26,16 @@ namespace Octopus.Client.Tests.Serialization
         {
             var date = JsonConvert.DeserializeObject<DateTimeOffset>($@"""{serializedDate}""", serializerSettings);
 
-            var timezone = hasTimeZone ? TimeSpan.FromHours(8) : DateTimeOffset.Now.Offset;
-            var expected = new DateTimeOffset(
+            var expectedDateWithoutOffset = new DateTime(
                 2022,
                 08,
                 24,
                 20,
                 54,
-                46,
-                timezone);
+                46);
+            var expected = hasTimeZone 
+                ? new DateTimeOffset(expectedDateWithoutOffset, TimeSpan.FromHours(8)) 
+                : new DateTimeOffset(expectedDateWithoutOffset);
 
             date
                 .Should()

--- a/source/Octopus.Client.Tests/Serialization/PermissiveInstantJsonConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/PermissiveInstantJsonConverterFixture.cs
@@ -21,14 +21,16 @@ namespace Octopus.Client.Tests.Serialization
         public void ShouldDeserializeInstantWithoutZone()
         {
             var result = JsonConvert.DeserializeObject<Instant?>(@"""2022-08-24T12:54:46""", serializerSettings);
-            var expected = Instant.FromUtc(
-                    2022,
-                    8,
-                    24,
-                    12,
-                    54,
-                    46)
-                .Minus(Duration.FromTimeSpan(DateTimeOffset.Now.Offset));
+            var expectedDateWithoutOffset = new DateTime(
+                2022,
+                08,
+                24,
+                12,
+                54,
+                46);
+            
+            var expected = Instant.FromDateTimeUtc(new DateTime(expectedDateWithoutOffset.Ticks, DateTimeKind.Utc))
+                .Minus(Duration.FromTimeSpan(new DateTimeOffset(expectedDateWithoutOffset).Offset));
 
             result
                 .Should()


### PR DESCRIPTION
`PermissiveInstantJsonConverterFixture` and `CrossPlatformDateTimeZoneJsonConverterFixture` had a tricky implicit assumption that a timezone always remains with the same offset, which is not true for timezones with daylight savings time (like Victoria). Making the tests fail when the offset is different from the verified date's offset.

The fix is to always use the offset as it was at the time when the check is made and not today's offset.