### PR TITLE
Change defaults for RPC Retries

### DIFF
--- a/source/Octopus.Server.Client/Model/MachineRpcCallRetryPolicy.cs
+++ b/source/Octopus.Server.Client/Model/MachineRpcCallRetryPolicy.cs
@@ -4,8 +4,8 @@ namespace Octopus.Client.Model;
 
 public class MachineRpcCallRetryPolicy
 {
-    public bool Enabled { get; set; } = false;
-    public TimeSpan RetryDuration { get; set; } = TimeSpan.FromMinutes(10);
-    public TimeSpan HealthyMachineHealthCheckRetryDuration { get; set; } = TimeSpan.FromMinutes(10);
-    public TimeSpan UnHealthyMachineHealthCheckRetryDuration { get; set; } = TimeSpan.FromMinutes(2);
+    public bool Enabled { get; set; } = true;
+    public TimeSpan RetryDuration { get; set; } = TimeSpan.FromMinutes(2.5);
+    public TimeSpan HealthyMachineHealthCheckRetryDuration { get; set; } = TimeSpan.FromMinutes(2.5);
+    public TimeSpan UnHealthyMachineHealthCheckRetryDuration { get; set; } = TimeSpan.FromMinutes(2.5);
 }


### PR DESCRIPTION
Change PRC retries to be on by default and set the retry duration to 2.5 minutes for new machine policies