### PR TITLE
add oci registry feedtype enum and resource

### DIFF
--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Assent" Version="2.2.0" />
+    <PackageReference Include="Assent" Version="1.9.3" />
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="FluentAssertions" Version="4.15.0" />
     <PackageReference Include="Nancy" Version="2.0.0" />

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Assent" Version="1.5.0" />
+    <PackageReference Include="Assent" Version="2.2.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="FluentAssertions" Version="4.15.0" />
     <PackageReference Include="Nancy" Version="2.0.0" />

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3110,10 +3110,11 @@ Octopus.Client.Model
       GitHub = 5
       BuiltIn = 6
       Helm = 7
-      AwsElasticContainerRegistry = 8
-      S3 = 9
-      AzureContainerRegistry = 10
-      GoogleContainerRegistry = 11
+      OciRegistry = 8
+      AwsElasticContainerRegistry = 9
+      S3 = 10
+      AzureContainerRegistry = 11
+      GoogleContainerRegistry = 12
   }
   class FileUpload
   {
@@ -3909,6 +3910,20 @@ Octopus.Client.Model
     .ctor()
     Double[] Data { get; set; }
     String Label { get; set; }
+  }
+  class OciRegistryFeedResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Model.FeedResource
+  {
+    .ctor()
+    Octopus.Client.Model.FeedType FeedType { get; }
+    String FeedUri { get; set; }
+    Octopus.Client.Model.SensitiveValue Password { get; set; }
+    String Username { get; set; }
   }
   class OctopusProjectFeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Server.Client/Model/FeedType.cs
+++ b/source/Octopus.Server.Client/Model/FeedType.cs
@@ -10,6 +10,7 @@
         GitHub,
         BuiltIn,
         Helm,
+        OciRegistry,
         AwsElasticContainerRegistry,
         S3,
         AzureContainerRegistry,

--- a/source/Octopus.Server.Client/Model/OciRegistryFeedResource.cs
+++ b/source/Octopus.Server.Client/Model/OciRegistryFeedResource.cs
@@ -1,17 +1,18 @@
 using Octopus.Client.Extensibility.Attributes;
 
-namespace Octopus.Client.Model;
-
-public class OciRegistryFeedResource : FeedResource
+namespace Octopus.Client.Model
 {
-    public override FeedType FeedType => FeedType.OciRegistry;
+    public class OciRegistryFeedResource : FeedResource
+    {
+        public override FeedType FeedType => FeedType.OciRegistry;
 
-    [Writeable]
-    public string FeedUri { get; set; }
+        [Writeable] 
+        public string FeedUri { get; set; }
 
-    [Writeable]
-    public string Username { get; set; }
+        [Writeable] 
+        public string Username { get; set; }
 
-    [Writeable]
-    public SensitiveValue Password { get; set; }
+        [Writeable] 
+        public SensitiveValue Password { get; set; }
+    }
 }

--- a/source/Octopus.Server.Client/Model/OciRegistryFeedResource.cs
+++ b/source/Octopus.Server.Client/Model/OciRegistryFeedResource.cs
@@ -1,0 +1,17 @@
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model;
+
+public class OciRegistryFeedResource : FeedResource
+{
+    public override FeedType FeedType => FeedType.OciRegistry;
+
+    [Writeable]
+    public string FeedUri { get; set; }
+
+    [Writeable]
+    public string Username { get; set; }
+
+    [Writeable]
+    public SensitiveValue Password { get; set; }
+}

--- a/source/Octopus.Server.Client/Serialization/FeedConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/FeedConverter.cs
@@ -17,6 +17,7 @@ namespace Octopus.Client.Serialization
                 {FeedType.BuiltIn, typeof(BuiltInFeedResource)},
                 {FeedType.AwsElasticContainerRegistry, typeof(AwsElasticContainerRegistryFeedResource)},
                 {FeedType.Helm, typeof(HelmFeedResource)},
+                {FeedType.OciRegistry, typeof(OciRegistryFeedResource)},
                 {FeedType.S3, typeof(S3FeedResource)},
                 {FeedType.AzureContainerRegistry, typeof(AzureContainerRegistryFeedResource)},
                 {FeedType.GoogleContainerRegistry, typeof(GoogleContainerRegistryFeedResource)},


### PR DESCRIPTION
This PR adds the new OCI Registry feed type as we're adding support for OCI Registries in Octopus Server.

[sc-43537]