### PR TITLE
Add step package reference id for git resource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3162,13 +3162,14 @@ Octopus.Client.Model
   }
   class GitDependencyResource
   {
-    .ctor(String, String, String, String, String[], String)
+    .ctor(String, String, String, String, String[], String, String)
     String DefaultBranch { get; }
     String[] FilePathFilters { get; }
     String GitCredentialId { get; }
     String GitCredentialType { get; }
     String Name { get; }
     String RepositoryUri { get; }
+    String StepPackageInputsReferenceId { get; set; }
   }
   class GitHubFeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3179,13 +3179,14 @@ Octopus.Client.Model
   }
   class GitDependencyResource
   {
-    .ctor(String, String, String, String, String[], String)
+    .ctor(String, String, String, String, String[], String, String)
     String DefaultBranch { get; }
     String[] FilePathFilters { get; }
     String GitCredentialId { get; }
     String GitCredentialType { get; }
     String Name { get; }
     String RepositoryUri { get; }
+    String StepPackageInputsReferenceId { get; set; }
   }
   class GitHubFeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Server.Client/Model/GitDependencyResource.cs
+++ b/source/Octopus.Server.Client/Model/GitDependencyResource.cs
@@ -8,14 +8,22 @@ namespace Octopus.Client.Model;
 /// </summary>
 public class GitDependencyResource
 {
-    public GitDependencyResource(string repositoryUri, string defaultBranch, string gitCredentialType, string? gitCredentialId = null, string[]? filePathFilters = null, string? name = null)
+    public GitDependencyResource(
+        string repositoryUri, 
+        string defaultBranch, 
+        string gitCredentialType,
+        string? gitCredentialId = null, 
+        string[]? filePathFilters = null, 
+        string? name = null,
+        string? stepPackageInputsReferenceId = null)
     {
         RepositoryUri = repositoryUri;
         DefaultBranch = defaultBranch;
         GitCredentialType = gitCredentialType;
         GitCredentialId = gitCredentialId;
-        FilePathFilters = filePathFilters ?? Array.Empty<string>();   
+        FilePathFilters = filePathFilters ?? Array.Empty<string>();
         Name = name ?? string.Empty;
+        StepPackageInputsReferenceId = stepPackageInputsReferenceId;
     }
 
     public string Name { get; }
@@ -24,4 +32,5 @@ public class GitDependencyResource
     public string[] FilePathFilters { get; }
     public string GitCredentialType { get; }
     public string? GitCredentialId { get; }
+    public string? StepPackageInputsReferenceId { get; set; }
 }


### PR DESCRIPTION
This PR adds the `StepPackageInputsReferenceId` field for git resources, so it can be used from step framework steps.