### PR TITLE
Fix Rocky Linux 9 build and test

### DIFF
--- a/build/containers/test-base/rocky9/Dockerfile
+++ b/build/containers/test-base/rocky9/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf install \
 
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
+
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /
 

--- a/build/containers/test-base/rocky9/Dockerfile
+++ b/build/containers/test-base/rocky9/Dockerfile
@@ -10,11 +10,10 @@ RUN dnf install \
         findutils \
         libicu \
         compat-openssl11 \
+        gzip \
     -y
 
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
-
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /
-


### PR DESCRIPTION
Nightly build had started failing. A check of the logs revealed that gzip was missing. It was not missing before, but I guess this is why we do nightly builds. I have added gzip to the rocky9 test process and all seems to work correctly now.