### PR TITLE
ensure client options is never null prior to client creation

### DIFF
--- a/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
+++ b/source/Octopus.Client.Tests/Integration/HttpIntegrationTestBase.cs
@@ -157,11 +157,8 @@ namespace Octopus.Client.Tests.Integration
         {
         }
 
-        protected virtual OctopusClientOptions GetClientOptions()
-        {
-            return new OctopusClientOptions();
-        }
-
+        protected virtual OctopusClientOptions GetClientOptions() => null;
+        
         [TearDown]
         public virtual void TearDown()
         {

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/TimeoutTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/TimeoutTests.cs
@@ -21,7 +21,7 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
 
         protected override OctopusClientOptions GetClientOptions()
         {
-            var options = base.GetClientOptions();
+            var options = new OctopusClientOptions();
             options.Timeout = TimeSpan.FromSeconds(5);
             return options;
         }

--- a/source/Octopus.Server.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncClient.cs
@@ -164,7 +164,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
 #if HTTP_CLIENT_SUPPORTS_SSL_OPTIONS
             try
             {
-                return await Create(serverEndpoint, options ?? new OctopusClientOptions(), true).ConfigureAwait(false);
+                return await Create(serverEndpoint, options, true).ConfigureAwait(false);
             }
             catch (PlatformNotSupportedException ex)
             {
@@ -197,6 +197,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
 
         private static async Task<IOctopusAsyncClient> Create(OctopusServerEndpoint serverEndpoint, OctopusClientOptions options, bool addHandler, string requestingTool = null)
         {
+            options ??= new OctopusClientOptions();
             var httpRouteExtractor = new HttpRouteExtractor(options.ScanForHttpRouteTypes);
             var client = new OctopusAsyncClient(serverEndpoint, options, addHandler, requestingTool, httpRouteExtractor);
             // User used to see this exception 


### PR DESCRIPTION
The `HttpIntegrationTestBase` was always setting the Client Options to a non-null value, and hiding possible issues where a null value was allowed on the `Create` methods.

Related to https://github.com/OctopusDeploy/OctopusTentacle/pull/450

[sc-42931]