### PR TITLE
Find by partial name support

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -8159,6 +8159,12 @@ Octopus.Client.Repositories.Async
     Task<List<TResource>> FindByNames(IEnumerable<String>, CancellationToken)
     Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
+  interface IFindByPartialName`1
+    Octopus.Client.Repositories.Async.IPaginate<TResource>
+  {
+    Task<List<TResource>> FindByPartialName(String, CancellationToken)
+    Task<List<TResource>> FindByPartialName(String, String, Object, CancellationToken)
+  }
   interface IGetAll`1
   {
     Task<List<TResource>> GetAll()
@@ -8601,6 +8607,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IFindByName<TenantResource>
     Octopus.Client.Repositories.Async.IPaginate<TenantResource>
     Octopus.Client.Repositories.Async.IGetAll<TenantResource>
+    Octopus.Client.Repositories.Async.IFindByPartialName<TenantResource>
   {
     Task<TenantEditor> CreateOrModify(String)
     Task<TenantEditor> CreateOrModify(String, String)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7415,6 +7415,11 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.TResource FindByName(String, String, Object)
     List<TResource> FindByNames(IEnumerable<String>, String, Object)
   }
+  interface IFindByPartialName`1
+    Octopus.Client.Repositories.IPaginate<TResource>
+  {
+    List<TResource> FindByPartialName(String, String, Object)
+  }
   interface IGetAll`1
   {
     List<TResource> GetAll()
@@ -7773,6 +7778,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IFindByName<TenantResource>
     Octopus.Client.Repositories.IPaginate<TenantResource>
     Octopus.Client.Repositories.IGetAll<TenantResource>
+    Octopus.Client.Repositories.IFindByPartialName<TenantResource>
   {
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1560,6 +1560,7 @@ Octopus.Client.Extensions
   abstract class StringExtensions
   {
     static String CommaSeparate(IEnumerable<Object>)
+    static Boolean Contains(String, String, StringComparison)
     static String NewLineSeparate(IEnumerable<Object>)
     static String StringJoin(IEnumerable<String>, String)
     static String ToCamelCase(String)

--- a/source/Octopus.Server.Client/Extensions/StringExtensions.cs
+++ b/source/Octopus.Server.Client/Extensions/StringExtensions.cs
@@ -26,5 +26,8 @@ namespace Octopus.Client.Extensions
             var result = first + remainder;
             return result;
         }
+
+        public static bool Contains(this string s, string text, StringComparison comp)
+            => s != null && text != null && s.IndexOf(text, comp) != -1;
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/BasicRepository.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Extensibility;
+using Octopus.Client.Extensions;
 using Octopus.Client.Model;
 using Octopus.Client.Util;
 using Octopus.Client.Validation;
@@ -264,7 +265,7 @@ namespace Octopus.Client.Repositories.Async
             return FindMany(r =>
             {
                 var named = r as INamedResource;
-                return named != null && named.Name.Contains(partialName);
+                return named != null && named.Name.Contains(partialName, StringComparison.OrdinalIgnoreCase);
             }, path, pathParameters);
         }
         

--- a/source/Octopus.Server.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/BasicRepository.cs
@@ -254,15 +254,15 @@ namespace Octopus.Client.Repositories.Async
             return await Client.Get<List<TResource>>(link, parameters, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<List<TResource>> FindByPartialName(string partialName, string path, object pathParameters, CancellationToken cancellationToken)
+        public async Task<List<TResource>> FindByPartialName(string partialName, string path, object pathParameters, CancellationToken cancellationToken)
         {
-            ThrowIfServerVersionIsNotCompatible(cancellationToken).ConfigureAwait(false);
+            await ThrowIfServerVersionIsNotCompatible(cancellationToken);
 
             partialName = (partialName ?? string.Empty).Trim();
             if (pathParameters == null)
                 pathParameters = new { partialName = partialName};
 
-            return FindMany(r =>
+            return await FindMany(r =>
             {
                 var named = r as INamedResource;
                 return named != null && named.Name.Contains(partialName, StringComparison.OrdinalIgnoreCase);

--- a/source/Octopus.Server.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/BasicRepository.cs
@@ -253,6 +253,26 @@ namespace Octopus.Client.Repositories.Async
             return await Client.Get<List<TResource>>(link, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        public Task<List<TResource>> FindByPartialName(string partialName, string path, object pathParameters, CancellationToken cancellationToken)
+        {
+            ThrowIfServerVersionIsNotCompatible(cancellationToken).ConfigureAwait(false);
+
+            partialName = (partialName ?? string.Empty).Trim();
+            if (pathParameters == null)
+                pathParameters = new { partialName = partialName};
+
+            return FindMany(r =>
+            {
+                var named = r as INamedResource;
+                return named != null && named.Name.Contains(partialName);
+            }, path, pathParameters);
+        }
+        
+        public Task<List<TResource>> FindByPartialName(string partialName, CancellationToken cancellationToken)
+        {
+            return FindByPartialName(partialName, null, null, cancellationToken);
+        }
+
         public Task<TResource> FindByName(string name, string path = null, object pathParameters = null)
         {
             return FindByName(name, path, pathParameters, CancellationToken.None);

--- a/source/Octopus.Server.Client/Repositories/Async/BasicRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/BasicRepository.cs
@@ -256,7 +256,7 @@ namespace Octopus.Client.Repositories.Async
 
         public async Task<List<TResource>> FindByPartialName(string partialName, string path, object pathParameters, CancellationToken cancellationToken)
         {
-            await ThrowIfServerVersionIsNotCompatible(cancellationToken);
+            await ThrowIfServerVersionIsNotCompatible(cancellationToken).ConfigureAwait(false);
 
             partialName = (partialName ?? string.Empty).Trim();
             if (pathParameters == null)

--- a/source/Octopus.Server.Client/Repositories/Async/IFindByPartialName.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IFindByPartialName.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Octopus.Client.Repositories.Async;
+
+public interface IFindByPartialName<TResource> : IPaginate<TResource>
+{
+    Task<List<TResource>> FindByPartialName(string partialName, CancellationToken cancellationToken);
+    Task<List<TResource>> FindByPartialName(string partialName, string path, object pathParameters, CancellationToken cancellationToken);
+}

--- a/source/Octopus.Server.Client/Repositories/Async/TenantRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/TenantRepository.cs
@@ -7,7 +7,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
-    public interface ITenantRepository : ICreate<TenantResource>, IModify<TenantResource>, IGet<TenantResource>, IDelete<TenantResource>, IFindByName<TenantResource>, IGetAll<TenantResource>
+    public interface ITenantRepository : ICreate<TenantResource>, IModify<TenantResource>, IGet<TenantResource>, IDelete<TenantResource>, IFindByName<TenantResource>, IGetAll<TenantResource>, IFindByPartialName<TenantResource>
     {
         Task<MultiTenancyStatusResource> Status();
         Task SetLogo(TenantResource tenant, string fileName, Stream contents);

--- a/source/Octopus.Server.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/BasicRepository.cs
@@ -5,6 +5,7 @@ using Octopus.Client.Model;
 using System.Text.RegularExpressions;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Extensibility;
+using Octopus.Client.Extensions;
 using Octopus.Client.Util;
 using Octopus.Client.Validation;
 
@@ -188,7 +189,7 @@ namespace Octopus.Client.Repositories
             return FindMany(r =>
             {
                 var named = r as INamedResource;
-                return named != null && named.Name.Contains(partialName);
+                return named != null && named.Name.Contains(partialName, StringComparison.OrdinalIgnoreCase);
             }, path, pathParameters);
         }
 

--- a/source/Octopus.Server.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/BasicRepository.cs
@@ -177,6 +177,21 @@ namespace Octopus.Client.Repositories
             return client.Get<List<TResource>>(link, parameters);
         }
 
+        public List<TResource> FindByPartialName(string partialName, string path = null, object pathParameters = null)
+        {
+            ThrowIfServerVersionIsNotCompatible();
+
+            partialName = (partialName ?? string.Empty).Trim();
+            if (pathParameters == null)
+                pathParameters = new { partialName = partialName};
+
+            return FindMany(r =>
+            {
+                var named = r as INamedResource;
+                return named != null && named.Name.Contains(partialName);
+            }, path, pathParameters);
+        }
+
         public TResource FindByName(string name, string path = null, object pathParameters = null)
         {
             ThrowIfServerVersionIsNotCompatible();

--- a/source/Octopus.Server.Client/Repositories/IFindByPartialName.cs
+++ b/source/Octopus.Server.Client/Repositories/IFindByPartialName.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Octopus.Client.Repositories;
+
+public interface IFindByPartialName<TResource> : IPaginate<TResource>
+{
+     List<TResource> FindByPartialName(string partialName, string path = null, object pathParameters = null);
+}

--- a/source/Octopus.Server.Client/Repositories/TenantRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/TenantRepository.cs
@@ -6,7 +6,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
 {
-    public interface ITenantRepository : ICreate<TenantResource>, IModify<TenantResource>, IGet<TenantResource>, IDelete<TenantResource>, IFindByName<TenantResource>, IGetAll<TenantResource>
+    public interface ITenantRepository : ICreate<TenantResource>, IModify<TenantResource>, IGet<TenantResource>, IDelete<TenantResource>, IFindByName<TenantResource>, IGetAll<TenantResource>, IFindByPartialName<TenantResource>
     {
         MultiTenancyStatusResource Status();
         void SetLogo(TenantResource tenant, string fileName, Stream contents);
@@ -18,7 +18,7 @@ namespace Octopus.Client.Repositories
         TenantEditor CreateOrModify(string name, string description);
         TenantEditor CreateOrModify(string name, string description, string cloneId);
     }
-    
+
     class TenantRepository : BasicRepository<TenantResource>, ITenantRepository
     {
         public TenantRepository(IOctopusRepository repository)


### PR DESCRIPTION
Add the ability to find by partial name. Server API has supported this for a while now, just updating client to make use of it.

First one to support this is tenants

Internal discussion with PET team - https://octopusdeploy.slack.com/archives/C04LWDDAC6L/p1689661870773089