### PR TITLE
Update push-package and setup-dotnet actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -174,7 +174,7 @@ jobs:
             ./artifacts/Octopus.Client.${{ needs.build.outputs.octoversion_fullsemver }}.nupkg
             ./artifacts/Octopus.Server.Client.${{ needs.build.outputs.octoversion_fullsemver }}.nupkg
       - name: Create Release in Octopus 🐙
-        uses: OctopusDeploy/create-release-action@v1
+        uses: OctopusDeploy/create-release-action@v3
         with:
           server: ${{ secrets.DEPLOY_URL }}
           space: Core Platform

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0 # all
       - name: Setup .NET 6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
       # Adjustment is done prior to Nuke build as OCTOVERSION information is included in the result package.
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
       - name: Run unit tests 🏗
@@ -165,7 +165,7 @@ jobs:
         with:
           version: latest   
       - name: Push to Octopus 🐙
-        uses: OctopusDeploy/push-package-action@v1
+        uses: OctopusDeploy/push-package-action@v3
         with:
           server: ${{ secrets.DEPLOY_URL }}
           space: Core Platform

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageDownload Include="AzureSignTool" Version="[3.0.0]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.2.951]" />
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.59]" />
   </ItemGroup>
 
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageDownload Include="AzureSignTool" Version="[3.0.0]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.59]" />
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.2.951]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Background

[sc-45166]

A nightly build didn't show up in deploy for OctopusClients. This is because there was a network timeout while pushing the nuget packages to octopus. The current version of the `push-packages-action` (v1) installs the .NET CLI and uses it to push packages. It was this installation that timed out.

This PR updates `push-packages-action` to v3 as it doesn't need the CLI at all.

It also updates the `setup-dotnet` action to v3 to stop the `Node.js 12 actions are deprecated.` warnings in the action logs.

We will still see the `The set-output command is deprecated and will be disabled soon` warning for now. We need swap over to `Octopus.OctoVersion.Tool` from `OctoVersion.Tool` to fix these warnings but that is blocked until https://github.com/nuke-build/nuke/pull/1104 is released in Nuke.


# Results

- Update `push-package-action` to `v3`
- Update `setup-dotnet` to `v3`
