### PR TITLE
Add releaseHistoryCount to GET project progression

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -8409,7 +8409,7 @@ Octopus.Client.Repositories.Async
     Task<GitTagResource> GetGitTag(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource, CancellationToken)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32>)
     Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32>)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -8410,7 +8410,7 @@ Octopus.Client.Repositories.Async
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32>)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -8435,7 +8435,7 @@ Octopus.Client.Repositories.Async
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32>)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -8434,7 +8434,7 @@ Octopus.Client.Repositories.Async
     Task<GitTagResource> GetGitTag(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource, CancellationToken)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32>)
     Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32>)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
@@ -61,7 +61,7 @@ namespace Octopus.Client.Repositories.Async
         
         [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<ProgressionResource> GetProgression(ProjectResource project);
-        Task<ProgressionResource> GetProgression(ProjectResource project, CancellationToken cancellationToken);
+        Task<ProgressionResource> GetProgression(ProjectResource project, CancellationToken cancellationToken, int? releaseHistoryCount = null);
         
         [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(ProjectResource project);
@@ -268,9 +268,10 @@ namespace Octopus.Client.Repositories.Async
             return GetProgression(project, CancellationToken.None);
         }
 
-        public Task<ProgressionResource> GetProgression(ProjectResource project, CancellationToken cancellationToken)
+        public Task<ProgressionResource> GetProgression(ProjectResource project, CancellationToken cancellationToken, int? releaseHistoryCount = null)
         {
-            return Client.Get<ProgressionResource>(project.Link("Progression"), cancellationToken);
+            var pathParameters = releaseHistoryCount.HasValue ? new { releaseHistoryCount } : null;
+            return Client.Get<ProgressionResource>(project.Link("Progression"), pathParameters, cancellationToken);
         }
 
         public Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(ProjectResource project)

--- a/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ProjectRepository.cs
@@ -60,7 +60,7 @@ namespace Octopus.Client.Repositories.Async
         Task<IReadOnlyList<ChannelResource>> GetAllChannels(ProjectResource project, CancellationToken cancellationToken);
         
         [Obsolete("Please use the overload with cancellation token instead.", false)]
-        Task<ProgressionResource> GetProgression(ProjectResource project);
+        Task<ProgressionResource> GetProgression(ProjectResource project, int? releaseHistoryCount = null);
         Task<ProgressionResource> GetProgression(ProjectResource project, CancellationToken cancellationToken, int? releaseHistoryCount = null);
         
         [Obsolete("Please use the overload with cancellation token instead.", false)]
@@ -263,9 +263,9 @@ namespace Octopus.Client.Repositories.Async
             return Client.ListAll<ChannelResource>(project.Link("Channels"), cancellationToken);
         }
 
-        public Task<ProgressionResource> GetProgression(ProjectResource project)
+        public Task<ProgressionResource> GetProgression(ProjectResource project, int? releaseHistoryCount = null)
         {
-            return GetProgression(project, CancellationToken.None);
+            return GetProgression(project, CancellationToken.None, releaseHistoryCount);
         }
 
         public Task<ProgressionResource> GetProgression(ProjectResource project, CancellationToken cancellationToken, int? releaseHistoryCount = null)


### PR DESCRIPTION
This is a partner PR to https://github.com/OctopusDeploy/OctopusDeploy/pull/19881, which added `releaseHistoryCount` to the project progression link template.

This PR adds the optional `releaseHistoryCount` value when sending a [GetProjectProgressionRequest](https://github.com/OctopusDeploy/OctopusDeploy/blob/2be9c86e473100bf68e83b8bbf3628aa7e03bb38/source/Octopus.Core/Features/Progression/MessageContracts/GetProjectProgressionRequest.cs) from the `IProjectRepostitory`.

[sc-58183]