### PR TITLE
Fix multipart trailer for sync client

### DIFF
--- a/source/Octopus.Client.Tests/Integration/OctopusClient/FileTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/FileTests.cs
@@ -19,7 +19,17 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             : base(UrlPathPrefixBehaviour.UseClassNameAsUrlPathPrefix)
         {
             Post(TestRootPath, p =>
-            {
+            { 
+                using (var reader = new StreamReader(Request.Body))
+                {
+                    var content = reader.ReadToEnd();
+                    if (!content.Trim().EndsWith("--"))
+                    {
+                        return CreateErrorResponse(
+                            $"The request did not include an appropriate boundary trailer ending with --");
+                    }
+                }
+                
                 var file = Request.Files.SingleOrDefault();
                 if (file == null)
                     return CreateErrorResponse($"No file");

--- a/source/Octopus.Server.Client/OctopusClient.cs
+++ b/source/Octopus.Server.Client/OctopusClient.cs
@@ -519,7 +519,6 @@ namespace Octopus.Client
                             webRequest.ContentType = "multipart/form-data; boundary=" + boundary;
 
                             var requestStream = webRequest.GetRequestStream();
-                            
                             requestStream.Write(boundarybytes, 0, boundarybytes.Length);
 
                             var headerTemplate = "Content-Disposition: form-data; name=file; filename={0}\r\nContent-Type: application/octet-stream\r\n\r\n";
@@ -527,9 +526,10 @@ namespace Octopus.Client
                             var headerbytes = Encoding.UTF8.GetBytes(header);
                             requestStream.Write(headerbytes, 0, headerbytes.Length);
                             fileUploadContent.Contents.CopyTo(requestStream);
-                            requestStream.Write(boundarybytes, 0, boundarybytes.Length);
+                                                        
+                            var boundarybytesTrailer = Encoding.ASCII.GetBytes("\r\n--" + boundary + "--\r\n"); 
+                            requestStream.Write(boundarybytesTrailer, 0, boundarybytesTrailer.Length);
                             requestStream.Flush();
-
                             requestStream.Close();
                         }
                         else


### PR DESCRIPTION
We previously updated our client to include a [trailing boundary](https://github.com/OctopusDeploy/OctopusClients/pull/720), but unfortunately during a rebase it was removed by accident. This PR fixes this oversight and adds the appropriate trailer boundary back into multipart data data being sent via the sync client.