### PR TITLE
add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ TestResults/
 /source/Octo/Properties/launchSettings.json
 **/ExpectedSdkVersion.txt
 **/launchSettings.json
+.DS_Store


### PR DESCRIPTION
Noticed this wasn't in there which is a bit annoying for Mac users as these files pop-up everywhere on MacOS.