### PR TITLE
Add Cron Expression to Event Retention resource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6483,6 +6483,7 @@ Octopus.Client.Model.EventRetention
     Octopus.Client.Extensibility.IResource
   {
     .ctor()
+    String CronExpression { get; set; }
     Int32 EventRetentionDays { get; set; }
     String Id { get; set; }
     Octopus.Client.Extensibility.LinkCollection Links { get; set; }

--- a/source/Octopus.Server.Client/Model/EventRetention/EventRetentionConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/EventRetention/EventRetentionConfigurationResource.cs
@@ -12,9 +12,12 @@ namespace Octopus.Client.Model.EventRetention
         }
 
         public string Id { get; set; }
-        
+
         [Writeable]
         public int EventRetentionDays { get; set; } = 90;
+
+        [Writeable]
+        public string CronExpression { get; set; } = "0 */4 * * *";
 
         public LinkCollection Links { get; set; }
     }


### PR DESCRIPTION
Adding CronExpression as a customisable field for Event retention. See https://github.com/OctopusDeploy/OctopusDeploy/pull/18006 for details.

[sc-40132]