### PR TITLE
Update log to use request method

### DIFF
--- a/source/Octopus.Server.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncClient.cs
@@ -613,7 +613,7 @@ Certificate thumbprint:   {certificate.Thumbprint}";
                 if (request.RequestResource != null)
                     message.Content = GetContent(request);
 
-                Logger.Trace($"DispatchRequest: {message.Method} {message.RequestUri}");
+                Logger.Trace($"DispatchRequest: {request.Method} {message.RequestUri}");
 
                 var completionOption = readResponse
                     ? HttpCompletionOption.ResponseContentRead


### PR DESCRIPTION
[sc-54145]

[This block](https://github.com/OctopusDeploy/OctopusClients/blob/1e047d18c7ae725b6d9583153137fa04252fb914/source/Octopus.Server.Client/OctopusAsyncClient.cs#L592-L596) overrides the HTTP method to a `POST` if it's a `PUT` or `DELETE`. I'm not entirely sure why this happens. A quick google suggests that it is to get around infrastructure with limitations/restrictions that only allow `GET` or `POST`.

We proceed to log the request URI with this overridden method. This causes confusion when trying to debug issues between client/server since the logged POST hides the actual method and there is no corresponding POST on the Server side.

Example:
![image](https://github.com/OctopusDeploy/OctopusClients/assets/36631337/9fc0b023-030a-4667-a03d-f4f83d366ddd)

This PR changes the log to use the actual request method. The trace log was originally added in https://github.com/OctopusDeploy/OctopusClients/pull/428 for debugging purposes so using the actual method feels correct.

I don't _think_ there is any value here logging both the override and the original request method.