### PR TITLE
Add support for token authentication

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3,7 +3,7 @@ Octopus.Client
   class DefaultLinkResolver
     Octopus.Client.ILinkResolver
   {
-    .ctor(Uri, String)
+    .ctor(Uri, String = "/api")
     Boolean IsUsingSecureConnection { get; }
     Uri Resolve(String)
     String ToString()
@@ -30,54 +30,54 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Task<TResource> Create(String, Octopus.Client.TResource, Object)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object = null)
     Task<TResource> Create(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task Delete(String, Object, Object)
+    Task Delete(String, Object = null, Object = null)
     Task Delete(String, CancellationToken)
     Task Delete(String, Object, Object, CancellationToken)
     Task<TResponse> Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object)
+    Task<TResource> Get(String, Object = null)
     Task<TResource> Get(String, CancellationToken)
     Task<TResource> Get(String, Object, CancellationToken)
-    Task<Stream> GetContent(String, Object)
+    Task<Stream> GetContent(String, Object = null)
     Task<Stream> GetContent(String, CancellationToken)
     Task<Stream> GetContent(String, Object, CancellationToken)
-    Task<ResourceCollection<TResource>> List(String, Object)
+    Task<ResourceCollection<TResource>> List(String, Object = null)
     Task<ResourceCollection<TResource>> List(String, CancellationToken)
     Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object = null)
     Task<IReadOnlyList<TResource>> ListAll(String, CancellationToken)
     Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
-    Task Post(String, Octopus.Client.TResource, Object)
+    Task Post(String, Octopus.Client.TResource, Object = null)
     Task Post(String, Octopus.Client.TResource, CancellationToken)
     Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object = null)
     Task<TResponse> Post(String, Octopus.Client.TResource, CancellationToken)
     Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Post(String)
     Task Post(String, CancellationToken)
     Task Put(String, Octopus.Client.TResource)
     Task Put(String, Octopus.Client.TResource, CancellationToken)
-    Task Put(String, Octopus.Client.TResource, Object)
+    Task Put(String, Octopus.Client.TResource, Object = null)
     Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Put(String)
     Task Put(String, CancellationToken)
     Task PutContent(String, Stream)
     Task PutContent(String, Stream, CancellationToken)
-    Uri QualifyUri(String, Object)
+    Uri QualifyUri(String, Object = null)
     Task<TResponse> Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
     Task SignOut()
     Task SignOut(CancellationToken)
-    Task<TResource> Update(String, Octopus.Client.TResource, Object)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object = null)
     Task<TResource> Update(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
@@ -95,34 +95,34 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
-    void Delete(String, Object, Object)
+    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object = null)
+    void Delete(String, Object = null, Object = null)
     Octopus.Client.TResponse Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
-    Octopus.Client.TResource Get(String, Object)
-    Stream GetContent(String, Object)
-    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object)
-    IReadOnlyList<TResource> ListAll(String, Object)
+    Octopus.Client.TResource Get(String, Object = null)
+    Stream GetContent(String, Object = null)
+    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object = null)
+    IReadOnlyList<TResource> ListAll(String, Object = null)
     void Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     void Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
-    void Post(String, Octopus.Client.TResource, Object)
-    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object)
+    void Post(String, Octopus.Client.TResource, Object = null)
+    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object = null)
     void Post(String)
     void Put(String, Octopus.Client.TResource)
     void Put(String)
-    void Put(String, Octopus.Client.TResource, Object)
+    void Put(String, Octopus.Client.TResource, Object = null)
     void PutContent(String, Stream)
-    Uri QualifyUri(String, Object)
+    Uri QualifyUri(String, Object = null)
     Octopus.Client.TResponse Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignOut()
-    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object)
+    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object = null)
   }
   interface IOctopusClientFactory
   {
-    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
-    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
   }
   interface IOctopusCommonAsyncRepository
   {
@@ -303,56 +303,56 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
-    Task<TResource> Create(String, Octopus.Client.TResource, Object)
+    static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object = null)
     Task<TResource> Create(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task Delete(String, Object, Object)
+    Task Delete(String, Object = null, Object = null)
     Task Delete(String, CancellationToken)
     Task Delete(String, Object, Object, CancellationToken)
     void Dispose()
     Task<TResponse> Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object)
+    Task<TResource> Get(String, Object = null)
     Task<TResource> Get(String, CancellationToken)
     Task<TResource> Get(String, Object, CancellationToken)
-    Task<Stream> GetContent(String, Object)
+    Task<Stream> GetContent(String, Object = null)
     Task<Stream> GetContent(String, CancellationToken)
     Task<Stream> GetContent(String, Object, CancellationToken)
-    Task<ResourceCollection<TResource>> List(String, Object)
+    Task<ResourceCollection<TResource>> List(String, Object = null)
     Task<ResourceCollection<TResource>> List(String, CancellationToken)
     Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object = null)
     Task<IReadOnlyList<TResource>> ListAll(String, CancellationToken)
     Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
-    Task Post(String, Octopus.Client.TResource, Object)
+    Task Post(String, Octopus.Client.TResource, Object = null)
     Task Post(String, Octopus.Client.TResource, CancellationToken)
     Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object = null)
     Task<TResponse> Post(String, Octopus.Client.TResource, CancellationToken)
     Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Post(String)
     Task Post(String, CancellationToken)
     Task Put(String, Octopus.Client.TResource)
     Task Put(String, Octopus.Client.TResource, CancellationToken)
-    Task Put(String, Octopus.Client.TResource, Object)
+    Task Put(String, Octopus.Client.TResource, Object = null)
     Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Put(String)
     Task Put(String, CancellationToken)
     Task PutContent(String, Stream)
     Task PutContent(String, Stream, CancellationToken)
-    Uri QualifyUri(String, Object)
+    Uri QualifyUri(String, Object = null)
     Task<TResponse> Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
     Task SignOut()
     Task SignOut(CancellationToken)
-    Task<TResource> Update(String, Octopus.Client.TResource, Object)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object = null)
     Task<TResource> Update(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
@@ -362,7 +362,7 @@ Octopus.Client
     Octopus.Client.IOctopusCommonAsyncRepository
     Octopus.Client.IOctopusSystemAsyncRepository
   {
-    .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
+    .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope = null)
     Octopus.Client.Repositories.Async.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.Async.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.Async.IArchivedEventFileRepository ArchivedEventFiles { get; }
@@ -444,42 +444,42 @@ Octopus.Client
     event Action<WebRequest> BeforeSendingHttpRequest
     event Action<OctopusResponse> ReceivedOctopusResponse
     event Action<OctopusRequest> SendingOctopusRequest
-    .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
-    void Delete(String, Object, Object)
+    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object = null)
+    void Delete(String, Object = null, Object = null)
     void Dispose()
     Octopus.Client.TResponse Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
-    Octopus.Client.TResource Get(String, Object)
-    Stream GetContent(String, Object)
+    Octopus.Client.TResource Get(String, Object = null)
+    Stream GetContent(String, Object = null)
     void Initialize()
-    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object)
-    IReadOnlyList<TResource> ListAll(String, Object)
+    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object = null)
+    IReadOnlyList<TResource> ListAll(String, Object = null)
     void Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     void Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
-    void Post(String, Octopus.Client.TResource, Object)
-    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object)
+    void Post(String, Octopus.Client.TResource, Object = null)
+    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object = null)
     void Post(String)
     void Put(String, Octopus.Client.TResource)
     void Put(String)
-    void Put(String, Octopus.Client.TResource, Object)
+    void Put(String, Octopus.Client.TResource, Object = null)
     void PutContent(String, Stream)
-    Uri QualifyUri(String, Object)
+    Uri QualifyUri(String, Object = null)
     Octopus.Client.TResponse Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignOut()
-    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object)
+    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object = null)
   }
   class OctopusClientFactory
     Octopus.Client.IOctopusClientFactory
   {
     .ctor()
-    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
-    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
   }
   class OctopusClientOptions
   {
@@ -501,7 +501,7 @@ Octopus.Client
   {
     .ctor(Octopus.Client.OctopusServerEndpoint)
     .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.RepositoryScope)
-    .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope)
+    .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope = null)
     Octopus.Client.Repositories.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.IArchivedEventFileRepository ArchivedEventFiles { get; }
@@ -574,7 +574,7 @@ Octopus.Client
   }
   abstract class OctopusRepositoryExtensions
   {
-    static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
+    static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope = null)
     static Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.IOctopusAsyncRepository, Octopus.Client.Model.SpaceResource)
     static Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.IOctopusRepository, Octopus.Client.Model.SpaceResource)
     static Octopus.Client.IOctopusSystemAsyncRepository ForSystem(Octopus.Client.IOctopusAsyncRepository)
@@ -582,7 +582,7 @@ Octopus.Client
   }
   class OctopusRequest
   {
-    .ctor(String, Uri, Object)
+    .ctor(String, Uri, Object = null)
     String Method { get; }
     Object RequestResource { get; }
     Uri Uri { get; }
@@ -605,14 +605,17 @@ Octopus.Client
   {
     .ctor(String)
     .ctor(String, String)
-    .ctor(String, String, ICredentials)
-    .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
+    .ctor(String, String, ICredentials, Boolean = False)
+    .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean = False)
     String ApiKey { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.ILinkResolver OctopusServer { get; }
     IWebProxy Proxy { get; set; }
+    String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
   }
   class RepositoryScope
   {
@@ -841,7 +844,7 @@ Octopus.Client.Editors
     .ctor(Octopus.Client.Repositories.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
+    Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode> = null)
     Octopus.Client.Editors.MachineEditor Customize(Action<MachineResource>)
     Octopus.Client.Editors.MachineEditor Save()
   }
@@ -865,7 +868,7 @@ Octopus.Client.Editors
     Octopus.Client.Editors.VariableSetEditor Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
     Octopus.Client.Editors.ProjectEditor Customize(Action<ProjectResource>)
     Octopus.Client.Editors.ProjectEditor IncludingLibraryVariableSets(Octopus.Client.Model.LibraryVariableSetResource[])
     Octopus.Client.Editors.ProjectEditor Save()
@@ -948,7 +951,7 @@ Octopus.Client.Editors
   {
     .ctor(Octopus.Client.Repositories.ITagSetRepository)
     Octopus.Client.Model.TagSetResource Instance { get; }
-    Octopus.Client.Editors.TagSetEditor AddOrUpdateTag(String, String, String)
+    Octopus.Client.Editors.TagSetEditor AddOrUpdateTag(String, String = null, String = "#6e6e6e")
     Octopus.Client.Editors.TagSetEditor ClearTags()
     Octopus.Client.Editors.TagSetEditor CreateOrModify(String)
     Octopus.Client.Editors.TagSetEditor CreateOrModify(String, String)
@@ -967,7 +970,7 @@ Octopus.Client.Editors
     Octopus.Client.Editors.TenantEditor ClearTags()
     Octopus.Client.Editors.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
-    Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String)
+    Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String = null)
     Octopus.Client.Editors.TenantEditor Customize(Action<TenantResource>)
     Octopus.Client.Editors.TenantEditor Save()
     Octopus.Client.Editors.TenantEditor SetLogo(String)
@@ -1148,7 +1151,7 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IEnvironmentRepository)
     Octopus.Client.Model.EnvironmentResource Instance { get; }
     Task<EnvironmentEditor> CreateOrModify(String)
-    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
+    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean = False)
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Octopus.Client.Editors.Async.EnvironmentEditor Customize(Action<EnvironmentResource>)
     Task<EnvironmentEditor> Save()
@@ -1197,7 +1200,7 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode> = null)
     Octopus.Client.Editors.Async.MachineEditor Customize(Action<MachineResource>)
     Task<MachineEditor> Save()
   }
@@ -1221,7 +1224,7 @@ Octopus.Client.Editors.Async
     Task<VariableSetEditor> Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.ProjectEditor Customize(Action<ProjectResource>)
@@ -1306,7 +1309,7 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.ITagSetRepository)
     Octopus.Client.Model.TagSetResource Instance { get; }
-    Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String, String)
+    Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String = null, String = "#6e6e6e")
     Octopus.Client.Editors.Async.TagSetEditor ClearTags()
     Task<TagSetEditor> CreateOrModify(String)
     Task<TagSetEditor> CreateOrModify(String, String)
@@ -1325,7 +1328,7 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.TenantEditor ClearTags()
     Octopus.Client.Editors.Async.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Task<TenantEditor> CreateOrModify(String)
-    Task<TenantEditor> CreateOrModify(String, String, String)
+    Task<TenantEditor> CreateOrModify(String, String, String = null)
     Octopus.Client.Editors.Async.TenantEditor Customize(Action<TenantResource>)
     Task<TenantEditor> Save()
     Task<TenantEditor> SetLogo(String)
@@ -1634,7 +1637,7 @@ Octopus.Client.Logging
     .ctor(Object, IntPtr)
     IAsyncResult BeginInvoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception, Object[], AsyncCallback, Object)
     Boolean EndInvoke(IAsyncResult)
-    Boolean Invoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception, Object[])
+    Boolean Invoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception = null, Object[])
   }
   LogLevel
   {
@@ -2857,7 +2860,7 @@ Octopus.Client.Model
     Octopus.Client.Model.DeploymentStepResource ClearActions()
     Octopus.Client.Model.DeploymentActionResource FindAction(String)
     Octopus.Client.Model.DeploymentStepResource RemoveAction(String)
-    Octopus.Client.Model.DeploymentStepResource RequirePackagesToBeAcquired(Boolean)
+    Octopus.Client.Model.DeploymentStepResource RequirePackagesToBeAcquired(Boolean = True)
     Octopus.Client.Model.DeploymentStepResource TargetingRoles(String[])
     Octopus.Client.Model.DeploymentStepResource WithCondition(Octopus.Client.Model.DeploymentStepCondition)
     Octopus.Client.Model.DeploymentStepResource WithPackageRequirement(Octopus.Client.Model.DeploymentStepPackageRequirement)
@@ -3180,14 +3183,14 @@ Octopus.Client.Model
     void Clear()
     Boolean Contains(Octopus.Client.Model.GitDependencyResource)
     void CopyTo(Octopus.Client.Model.GitDependencyResource[], Int32)
-    Octopus.Client.Model.GitDependencyResource GetByName(String)
+    Octopus.Client.Model.GitDependencyResource GetByName(String = "")
     IEnumerator<GitDependencyResource> GetEnumerator()
     Boolean Remove(Octopus.Client.Model.GitDependencyResource)
     Boolean TryGetByName(String, Octopus.Client.Model.GitDependencyResource&)
   }
   class GitDependencyResource
   {
-    .ctor(String, String, String, String, String[], String, String)
+    .ctor(String, String, String, String = null, String[] = null, String = null, String = null)
     String DefaultBranch { get; }
     String[] FilePathFilters { get; }
     String GitCredentialId { get; }
@@ -5080,7 +5083,7 @@ Octopus.Client.Model
   {
     .ctor(String)
     .ctor(Octopus.Client.Model.SemanticVersion)
-    .ctor(Version, String, String)
+    .ctor(Version, String = null, String = null)
     .ctor(Int32, Int32, Int32)
     .ctor(Int32, Int32, Int32, String)
     .ctor(Int32, Int32, Int32, String, String)
@@ -5088,16 +5091,16 @@ Octopus.Client.Model
     .ctor(Int32, Int32, Int32, Int32)
     .ctor(Int32, Int32, Int32, Int32, String, String)
     .ctor(Int32, Int32, Int32, Int32, IEnumerable<String>, String)
-    .ctor(Version, IEnumerable<String>, String, String, Boolean)
+    .ctor(Version, IEnumerable<String>, String, String, Boolean = False)
     Boolean IsLegacyVersion { get; }
     Boolean IsSemVer2 { get; }
     String OriginalString { get; }
     Int32 Revision { get; }
     Version Version { get; }
     static String IncrementRelease(String)
-    static Octopus.Client.Model.SemanticVersion Parse(String, Boolean)
+    static Octopus.Client.Model.SemanticVersion Parse(String, Boolean = False)
     String ToString()
-    static Boolean TryParse(String, Octopus.Client.Model.SemanticVersion&, Boolean)
+    static Boolean TryParse(String, Octopus.Client.Model.SemanticVersion&, Boolean = False)
     static Boolean TryParseStrict(String, Octopus.Client.Model.SemanticVersion&)
   }
   class SemanticVersionComparer
@@ -5381,7 +5384,7 @@ Octopus.Client.Model
     Int32 SortOrder { get; set; }
     String SpaceId { get; set; }
     IList<TagResource> Tags { get; set; }
-    Octopus.Client.Model.TagSetResource AddOrUpdateTag(String, String, String)
+    Octopus.Client.Model.TagSetResource AddOrUpdateTag(String, String = null, String = "#6e6e6e")
     Octopus.Client.Model.TagSetResource RemoveTag(String)
   }
   TargetType
@@ -6346,7 +6349,7 @@ Octopus.Client.Model.DeploymentProcess
   class InlineScriptActionFromFileInAssembly
     Octopus.Client.Model.DeploymentProcess.ScriptAction
   {
-    .ctor(String, Assembly)
+    .ctor(String, Assembly = null)
     Assembly ResourceAssembly { get; }
     String ResourceName { get; }
     Octopus.Client.Model.DeploymentProcess.ScriptSource Source { get; }
@@ -6358,7 +6361,7 @@ Octopus.Client.Model.DeploymentProcess
     Octopus.Client.Model.DeploymentProcess.ScriptSource Source { get; }
     Octopus.Client.Model.ScriptSyntax Syntax { get; }
     static Octopus.Client.Model.DeploymentProcess.InlineScriptAction InlineScript(Octopus.Client.Model.ScriptSyntax, String)
-    static Octopus.Client.Model.DeploymentProcess.InlineScriptActionFromFileInAssembly InlineScriptFromFileInAssembly(String, Assembly)
+    static Octopus.Client.Model.DeploymentProcess.InlineScriptActionFromFileInAssembly InlineScriptFromFileInAssembly(String, Assembly = null)
   }
   class ScriptActionFromFileInPackage
     Octopus.Client.Model.DeploymentProcess.ScriptAction
@@ -6670,7 +6673,7 @@ Octopus.Client.Model.Forms
 {
   class Button
   {
-    .ctor(String, String)
+    .ctor(String, String = null)
     String Text { get; }
     Object Value { get; }
   }
@@ -6690,20 +6693,20 @@ Octopus.Client.Model.Forms
   class Form
   {
     .ctor()
-    .ctor(IEnumerable<FormElement>, IDictionary<String, String>)
+    .ctor(IEnumerable<FormElement> = null, IDictionary<String, String> = null)
     List<FormElement> Elements { get; }
     Dictionary<String, String> Values { get; }
   }
   class FormElement
   {
-    .ctor(String, Octopus.Client.Model.Forms.Control, Boolean)
+    .ctor(String, Octopus.Client.Model.Forms.Control, Boolean = False)
     Octopus.Client.Model.Forms.Control Control { get; }
     Boolean IsValueRequired { get; }
     String Name { get; }
   }
   abstract class FormExtensions
   {
-    static void AddElement(Octopus.Client.Model.Forms.Form, String, Octopus.Client.Model.Forms.Control, String, Boolean)
+    static void AddElement(Octopus.Client.Model.Forms.Form, String, Octopus.Client.Model.Forms.Control, String = null, Boolean = False)
     static Object GetCoercedValue(Octopus.Client.Model.Forms.Form, String)
     static void SetValue(Octopus.Client.Model.Forms.Form, String, String)
     static void UpdateValues(Octopus.Client.Model.Forms.Form, IDictionary<String, String>)
@@ -7324,8 +7327,8 @@ Octopus.Client.Repositories
     void Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     void DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Get(String)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32, Int32)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32 = 0, Int32 = 30)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
   }
@@ -7339,15 +7342,15 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    List<TAccount> FindAllOfType(Object)
+    List<TAccount> FindAllOfType(Object = null)
     Octopus.Client.Repositories.TAccount FindByNameOfType(String)
     List<TAccount> FindByNamesOfType(IEnumerable<String>)
-    List<TAccount> FindManyOfType(Func<TAccount, Boolean>, Object)
-    Octopus.Client.Repositories.TAccount FindOneOfType(Func<TAccount, Boolean>, Object)
+    List<TAccount> FindManyOfType(Func<TAccount, Boolean>, Object = null)
+    Octopus.Client.Repositories.TAccount FindOneOfType(Func<TAccount, Boolean>, Object = null)
     Octopus.Client.Model.Accounts.Usages.AccountUsageResource GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
     Octopus.Client.Repositories.TAccount GetOfType(String)
     List<TAccount> GetOfType(String[])
-    void PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
+    void PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object = null)
     Octopus.Client.Repositories.TAccount RefreshOfType(Octopus.Client.Repositories.TAccount)
   }
   interface IActionTemplateRepository
@@ -7368,7 +7371,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<ArchivedEventFileResource>
   {
     Stream GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
-    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32 = 0, Nullable<Int32> = null)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.IPaginate<ArtifactResource>
@@ -7391,8 +7394,8 @@ Octopus.Client.Repositories
     void Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     void DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Get(String)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32, Int32)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32 = 0, Int32 = 30)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation)
   }
@@ -7401,9 +7404,9 @@ Octopus.Client.Repositories
     void DeletePackage(Octopus.Client.Model.PackageResource)
     void DeletePackages(IReadOnlyList<PackageResource>)
     Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String, String)
-    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32, Int32)
-    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
-    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
+    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean = False)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean, Boolean)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
@@ -7430,8 +7433,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<CertificateResource>
   {
     void Archive(Octopus.Client.Model.CertificateResource)
-    Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
-    Stream ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
+    Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat> = null, String = null, Boolean = False)
+    Stream ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean = False, Octopus.Client.Model.CertificateExportPemOptions = PrimaryOnly)
     Octopus.Client.Model.CertificateConfigurationResource GetOctopusCertificate()
     Octopus.Client.Model.CertificateResource Replace(Octopus.Client.Model.CertificateResource, String, String)
     void UnArchive(Octopus.Client.Model.CertificateResource)
@@ -7462,7 +7465,7 @@ Octopus.Client.Repositories
   }
   interface ICreate`1
   {
-    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object)
+    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object = null)
   }
   interface IDashboardConfigurationRepository
   {
@@ -7472,7 +7475,7 @@ Octopus.Client.Repositories
   interface IDashboardRepository
   {
     Octopus.Client.Model.DashboardResource GetDashboard()
-    Octopus.Client.Model.DashboardResource GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
+    Octopus.Client.Model.DashboardResource GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions = IncludeCurrentDeploymentOnly)
   }
   interface IDefectsRepository
   {
@@ -7499,8 +7502,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.IDelete<DeploymentResource>
   {
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindAll(String[], String[], Int32, Nullable<Int32>)
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindBy(String[], String[], Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindAll(String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindBy(String[], String[], Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.DeploymentResource)
     void Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     void Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
@@ -7525,9 +7528,9 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String)
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String, String)
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String, String, Boolean)
-    List<MachineResource> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
+    List<MachineResource> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null)
     void Sort(String[])
-    Octopus.Client.Model.EnvironmentsSummaryResource Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
+    Octopus.Client.Model.EnvironmentsSummaryResource Summary(String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, Nullable<Boolean> = False)
   }
   interface IEventRepository
     Octopus.Client.Repositories.IGet<EventResource>
@@ -7537,8 +7540,8 @@ Octopus.Client.Repositories
     IReadOnlyList<EventCategoryResource> GetCategories()
     IReadOnlyList<DocumentTypeResource> GetDocumentTypes()
     IReadOnlyList<EventGroupResource> GetGroups()
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, String, String, Boolean)
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32 = 0, String = null, String = null, Boolean = False)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Boolean = True, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null, Nullable<Int64> = null, Nullable<Int64> = null, String = null, String = null, String = null)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -7558,13 +7561,13 @@ Octopus.Client.Repositories
   interface IFindByName`1
     Octopus.Client.Repositories.IPaginate<TResource>
   {
-    Octopus.Client.Repositories.TResource FindByName(String, String, Object)
-    List<TResource> FindByNames(IEnumerable<String>, String, Object)
+    Octopus.Client.Repositories.TResource FindByName(String, String = null, Object = null)
+    List<TResource> FindByNames(IEnumerable<String>, String = null, Object = null)
   }
   interface IFindByPartialName`1
     Octopus.Client.Repositories.IPaginate<TResource>
   {
-    List<TResource> FindByPartialName(String, String, Object)
+    List<TResource> FindByPartialName(String, String = null, Object = null)
   }
   interface IGetAll`1
   {
@@ -7580,7 +7583,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<InterruptionResource>
   {
     Octopus.Client.Model.UserResource GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Octopus.Client.Model.ResourceCollection<InterruptionResource> List(Int32, Nullable<Int32>, Boolean, String)
+    Octopus.Client.Model.ResourceCollection<InterruptionResource> List(Int32 = 0, Nullable<Int32> = null, Boolean = False, String = null)
     void Submit(Octopus.Client.Model.InterruptionResource)
     void TakeResponsibility(Octopus.Client.Model.InterruptionResource)
   }
@@ -7634,13 +7637,13 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Octopus.Client.Model.MachineResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Octopus.Client.Model.MachineResource Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
     Octopus.Client.Model.MachineResource Discover(Octopus.Client.Model.DiscoverMachineOptions)
     List<MachineResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.MachineResource)
-    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType>)
+    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType> = null)
     IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
+    Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, String = null)
   }
   interface IMachineRoleRepository
   {
@@ -7667,10 +7670,10 @@ Octopus.Client.Repositories
   }
   interface IPaginate`1
   {
-    List<TResource> FindAll(String, Object)
-    List<TResource> FindMany(Func<TResource, Boolean>, String, Object)
-    Octopus.Client.Repositories.TResource FindOne(Func<TResource, Boolean>, String, Object)
-    void Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
+    List<TResource> FindAll(String = null, Object = null)
+    List<TResource> FindMany(Func<TResource, Boolean>, String = null, Object = null)
+    Octopus.Client.Repositories.TResource FindOne(Func<TResource, Boolean>, String = null, Object = null)
+    void Paginate(Func<ResourceCollection<TResource>, Boolean>, String = null, Object = null)
   }
   interface IPerformanceConfigurationRepository
   {
@@ -7702,7 +7705,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.Git.ConvertProjectToGitResponse ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String)
     Octopus.Client.Model.Git.ConvertProjectToGitResponse ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String, String)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource)
     IReadOnlyList<ReleaseResource> GetAllReleases(Octopus.Client.Model.ProjectResource)
     IReadOnlyList<RunbookResource> GetAllRunbooks(Octopus.Client.Model.ProjectResource)
@@ -7716,10 +7719,10 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<GitTagResource> GetGitTags(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ProgressionResource GetProgression(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ReleaseResource GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
-    Octopus.Client.Model.ResourceCollection<RunbookResource> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Octopus.Client.Model.ResourceCollection<RunbookResource> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Octopus.Client.Model.RunbookSnapshotResource GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> GetTriggers(Octopus.Client.Model.ProjectResource)
     void SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
   }
@@ -7749,9 +7752,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IModify<ReleaseResource>
     Octopus.Client.Repositories.IDelete<ReleaseResource>
   {
-    Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean)
-    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean = False)
+    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.DeploymentPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
     Octopus.Client.Model.LifecycleProgressionResource GetProgression(Octopus.Client.Model.ReleaseResource)
     Octopus.Client.Model.DeploymentTemplateResource GetTemplate(Octopus.Client.Model.ReleaseResource)
@@ -7793,7 +7796,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.IDelete<RunbookRunResource>
   {
-    Octopus.Client.Model.ResourceCollection<RunbookRunResource> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<RunbookRunResource> FindBy(String[], String[], String[], Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.RunbookRunResource)
     void Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     void Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
@@ -7806,9 +7809,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<RunbookSnapshotResource>
   {
     Octopus.Client.Model.RunbookSnapshotResource Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.RunbookRunPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Octopus.Client.Model.ResourceCollection<RunbookRunResource> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<RunbookRunResource> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.RunbookRunTemplateResource GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
     Octopus.Client.Model.RunbookSnapshotResource SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
   }
@@ -7878,25 +7881,25 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICanExtendSpaceContext<ITaskRepository>
   {
     void Cancel(Octopus.Client.Model.TaskResource)
-    Octopus.Client.Model.TaskResource ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
-    Octopus.Client.Model.TaskResource ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
-    Octopus.Client.Model.TaskResource ExecuteBackup(String)
-    Octopus.Client.Model.TaskResource ExecuteCalamariUpdate(String, String[])
-    Octopus.Client.Model.TaskResource ExecuteCommunityActionTemplatesSynchronisation(String)
-    Octopus.Client.Model.TaskResource ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
-    Octopus.Client.Model.TaskResource ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
-    Octopus.Client.Model.TaskResourceCollection GetActiveWithSummary(Int32, Int32)
-    List<TaskResource> GetAllActive(Int32)
-    Octopus.Client.Model.TaskResourceCollection GetAllWithSummary(Int32, Int32)
-    Octopus.Client.Model.TaskDetailsResource GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
+    Octopus.Client.Model.TaskResource ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
+    Octopus.Client.Model.TaskResource ExecuteAdHocScript(String, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
+    Octopus.Client.Model.TaskResource ExecuteBackup(String = null)
+    Octopus.Client.Model.TaskResource ExecuteCalamariUpdate(String = null, String[] = null)
+    Octopus.Client.Model.TaskResource ExecuteCommunityActionTemplatesSynchronisation(String = null)
+    Octopus.Client.Model.TaskResource ExecuteHealthCheck(String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
+    Octopus.Client.Model.TaskResource ExecuteTentacleUpgrade(String = null, String = null, String[] = null, String = null, String = null, String[] = null)
+    Octopus.Client.Model.TaskResourceCollection GetActiveWithSummary(Int32 = Int.MaxValue, Int32 = 0)
+    List<TaskResource> GetAllActive(Int32 = Int.MaxValue)
+    Octopus.Client.Model.TaskResourceCollection GetAllWithSummary(Int32 = Int.MaxValue, Int32 = 0)
+    Octopus.Client.Model.TaskDetailsResource GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean> = null, Nullable<Int32> = null)
     IReadOnlyList<TaskResource> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
     String GetRawOutputLog(Octopus.Client.Model.TaskResource)
     Octopus.Client.Model.TaskTypeResource[] GetTaskTypes()
     void ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String)
     void Rerun(Octopus.Client.Model.TaskResource)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Action<TaskResource[]>)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource, Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Nullable<TimeSpan> = null, Action<TaskResource[]> = null)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.ICreate<TeamResource>
@@ -7929,8 +7932,8 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String)
-    List<TenantResource> FindAll(String, String[], Int32)
-    List<TenantsMissingVariablesResource> GetMissingVariables(String, String, String)
+    List<TenantResource> FindAll(String, String[] = null, Int32 = Int.MaxValue)
+    List<TenantsMissingVariablesResource> GetMissingVariables(String = null, String = null, String = null)
     Octopus.Client.Model.TenantVariableResource GetVariables(Octopus.Client.Model.TenantResource)
     Octopus.Client.Model.TenantVariableResource ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     void SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
@@ -7966,8 +7969,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<UserResource>
     Octopus.Client.Repositories.ICreate<UserResource>
   {
-    Octopus.Client.Model.UserResource Create(String, String, String, String)
-    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
+    Octopus.Client.Model.UserResource Create(String, String, String = null, String = null)
+    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String = null, Nullable<DateTimeOffset> = null)
     Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     Octopus.Client.Model.UserResource FindByUsername(String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -7979,7 +7982,7 @@ Octopus.Client.Repositories
     void RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     void RevokeSessions(Octopus.Client.Model.UserResource)
     void SignIn(Octopus.Client.Model.LoginCommand)
-    void SignIn(String, String, Boolean)
+    void SignIn(String, String, Boolean = False)
     void SignOut()
   }
   interface IUserRolesRepository
@@ -8001,10 +8004,10 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IModify<VariableSetResource>
     Octopus.Client.Repositories.IGetAll<VariableSetResource>
   {
-    Octopus.Client.Model.VariableSetResource Get(Octopus.Client.Model.ProjectResource, String)
-    String[] GetVariableNames(String, String[], String)
+    Octopus.Client.Model.VariableSetResource Get(Octopus.Client.Model.ProjectResource, String = null)
+    String[] GetVariableNames(String, String[], String = null)
     Octopus.Client.Model.VariableSetResource GetVariablePreview(String, String, String, String, String, String, String, String)
-    Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
+    Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
@@ -8017,9 +8020,9 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.WorkerPoolEditor CreateOrModify(String)
     Octopus.Client.Editors.WorkerPoolEditor CreateOrModify(String, String)
-    List<WorkerResource> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
+    List<WorkerResource> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, Nullable<Boolean> = False, String = null, String = null)
     void Sort(String[])
-    Octopus.Client.Model.WorkerPoolsSummaryResource Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
+    Octopus.Client.Model.WorkerPoolsSummaryResource Summary(String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, Nullable<Boolean> = False)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.IFindByName<WorkerResource>
@@ -8030,10 +8033,10 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<WorkerResource>
   {
     Octopus.Client.Editors.WorkerEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Octopus.Client.Model.WorkerResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Octopus.Client.Model.WorkerResource Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
     List<WorkerResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+    Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null)
   }
   class PerformanceConfigurationRepository
     Octopus.Client.Repositories.IPerformanceConfigurationRepository
@@ -8064,15 +8067,15 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    Task<List<TAccount>> FindAllOfType(Object)
+    Task<List<TAccount>> FindAllOfType(Object = null)
     Task<TAccount> FindByNameOfType(String)
     Task<List<TAccount>> FindByNamesOfType(IEnumerable<String>)
-    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object)
-    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object)
+    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object = null)
+    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object = null)
     Task<AccountUsageResource> GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
     Task<TAccount> GetOfType(String)
     Task<List<TAccount>> GetOfType(String[])
-    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
+    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object = null)
     Task<TAccount> RefreshOfType(Octopus.Client.Repositories.Async.TAccount)
   }
   interface IActionTemplateRepository
@@ -8093,7 +8096,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ArchivedEventFileResource>
   {
     Task<Stream> GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
-    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32, Nullable<Int32>)
+    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32 = 0, Nullable<Int32> = null)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.Async.IPaginate<ArtifactResource>
@@ -8116,8 +8119,8 @@ Octopus.Client.Repositories.Async
     Task Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Task<OctopusPackageVersionBuildInformationMappedResource> Get(String)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32, Int32)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32, Int32)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32 = 0, Int32 = 30)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32 = 0, Int32 = 30)
     Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
     Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Boolean)
   }
@@ -8126,9 +8129,9 @@ Octopus.Client.Repositories.Async
     Task DeletePackage(Octopus.Client.Model.PackageResource)
     Task DeletePackages(IReadOnlyList<PackageResource>)
     Task<PackageFromBuiltInFeedResource> GetPackage(String, String)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32 = 0, Int32 = 30)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32 = 0, Int32 = 30)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean = False)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
@@ -8155,8 +8158,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<CertificateResource>
   {
     Task Archive(Octopus.Client.Model.CertificateResource)
-    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
-    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
+    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat> = null, String = null, Boolean = False)
+    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean = False, Octopus.Client.Model.CertificateExportPemOptions = PrimaryOnly)
     Task<CertificateConfigurationResource> GetOctopusCertificate()
     Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String)
     Task UnArchive(Octopus.Client.Model.CertificateResource)
@@ -8173,7 +8176,7 @@ Octopus.Client.Repositories.Async
     Task<ChannelResource> FindByName(Octopus.Client.Model.ProjectResource, String)
     Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ChannelResource)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ChannelResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32, Nullable<Int32>, String)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32 = 0, Nullable<Int32> = null, String = null)
   }
   interface ICommunityActionTemplateRepository
     Octopus.Client.Repositories.Async.IGet<CommunityActionTemplateResource>
@@ -8189,7 +8192,7 @@ Octopus.Client.Repositories.Async
   }
   interface ICreate`1
   {
-    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object)
+    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object = null)
     Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, CancellationToken)
     Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object, CancellationToken)
   }
@@ -8201,7 +8204,7 @@ Octopus.Client.Repositories.Async
   interface IDashboardRepository
   {
     Task<DashboardResource> GetDashboard()
-    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
+    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions = IncludeCurrentDeploymentOnly)
   }
   interface IDefectsRepository
   {
@@ -8233,8 +8236,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.Async.IDelete<DeploymentResource>
   {
-    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32, Nullable<Int32>)
-    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32, Nullable<Int32>)
+    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32 = 0, Nullable<Int32> = null)
     Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource)
     Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
@@ -8264,9 +8267,9 @@ Octopus.Client.Repositories.Async
     Task<EnvironmentEditor> CreateOrModify(String)
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
-    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
+    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null)
     Task Sort(String[])
-    Task<EnvironmentsSummaryResource> Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
+    Task<EnvironmentsSummaryResource> Summary(String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, Nullable<Boolean> = False)
   }
   interface IEventRepository
     Octopus.Client.Repositories.Async.IGet<EventResource>
@@ -8276,8 +8279,8 @@ Octopus.Client.Repositories.Async
     Task<IReadOnlyList<EventCategoryResource>> GetCategories()
     Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes()
     Task<IReadOnlyList<EventGroupResource>> GetGroups()
-    Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean)
-    Task<ResourceCollection<EventResource>> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
+    Task<ResourceCollection<EventResource>> List(Int32 = 0, String = null, String = null, Boolean = False)
+    Task<ResourceCollection<EventResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Boolean = True, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null, Nullable<Int64> = null, Nullable<Int64> = null, String = null, String = null, String = null)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -8298,10 +8301,10 @@ Octopus.Client.Repositories.Async
   interface IFindByName`1
     Octopus.Client.Repositories.Async.IPaginate<TResource>
   {
-    Task<TResource> FindByName(String, String, Object)
+    Task<TResource> FindByName(String, String = null, Object = null)
     Task<TResource> FindByName(String, CancellationToken)
     Task<TResource> FindByName(String, String, Object, CancellationToken)
-    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, String = null, Object = null)
     Task<List<TResource>> FindByNames(IEnumerable<String>, CancellationToken)
     Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
@@ -8339,7 +8342,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<InterruptionResource>
   {
     Task<UserResource> GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Task<ResourceCollection<InterruptionResource>> List(Int32, Nullable<Int32>, Boolean, String)
+    Task<ResourceCollection<InterruptionResource>> List(Int32 = 0, Nullable<Int32> = null, Boolean = False, String = null)
     Task Submit(Octopus.Client.Model.InterruptionResource)
     Task TakeResponsibility(Octopus.Client.Model.InterruptionResource)
   }
@@ -8392,13 +8395,13 @@ Octopus.Client.Repositories.Async
   {
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Task<MachineResource> Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
     Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions)
     Task<List<MachineResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Task<ResourceCollection<MachineResource>> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
+    Task<ResourceCollection<MachineResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, String = null)
   }
   interface IMachineRoleRepository
   {
@@ -8426,16 +8429,16 @@ Octopus.Client.Repositories.Async
   }
   interface IPaginate`1
   {
-    Task<List<TResource>> FindAll(String, Object)
+    Task<List<TResource>> FindAll(String = null, Object = null)
     Task<List<TResource>> FindAll(CancellationToken)
     Task<List<TResource>> FindAll(String, Object, CancellationToken)
-    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String = null, Object = null)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, CancellationToken)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object, CancellationToken)
-    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object)
+    Task<TResource> FindOne(Func<TResource, Boolean>, String = null, Object = null)
     Task<TResource> FindOne(Func<TResource, Boolean>, CancellationToken)
     Task<TResource> FindOne(Func<TResource, Boolean>, String, Object, CancellationToken)
-    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String = null, Object = null)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object, CancellationToken)
   }
@@ -8476,7 +8479,7 @@ Octopus.Client.Repositories.Async
     Task<ConvertProjectToGitResponse> ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, CancellationToken)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -8501,19 +8504,19 @@ Octopus.Client.Repositories.Async
     Task<GitTagResource> GetGitTag(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource, CancellationToken)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32>)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32>)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32> = null)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32> = null)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
-    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
     Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
     Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
     Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
@@ -8547,12 +8550,12 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<ReleaseResource>
     Octopus.Client.Repositories.Async.IDelete<ReleaseResource>
   {
-    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean)
+    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean = False)
     Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean, CancellationToken)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, CancellationToken)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
-    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, CancellationToken)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
     Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
@@ -8570,7 +8573,7 @@ Octopus.Client.Repositories.Async
   }
   interface IRetentionPolicyRepository
   {
-    Task<TaskResource> ApplyNow(String)
+    Task<TaskResource> ApplyNow(String = null)
   }
   interface IRunbookProcessRepository
     Octopus.Client.Repositories.Async.IGet<RunbookProcessResource>
@@ -8600,7 +8603,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookRunResource>
   {
-    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
+    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32 = 0, Nullable<Int32> = null)
     Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
@@ -8613,9 +8616,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<RunbookSnapshotResource>
   {
     Task<RunbookSnapshotResource> Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
     Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
     Task<RunbookRunTemplateResource> GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
     Task<RunbookSnapshotResource> SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
   }
@@ -8686,28 +8689,28 @@ Octopus.Client.Repositories.Async
   {
     Task Cancel(Octopus.Client.Model.TaskResource)
     Task Cancel(Octopus.Client.Model.TaskResource, CancellationToken)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, CancellationToken, String[], String[], String[], String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteAdHocScript(String, CancellationToken, String[], String[], String[], String, String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteBackup(String)
-    Task<TaskResource> ExecuteBackup(CancellationToken, String)
-    Task<TaskResource> ExecuteCalamariUpdate(String, String[])
-    Task<TaskResource> ExecuteCalamariUpdate(CancellationToken, String, String[])
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String)
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(CancellationToken, String)
-    Task<TaskResource> ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
-    Task<TaskResource> ExecuteHealthCheck(CancellationToken, String, Int32, Int32, String, String[], String, String, String[])
-    Task<TaskResource> ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
-    Task<TaskResource> ExecuteTentacleUpgrade(CancellationToken, String, String, String[], String, String, String[])
-    Task<TaskResourceCollection> GetActiveWithSummary(Int32, Int32)
-    Task<TaskResourceCollection> GetActiveWithSummary(CancellationToken, Int32, Int32)
-    Task<List<TaskResource>> GetAllActive(Int32)
-    Task<List<TaskResource>> GetAllActive(CancellationToken, Int32)
-    Task<TaskResourceCollection> GetAllWithSummary(Int32, Int32)
-    Task<TaskResourceCollection> GetAllWithSummary(CancellationToken, Int32, Int32)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, CancellationToken, Nullable<Boolean>, Nullable<Int32>)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, CancellationToken, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
+    Task<TaskResource> ExecuteAdHocScript(String, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
+    Task<TaskResource> ExecuteAdHocScript(String, CancellationToken, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
+    Task<TaskResource> ExecuteBackup(String = null)
+    Task<TaskResource> ExecuteBackup(CancellationToken, String = null)
+    Task<TaskResource> ExecuteCalamariUpdate(String = null, String[] = null)
+    Task<TaskResource> ExecuteCalamariUpdate(CancellationToken, String = null, String[] = null)
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String = null)
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(CancellationToken, String = null)
+    Task<TaskResource> ExecuteHealthCheck(String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
+    Task<TaskResource> ExecuteHealthCheck(CancellationToken, String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
+    Task<TaskResource> ExecuteTentacleUpgrade(String = null, String = null, String[] = null, String = null, String = null, String[] = null)
+    Task<TaskResource> ExecuteTentacleUpgrade(CancellationToken, String = null, String = null, String[] = null, String = null, String = null, String[] = null)
+    Task<TaskResourceCollection> GetActiveWithSummary(Int32 = Int.MaxValue, Int32 = 0)
+    Task<TaskResourceCollection> GetActiveWithSummary(CancellationToken, Int32 = Int.MaxValue, Int32 = 0)
+    Task<List<TaskResource>> GetAllActive(Int32 = Int.MaxValue)
+    Task<List<TaskResource>> GetAllActive(CancellationToken, Int32 = Int.MaxValue)
+    Task<TaskResourceCollection> GetAllWithSummary(Int32 = Int.MaxValue, Int32 = 0)
+    Task<TaskResourceCollection> GetAllWithSummary(CancellationToken, Int32 = Int.MaxValue, Int32 = 0)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean> = null, Nullable<Int32> = null)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, CancellationToken, Nullable<Boolean> = null, Nullable<Int32> = null)
     Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
     Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource, CancellationToken)
     Task<String> GetRawOutputLog(Octopus.Client.Model.TaskResource)
@@ -8718,14 +8721,14 @@ Octopus.Client.Repositories.Async
     Task ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String, CancellationToken)
     Task Rerun(Octopus.Client.Model.TaskResource)
     Task Rerun(Octopus.Client.Model.TaskResource, CancellationToken)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, CancellationToken, Int32, Int32, Action<TaskResource[], CancellationToken>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Int32, Action<TaskResource[], CancellationToken>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Func<TaskResource[], Task>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Int32, Func<TaskResource[], CancellationToken, Task>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Func<TaskResource[], Task>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Nullable<TimeSpan>, Func<TaskResource[], CancellationToken, Task>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, CancellationToken, Int32 = 4, Int32 = 0, Action<TaskResource[], CancellationToken> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Int32 = 0, Action<TaskResource[], CancellationToken> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Func<TaskResource[], Task> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Int32 = 0, Func<TaskResource[], CancellationToken, Task> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Nullable<TimeSpan> = null, Func<TaskResource[], Task> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Nullable<TimeSpan> = null, Func<TaskResource[], CancellationToken, Task> = null)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.Async.ICreate<TeamResource>
@@ -8758,8 +8761,8 @@ Octopus.Client.Repositories.Async
     Task<TenantEditor> CreateOrModify(String)
     Task<TenantEditor> CreateOrModify(String, String)
     Task<TenantEditor> CreateOrModify(String, String, String)
-    Task<List<TenantResource>> FindAll(String, String[], Int32)
-    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String, String, String)
+    Task<List<TenantResource>> FindAll(String, String[] = null, Int32 = Int.MaxValue)
+    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String = null, String = null, String = null)
     Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource)
     Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
@@ -8796,8 +8799,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<UserResource>
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
-    Task<UserResource> Create(String, String, String, String)
-    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
+    Task<UserResource> Create(String, String, String = null, String = null)
+    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String = null, Nullable<DateTimeOffset> = null)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -8809,7 +8812,7 @@ Octopus.Client.Repositories.Async
     Task RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     Task RevokeSessions(Octopus.Client.Model.UserResource)
     Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignIn(String, String, Boolean)
+    Task SignIn(String, String, Boolean = False)
     Task SignOut()
   }
   interface IUserRolesRepository
@@ -8831,15 +8834,15 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<VariableSetResource>
     Octopus.Client.Repositories.Async.IGetAll<VariableSetResource>
   {
-    Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String = null)
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<String[]> GetVariableNames(String, String[], String)
+    Task<String[]> GetVariableNames(String, String[], String = null)
     Task<String[]> GetVariableNames(String, String[], CancellationToken)
     Task<String[]> GetVariableNames(String, String[], String, CancellationToken)
     Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String)
     Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String, CancellationToken)
-    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
+    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null)
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String, CancellationToken)
   }
@@ -8854,9 +8857,9 @@ Octopus.Client.Repositories.Async
   {
     Task<WorkerPoolEditor> CreateOrModify(String)
     Task<WorkerPoolEditor> CreateOrModify(String, String)
-    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
+    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, Nullable<Boolean> = False, String = null, String = null)
     Task Sort(String[])
-    Task<WorkerPoolsSummaryResource> Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
+    Task<WorkerPoolsSummaryResource> Summary(String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, Nullable<Boolean> = False)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerResource>
@@ -8867,10 +8870,10 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<WorkerResource>
   {
     Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Task<WorkerResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Task<WorkerResource> Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
     Task<List<WorkerResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+    Task<ResourceCollection<WorkerResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null)
   }
   class SpaceScopedOperationOutsideOfCurrentSpaceContextException
     ISerializable

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -608,11 +608,11 @@ Octopus.Client
     .ctor(String, String, ICredentials)
     .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
     String ApiKey { get; }
+    String BearerToken { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.ILinkResolver OctopusServer { get; }
     IWebProxy Proxy { get; set; }
-    String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
     static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String, ICredentials)
     static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String, ICredentials)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3,7 +3,7 @@ Octopus.Client
   class DefaultLinkResolver
     Octopus.Client.ILinkResolver
   {
-    .ctor(Uri, String = "/api")
+    .ctor(Uri, String)
     Boolean IsUsingSecureConnection { get; }
     Uri Resolve(String)
     String ToString()
@@ -30,54 +30,54 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Task<TResource> Create(String, Octopus.Client.TResource, Object = null)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task<TResource> Create(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task Delete(String, Object = null, Object = null)
+    Task Delete(String, Object, Object)
     Task Delete(String, CancellationToken)
     Task Delete(String, Object, Object, CancellationToken)
     Task<TResponse> Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object = null)
+    Task<TResource> Get(String, Object)
     Task<TResource> Get(String, CancellationToken)
     Task<TResource> Get(String, Object, CancellationToken)
-    Task<Stream> GetContent(String, Object = null)
+    Task<Stream> GetContent(String, Object)
     Task<Stream> GetContent(String, CancellationToken)
     Task<Stream> GetContent(String, Object, CancellationToken)
-    Task<ResourceCollection<TResource>> List(String, Object = null)
+    Task<ResourceCollection<TResource>> List(String, Object)
     Task<ResourceCollection<TResource>> List(String, CancellationToken)
     Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object = null)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object)
     Task<IReadOnlyList<TResource>> ListAll(String, CancellationToken)
     Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
-    Task Post(String, Octopus.Client.TResource, Object = null)
+    Task Post(String, Octopus.Client.TResource, Object)
     Task Post(String, Octopus.Client.TResource, CancellationToken)
     Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object = null)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
     Task<TResponse> Post(String, Octopus.Client.TResource, CancellationToken)
     Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Post(String)
     Task Post(String, CancellationToken)
     Task Put(String, Octopus.Client.TResource)
     Task Put(String, Octopus.Client.TResource, CancellationToken)
-    Task Put(String, Octopus.Client.TResource, Object = null)
+    Task Put(String, Octopus.Client.TResource, Object)
     Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Put(String)
     Task Put(String, CancellationToken)
     Task PutContent(String, Stream)
     Task PutContent(String, Stream, CancellationToken)
-    Uri QualifyUri(String, Object = null)
+    Uri QualifyUri(String, Object)
     Task<TResponse> Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
     Task SignOut()
     Task SignOut(CancellationToken)
-    Task<TResource> Update(String, Octopus.Client.TResource, Object = null)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object)
     Task<TResource> Update(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
@@ -95,34 +95,34 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object = null)
-    void Delete(String, Object = null, Object = null)
+    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
+    void Delete(String, Object, Object)
     Octopus.Client.TResponse Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
-    Octopus.Client.TResource Get(String, Object = null)
-    Stream GetContent(String, Object = null)
-    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object = null)
-    IReadOnlyList<TResource> ListAll(String, Object = null)
+    Octopus.Client.TResource Get(String, Object)
+    Stream GetContent(String, Object)
+    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object)
+    IReadOnlyList<TResource> ListAll(String, Object)
     void Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     void Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
-    void Post(String, Octopus.Client.TResource, Object = null)
-    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object = null)
+    void Post(String, Octopus.Client.TResource, Object)
+    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object)
     void Post(String)
     void Put(String, Octopus.Client.TResource)
     void Put(String)
-    void Put(String, Octopus.Client.TResource, Object = null)
+    void Put(String, Octopus.Client.TResource, Object)
     void PutContent(String, Stream)
-    Uri QualifyUri(String, Object = null)
+    Uri QualifyUri(String, Object)
     Octopus.Client.TResponse Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignOut()
-    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object = null)
+    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object)
   }
   interface IOctopusClientFactory
   {
-    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
-    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
   }
   interface IOctopusCommonAsyncRepository
   {
@@ -303,56 +303,56 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
-    Task<TResource> Create(String, Octopus.Client.TResource, Object = null)
+    static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task<TResource> Create(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task Delete(String, Object = null, Object = null)
+    Task Delete(String, Object, Object)
     Task Delete(String, CancellationToken)
     Task Delete(String, Object, Object, CancellationToken)
     void Dispose()
     Task<TResponse> Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object = null)
+    Task<TResource> Get(String, Object)
     Task<TResource> Get(String, CancellationToken)
     Task<TResource> Get(String, Object, CancellationToken)
-    Task<Stream> GetContent(String, Object = null)
+    Task<Stream> GetContent(String, Object)
     Task<Stream> GetContent(String, CancellationToken)
     Task<Stream> GetContent(String, Object, CancellationToken)
-    Task<ResourceCollection<TResource>> List(String, Object = null)
+    Task<ResourceCollection<TResource>> List(String, Object)
     Task<ResourceCollection<TResource>> List(String, CancellationToken)
     Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object = null)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object)
     Task<IReadOnlyList<TResource>> ListAll(String, CancellationToken)
     Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
-    Task Post(String, Octopus.Client.TResource, Object = null)
+    Task Post(String, Octopus.Client.TResource, Object)
     Task Post(String, Octopus.Client.TResource, CancellationToken)
     Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object = null)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
     Task<TResponse> Post(String, Octopus.Client.TResource, CancellationToken)
     Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Post(String)
     Task Post(String, CancellationToken)
     Task Put(String, Octopus.Client.TResource)
     Task Put(String, Octopus.Client.TResource, CancellationToken)
-    Task Put(String, Octopus.Client.TResource, Object = null)
+    Task Put(String, Octopus.Client.TResource, Object)
     Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Put(String)
     Task Put(String, CancellationToken)
     Task PutContent(String, Stream)
     Task PutContent(String, Stream, CancellationToken)
-    Uri QualifyUri(String, Object = null)
+    Uri QualifyUri(String, Object)
     Task<TResponse> Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
     Task SignOut()
     Task SignOut(CancellationToken)
-    Task<TResource> Update(String, Octopus.Client.TResource, Object = null)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object)
     Task<TResource> Update(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
@@ -362,7 +362,7 @@ Octopus.Client
     Octopus.Client.IOctopusCommonAsyncRepository
     Octopus.Client.IOctopusSystemAsyncRepository
   {
-    .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope = null)
+    .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
     Octopus.Client.Repositories.Async.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.Async.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.Async.IArchivedEventFileRepository ArchivedEventFiles { get; }
@@ -444,42 +444,42 @@ Octopus.Client
     event Action<WebRequest> BeforeSendingHttpRequest
     event Action<OctopusResponse> ReceivedOctopusResponse
     event Action<OctopusRequest> SendingOctopusRequest
-    .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object = null)
-    void Delete(String, Object = null, Object = null)
+    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
+    void Delete(String, Object, Object)
     void Dispose()
     Octopus.Client.TResponse Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
-    Octopus.Client.TResource Get(String, Object = null)
-    Stream GetContent(String, Object = null)
+    Octopus.Client.TResource Get(String, Object)
+    Stream GetContent(String, Object)
     void Initialize()
-    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object = null)
-    IReadOnlyList<TResource> ListAll(String, Object = null)
+    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object)
+    IReadOnlyList<TResource> ListAll(String, Object)
     void Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     void Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
-    void Post(String, Octopus.Client.TResource, Object = null)
-    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object = null)
+    void Post(String, Octopus.Client.TResource, Object)
+    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object)
     void Post(String)
     void Put(String, Octopus.Client.TResource)
     void Put(String)
-    void Put(String, Octopus.Client.TResource, Object = null)
+    void Put(String, Octopus.Client.TResource, Object)
     void PutContent(String, Stream)
-    Uri QualifyUri(String, Object = null)
+    Uri QualifyUri(String, Object)
     Octopus.Client.TResponse Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignOut()
-    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object = null)
+    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object)
   }
   class OctopusClientFactory
     Octopus.Client.IOctopusClientFactory
   {
     .ctor()
-    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
-    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
   }
   class OctopusClientOptions
   {
@@ -501,7 +501,7 @@ Octopus.Client
   {
     .ctor(Octopus.Client.OctopusServerEndpoint)
     .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.RepositoryScope)
-    .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope = null)
+    .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope)
     Octopus.Client.Repositories.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.IArchivedEventFileRepository ArchivedEventFiles { get; }
@@ -574,7 +574,7 @@ Octopus.Client
   }
   abstract class OctopusRepositoryExtensions
   {
-    static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope = null)
+    static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
     static Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.IOctopusAsyncRepository, Octopus.Client.Model.SpaceResource)
     static Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.IOctopusRepository, Octopus.Client.Model.SpaceResource)
     static Octopus.Client.IOctopusSystemAsyncRepository ForSystem(Octopus.Client.IOctopusAsyncRepository)
@@ -582,7 +582,7 @@ Octopus.Client
   }
   class OctopusRequest
   {
-    .ctor(String, Uri, Object = null)
+    .ctor(String, Uri, Object)
     String Method { get; }
     Object RequestResource { get; }
     Uri Uri { get; }
@@ -605,17 +605,14 @@ Octopus.Client
   {
     .ctor(String)
     .ctor(String, String)
-    .ctor(String, String, ICredentials, Boolean = False)
-    .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean = False)
+    .ctor(String, String, ICredentials)
+    .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
     String ApiKey { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.ILinkResolver OctopusServer { get; }
     IWebProxy Proxy { get; set; }
-    String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
-    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
-    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
   }
   class RepositoryScope
   {
@@ -844,7 +841,7 @@ Octopus.Client.Editors
     .ctor(Octopus.Client.Repositories.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode> = null)
+    Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.MachineEditor Customize(Action<MachineResource>)
     Octopus.Client.Editors.MachineEditor Save()
   }
@@ -868,7 +865,7 @@ Octopus.Client.Editors
     Octopus.Client.Editors.VariableSetEditor Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
+    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Octopus.Client.Editors.ProjectEditor Customize(Action<ProjectResource>)
     Octopus.Client.Editors.ProjectEditor IncludingLibraryVariableSets(Octopus.Client.Model.LibraryVariableSetResource[])
     Octopus.Client.Editors.ProjectEditor Save()
@@ -951,7 +948,7 @@ Octopus.Client.Editors
   {
     .ctor(Octopus.Client.Repositories.ITagSetRepository)
     Octopus.Client.Model.TagSetResource Instance { get; }
-    Octopus.Client.Editors.TagSetEditor AddOrUpdateTag(String, String = null, String = "#6e6e6e")
+    Octopus.Client.Editors.TagSetEditor AddOrUpdateTag(String, String, String)
     Octopus.Client.Editors.TagSetEditor ClearTags()
     Octopus.Client.Editors.TagSetEditor CreateOrModify(String)
     Octopus.Client.Editors.TagSetEditor CreateOrModify(String, String)
@@ -970,7 +967,7 @@ Octopus.Client.Editors
     Octopus.Client.Editors.TenantEditor ClearTags()
     Octopus.Client.Editors.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
-    Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String = null)
+    Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String)
     Octopus.Client.Editors.TenantEditor Customize(Action<TenantResource>)
     Octopus.Client.Editors.TenantEditor Save()
     Octopus.Client.Editors.TenantEditor SetLogo(String)
@@ -1151,7 +1148,7 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IEnvironmentRepository)
     Octopus.Client.Model.EnvironmentResource Instance { get; }
     Task<EnvironmentEditor> CreateOrModify(String)
-    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean = False)
+    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Octopus.Client.Editors.Async.EnvironmentEditor Customize(Action<EnvironmentResource>)
     Task<EnvironmentEditor> Save()
@@ -1200,7 +1197,7 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode> = null)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.Async.MachineEditor Customize(Action<MachineResource>)
     Task<MachineEditor> Save()
   }
@@ -1224,7 +1221,7 @@ Octopus.Client.Editors.Async
     Task<VariableSetEditor> Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.ProjectEditor Customize(Action<ProjectResource>)
@@ -1309,7 +1306,7 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.ITagSetRepository)
     Octopus.Client.Model.TagSetResource Instance { get; }
-    Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String = null, String = "#6e6e6e")
+    Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String, String)
     Octopus.Client.Editors.Async.TagSetEditor ClearTags()
     Task<TagSetEditor> CreateOrModify(String)
     Task<TagSetEditor> CreateOrModify(String, String)
@@ -1328,7 +1325,7 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.TenantEditor ClearTags()
     Octopus.Client.Editors.Async.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Task<TenantEditor> CreateOrModify(String)
-    Task<TenantEditor> CreateOrModify(String, String, String = null)
+    Task<TenantEditor> CreateOrModify(String, String, String)
     Octopus.Client.Editors.Async.TenantEditor Customize(Action<TenantResource>)
     Task<TenantEditor> Save()
     Task<TenantEditor> SetLogo(String)
@@ -1637,7 +1634,7 @@ Octopus.Client.Logging
     .ctor(Object, IntPtr)
     IAsyncResult BeginInvoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception, Object[], AsyncCallback, Object)
     Boolean EndInvoke(IAsyncResult)
-    Boolean Invoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception = null, Object[])
+    Boolean Invoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception, Object[])
   }
   LogLevel
   {
@@ -2860,7 +2857,7 @@ Octopus.Client.Model
     Octopus.Client.Model.DeploymentStepResource ClearActions()
     Octopus.Client.Model.DeploymentActionResource FindAction(String)
     Octopus.Client.Model.DeploymentStepResource RemoveAction(String)
-    Octopus.Client.Model.DeploymentStepResource RequirePackagesToBeAcquired(Boolean = True)
+    Octopus.Client.Model.DeploymentStepResource RequirePackagesToBeAcquired(Boolean)
     Octopus.Client.Model.DeploymentStepResource TargetingRoles(String[])
     Octopus.Client.Model.DeploymentStepResource WithCondition(Octopus.Client.Model.DeploymentStepCondition)
     Octopus.Client.Model.DeploymentStepResource WithPackageRequirement(Octopus.Client.Model.DeploymentStepPackageRequirement)
@@ -3183,14 +3180,14 @@ Octopus.Client.Model
     void Clear()
     Boolean Contains(Octopus.Client.Model.GitDependencyResource)
     void CopyTo(Octopus.Client.Model.GitDependencyResource[], Int32)
-    Octopus.Client.Model.GitDependencyResource GetByName(String = "")
+    Octopus.Client.Model.GitDependencyResource GetByName(String)
     IEnumerator<GitDependencyResource> GetEnumerator()
     Boolean Remove(Octopus.Client.Model.GitDependencyResource)
     Boolean TryGetByName(String, Octopus.Client.Model.GitDependencyResource&)
   }
   class GitDependencyResource
   {
-    .ctor(String, String, String, String = null, String[] = null, String = null, String = null)
+    .ctor(String, String, String, String, String[], String, String)
     String DefaultBranch { get; }
     String[] FilePathFilters { get; }
     String GitCredentialId { get; }
@@ -5083,7 +5080,7 @@ Octopus.Client.Model
   {
     .ctor(String)
     .ctor(Octopus.Client.Model.SemanticVersion)
-    .ctor(Version, String = null, String = null)
+    .ctor(Version, String, String)
     .ctor(Int32, Int32, Int32)
     .ctor(Int32, Int32, Int32, String)
     .ctor(Int32, Int32, Int32, String, String)
@@ -5091,16 +5088,16 @@ Octopus.Client.Model
     .ctor(Int32, Int32, Int32, Int32)
     .ctor(Int32, Int32, Int32, Int32, String, String)
     .ctor(Int32, Int32, Int32, Int32, IEnumerable<String>, String)
-    .ctor(Version, IEnumerable<String>, String, String, Boolean = False)
+    .ctor(Version, IEnumerable<String>, String, String, Boolean)
     Boolean IsLegacyVersion { get; }
     Boolean IsSemVer2 { get; }
     String OriginalString { get; }
     Int32 Revision { get; }
     Version Version { get; }
     static String IncrementRelease(String)
-    static Octopus.Client.Model.SemanticVersion Parse(String, Boolean = False)
+    static Octopus.Client.Model.SemanticVersion Parse(String, Boolean)
     String ToString()
-    static Boolean TryParse(String, Octopus.Client.Model.SemanticVersion&, Boolean = False)
+    static Boolean TryParse(String, Octopus.Client.Model.SemanticVersion&, Boolean)
     static Boolean TryParseStrict(String, Octopus.Client.Model.SemanticVersion&)
   }
   class SemanticVersionComparer
@@ -5384,7 +5381,7 @@ Octopus.Client.Model
     Int32 SortOrder { get; set; }
     String SpaceId { get; set; }
     IList<TagResource> Tags { get; set; }
-    Octopus.Client.Model.TagSetResource AddOrUpdateTag(String, String = null, String = "#6e6e6e")
+    Octopus.Client.Model.TagSetResource AddOrUpdateTag(String, String, String)
     Octopus.Client.Model.TagSetResource RemoveTag(String)
   }
   TargetType
@@ -6349,7 +6346,7 @@ Octopus.Client.Model.DeploymentProcess
   class InlineScriptActionFromFileInAssembly
     Octopus.Client.Model.DeploymentProcess.ScriptAction
   {
-    .ctor(String, Assembly = null)
+    .ctor(String, Assembly)
     Assembly ResourceAssembly { get; }
     String ResourceName { get; }
     Octopus.Client.Model.DeploymentProcess.ScriptSource Source { get; }
@@ -6361,7 +6358,7 @@ Octopus.Client.Model.DeploymentProcess
     Octopus.Client.Model.DeploymentProcess.ScriptSource Source { get; }
     Octopus.Client.Model.ScriptSyntax Syntax { get; }
     static Octopus.Client.Model.DeploymentProcess.InlineScriptAction InlineScript(Octopus.Client.Model.ScriptSyntax, String)
-    static Octopus.Client.Model.DeploymentProcess.InlineScriptActionFromFileInAssembly InlineScriptFromFileInAssembly(String, Assembly = null)
+    static Octopus.Client.Model.DeploymentProcess.InlineScriptActionFromFileInAssembly InlineScriptFromFileInAssembly(String, Assembly)
   }
   class ScriptActionFromFileInPackage
     Octopus.Client.Model.DeploymentProcess.ScriptAction
@@ -6673,7 +6670,7 @@ Octopus.Client.Model.Forms
 {
   class Button
   {
-    .ctor(String, String = null)
+    .ctor(String, String)
     String Text { get; }
     Object Value { get; }
   }
@@ -6693,20 +6690,20 @@ Octopus.Client.Model.Forms
   class Form
   {
     .ctor()
-    .ctor(IEnumerable<FormElement> = null, IDictionary<String, String> = null)
+    .ctor(IEnumerable<FormElement>, IDictionary<String, String>)
     List<FormElement> Elements { get; }
     Dictionary<String, String> Values { get; }
   }
   class FormElement
   {
-    .ctor(String, Octopus.Client.Model.Forms.Control, Boolean = False)
+    .ctor(String, Octopus.Client.Model.Forms.Control, Boolean)
     Octopus.Client.Model.Forms.Control Control { get; }
     Boolean IsValueRequired { get; }
     String Name { get; }
   }
   abstract class FormExtensions
   {
-    static void AddElement(Octopus.Client.Model.Forms.Form, String, Octopus.Client.Model.Forms.Control, String = null, Boolean = False)
+    static void AddElement(Octopus.Client.Model.Forms.Form, String, Octopus.Client.Model.Forms.Control, String, Boolean)
     static Object GetCoercedValue(Octopus.Client.Model.Forms.Form, String)
     static void SetValue(Octopus.Client.Model.Forms.Form, String, String)
     static void UpdateValues(Octopus.Client.Model.Forms.Form, IDictionary<String, String>)
@@ -7327,8 +7324,8 @@ Octopus.Client.Repositories
     void Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     void DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Get(String)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32 = 0, Int32 = 30)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32, Int32)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
   }
@@ -7342,15 +7339,15 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    List<TAccount> FindAllOfType(Object = null)
+    List<TAccount> FindAllOfType(Object)
     Octopus.Client.Repositories.TAccount FindByNameOfType(String)
     List<TAccount> FindByNamesOfType(IEnumerable<String>)
-    List<TAccount> FindManyOfType(Func<TAccount, Boolean>, Object = null)
-    Octopus.Client.Repositories.TAccount FindOneOfType(Func<TAccount, Boolean>, Object = null)
+    List<TAccount> FindManyOfType(Func<TAccount, Boolean>, Object)
+    Octopus.Client.Repositories.TAccount FindOneOfType(Func<TAccount, Boolean>, Object)
     Octopus.Client.Model.Accounts.Usages.AccountUsageResource GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
     Octopus.Client.Repositories.TAccount GetOfType(String)
     List<TAccount> GetOfType(String[])
-    void PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object = null)
+    void PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
     Octopus.Client.Repositories.TAccount RefreshOfType(Octopus.Client.Repositories.TAccount)
   }
   interface IActionTemplateRepository
@@ -7371,7 +7368,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<ArchivedEventFileResource>
   {
     Stream GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
-    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32, Nullable<Int32>)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.IPaginate<ArtifactResource>
@@ -7394,8 +7391,8 @@ Octopus.Client.Repositories
     void Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     void DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Get(String)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32 = 0, Int32 = 30)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32, Int32)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation)
   }
@@ -7404,9 +7401,9 @@ Octopus.Client.Repositories
     void DeletePackage(Octopus.Client.Model.PackageResource)
     void DeletePackages(IReadOnlyList<PackageResource>)
     Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String, String)
-    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32 = 0, Int32 = 30)
-    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32 = 0, Int32 = 30)
-    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean = False)
+    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean, Boolean)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
@@ -7433,8 +7430,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<CertificateResource>
   {
     void Archive(Octopus.Client.Model.CertificateResource)
-    Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat> = null, String = null, Boolean = False)
-    Stream ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean = False, Octopus.Client.Model.CertificateExportPemOptions = PrimaryOnly)
+    Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
+    Stream ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
     Octopus.Client.Model.CertificateConfigurationResource GetOctopusCertificate()
     Octopus.Client.Model.CertificateResource Replace(Octopus.Client.Model.CertificateResource, String, String)
     void UnArchive(Octopus.Client.Model.CertificateResource)
@@ -7465,7 +7462,7 @@ Octopus.Client.Repositories
   }
   interface ICreate`1
   {
-    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object = null)
+    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object)
   }
   interface IDashboardConfigurationRepository
   {
@@ -7475,7 +7472,7 @@ Octopus.Client.Repositories
   interface IDashboardRepository
   {
     Octopus.Client.Model.DashboardResource GetDashboard()
-    Octopus.Client.Model.DashboardResource GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions = IncludeCurrentDeploymentOnly)
+    Octopus.Client.Model.DashboardResource GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
   }
   interface IDefectsRepository
   {
@@ -7502,8 +7499,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.IDelete<DeploymentResource>
   {
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindAll(String[], String[], Int32 = 0, Nullable<Int32> = null)
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindBy(String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindAll(String[], String[], Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindBy(String[], String[], Int32, Nullable<Int32>)
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.DeploymentResource)
     void Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     void Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
@@ -7528,9 +7525,9 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String)
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String, String)
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String, String, Boolean)
-    List<MachineResource> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null)
+    List<MachineResource> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
     void Sort(String[])
-    Octopus.Client.Model.EnvironmentsSummaryResource Summary(String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, Nullable<Boolean> = False)
+    Octopus.Client.Model.EnvironmentsSummaryResource Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
   }
   interface IEventRepository
     Octopus.Client.Repositories.IGet<EventResource>
@@ -7540,8 +7537,8 @@ Octopus.Client.Repositories
     IReadOnlyList<EventCategoryResource> GetCategories()
     IReadOnlyList<DocumentTypeResource> GetDocumentTypes()
     IReadOnlyList<EventGroupResource> GetGroups()
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32 = 0, String = null, String = null, Boolean = False)
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Boolean = True, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null, Nullable<Int64> = null, Nullable<Int64> = null, String = null, String = null, String = null)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, String, String, Boolean)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -7561,13 +7558,13 @@ Octopus.Client.Repositories
   interface IFindByName`1
     Octopus.Client.Repositories.IPaginate<TResource>
   {
-    Octopus.Client.Repositories.TResource FindByName(String, String = null, Object = null)
-    List<TResource> FindByNames(IEnumerable<String>, String = null, Object = null)
+    Octopus.Client.Repositories.TResource FindByName(String, String, Object)
+    List<TResource> FindByNames(IEnumerable<String>, String, Object)
   }
   interface IFindByPartialName`1
     Octopus.Client.Repositories.IPaginate<TResource>
   {
-    List<TResource> FindByPartialName(String, String = null, Object = null)
+    List<TResource> FindByPartialName(String, String, Object)
   }
   interface IGetAll`1
   {
@@ -7583,7 +7580,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<InterruptionResource>
   {
     Octopus.Client.Model.UserResource GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Octopus.Client.Model.ResourceCollection<InterruptionResource> List(Int32 = 0, Nullable<Int32> = null, Boolean = False, String = null)
+    Octopus.Client.Model.ResourceCollection<InterruptionResource> List(Int32, Nullable<Int32>, Boolean, String)
     void Submit(Octopus.Client.Model.InterruptionResource)
     void TakeResponsibility(Octopus.Client.Model.InterruptionResource)
   }
@@ -7637,13 +7634,13 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Octopus.Client.Model.MachineResource Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
+    Octopus.Client.Model.MachineResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
     Octopus.Client.Model.MachineResource Discover(Octopus.Client.Model.DiscoverMachineOptions)
     List<MachineResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.MachineResource)
-    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType> = null)
+    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType>)
     IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, String = null)
+    Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
   }
   interface IMachineRoleRepository
   {
@@ -7670,10 +7667,10 @@ Octopus.Client.Repositories
   }
   interface IPaginate`1
   {
-    List<TResource> FindAll(String = null, Object = null)
-    List<TResource> FindMany(Func<TResource, Boolean>, String = null, Object = null)
-    Octopus.Client.Repositories.TResource FindOne(Func<TResource, Boolean>, String = null, Object = null)
-    void Paginate(Func<ResourceCollection<TResource>, Boolean>, String = null, Object = null)
+    List<TResource> FindAll(String, Object)
+    List<TResource> FindMany(Func<TResource, Boolean>, String, Object)
+    Octopus.Client.Repositories.TResource FindOne(Func<TResource, Boolean>, String, Object)
+    void Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
   }
   interface IPerformanceConfigurationRepository
   {
@@ -7705,7 +7702,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.Git.ConvertProjectToGitResponse ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String)
     Octopus.Client.Model.Git.ConvertProjectToGitResponse ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String, String)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
+    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource)
     IReadOnlyList<ReleaseResource> GetAllReleases(Octopus.Client.Model.ProjectResource)
     IReadOnlyList<RunbookResource> GetAllRunbooks(Octopus.Client.Model.ProjectResource)
@@ -7719,10 +7716,10 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<GitTagResource> GetGitTags(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ProgressionResource GetProgression(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ReleaseResource GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
-    Octopus.Client.Model.ResourceCollection<RunbookResource> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Octopus.Client.Model.ResourceCollection<RunbookResource> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Octopus.Client.Model.RunbookSnapshotResource GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> GetTriggers(Octopus.Client.Model.ProjectResource)
     void SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
   }
@@ -7752,9 +7749,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IModify<ReleaseResource>
     Octopus.Client.Repositories.IDelete<ReleaseResource>
   {
-    Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean = False)
-    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean)
+    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.DeploymentPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
     Octopus.Client.Model.LifecycleProgressionResource GetProgression(Octopus.Client.Model.ReleaseResource)
     Octopus.Client.Model.DeploymentTemplateResource GetTemplate(Octopus.Client.Model.ReleaseResource)
@@ -7796,7 +7793,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.IDelete<RunbookRunResource>
   {
-    Octopus.Client.Model.ResourceCollection<RunbookRunResource> FindBy(String[], String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<RunbookRunResource> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.RunbookRunResource)
     void Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     void Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
@@ -7809,9 +7806,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<RunbookSnapshotResource>
   {
     Octopus.Client.Model.RunbookSnapshotResource Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.RunbookRunPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Octopus.Client.Model.ResourceCollection<RunbookRunResource> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<RunbookRunResource> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.RunbookRunTemplateResource GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
     Octopus.Client.Model.RunbookSnapshotResource SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
   }
@@ -7881,25 +7878,25 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICanExtendSpaceContext<ITaskRepository>
   {
     void Cancel(Octopus.Client.Model.TaskResource)
-    Octopus.Client.Model.TaskResource ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
-    Octopus.Client.Model.TaskResource ExecuteAdHocScript(String, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
-    Octopus.Client.Model.TaskResource ExecuteBackup(String = null)
-    Octopus.Client.Model.TaskResource ExecuteCalamariUpdate(String = null, String[] = null)
-    Octopus.Client.Model.TaskResource ExecuteCommunityActionTemplatesSynchronisation(String = null)
-    Octopus.Client.Model.TaskResource ExecuteHealthCheck(String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
-    Octopus.Client.Model.TaskResource ExecuteTentacleUpgrade(String = null, String = null, String[] = null, String = null, String = null, String[] = null)
-    Octopus.Client.Model.TaskResourceCollection GetActiveWithSummary(Int32 = Int.MaxValue, Int32 = 0)
-    List<TaskResource> GetAllActive(Int32 = Int.MaxValue)
-    Octopus.Client.Model.TaskResourceCollection GetAllWithSummary(Int32 = Int.MaxValue, Int32 = 0)
-    Octopus.Client.Model.TaskDetailsResource GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean> = null, Nullable<Int32> = null)
+    Octopus.Client.Model.TaskResource ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
+    Octopus.Client.Model.TaskResource ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
+    Octopus.Client.Model.TaskResource ExecuteBackup(String)
+    Octopus.Client.Model.TaskResource ExecuteCalamariUpdate(String, String[])
+    Octopus.Client.Model.TaskResource ExecuteCommunityActionTemplatesSynchronisation(String)
+    Octopus.Client.Model.TaskResource ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
+    Octopus.Client.Model.TaskResource ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
+    Octopus.Client.Model.TaskResourceCollection GetActiveWithSummary(Int32, Int32)
+    List<TaskResource> GetAllActive(Int32)
+    Octopus.Client.Model.TaskResourceCollection GetAllWithSummary(Int32, Int32)
+    Octopus.Client.Model.TaskDetailsResource GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
     IReadOnlyList<TaskResource> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
     String GetRawOutputLog(Octopus.Client.Model.TaskResource)
     Octopus.Client.Model.TaskTypeResource[] GetTaskTypes()
     void ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String)
     void Rerun(Octopus.Client.Model.TaskResource)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource, Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Nullable<TimeSpan> = null, Action<TaskResource[]> = null)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Action<TaskResource[]>)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.ICreate<TeamResource>
@@ -7932,8 +7929,8 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String)
-    List<TenantResource> FindAll(String, String[] = null, Int32 = Int.MaxValue)
-    List<TenantsMissingVariablesResource> GetMissingVariables(String = null, String = null, String = null)
+    List<TenantResource> FindAll(String, String[], Int32)
+    List<TenantsMissingVariablesResource> GetMissingVariables(String, String, String)
     Octopus.Client.Model.TenantVariableResource GetVariables(Octopus.Client.Model.TenantResource)
     Octopus.Client.Model.TenantVariableResource ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     void SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
@@ -7969,8 +7966,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<UserResource>
     Octopus.Client.Repositories.ICreate<UserResource>
   {
-    Octopus.Client.Model.UserResource Create(String, String, String = null, String = null)
-    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String = null, Nullable<DateTimeOffset> = null)
+    Octopus.Client.Model.UserResource Create(String, String, String, String)
+    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     Octopus.Client.Model.UserResource FindByUsername(String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -7982,7 +7979,7 @@ Octopus.Client.Repositories
     void RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     void RevokeSessions(Octopus.Client.Model.UserResource)
     void SignIn(Octopus.Client.Model.LoginCommand)
-    void SignIn(String, String, Boolean = False)
+    void SignIn(String, String, Boolean)
     void SignOut()
   }
   interface IUserRolesRepository
@@ -8004,10 +8001,10 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IModify<VariableSetResource>
     Octopus.Client.Repositories.IGetAll<VariableSetResource>
   {
-    Octopus.Client.Model.VariableSetResource Get(Octopus.Client.Model.ProjectResource, String = null)
-    String[] GetVariableNames(String, String[], String = null)
+    Octopus.Client.Model.VariableSetResource Get(Octopus.Client.Model.ProjectResource, String)
+    String[] GetVariableNames(String, String[], String)
     Octopus.Client.Model.VariableSetResource GetVariablePreview(String, String, String, String, String, String, String, String)
-    Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null)
+    Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
@@ -8020,9 +8017,9 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.WorkerPoolEditor CreateOrModify(String)
     Octopus.Client.Editors.WorkerPoolEditor CreateOrModify(String, String)
-    List<WorkerResource> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, Nullable<Boolean> = False, String = null, String = null)
+    List<WorkerResource> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
     void Sort(String[])
-    Octopus.Client.Model.WorkerPoolsSummaryResource Summary(String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, Nullable<Boolean> = False)
+    Octopus.Client.Model.WorkerPoolsSummaryResource Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.IFindByName<WorkerResource>
@@ -8033,10 +8030,10 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<WorkerResource>
   {
     Octopus.Client.Editors.WorkerEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Octopus.Client.Model.WorkerResource Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
+    Octopus.Client.Model.WorkerResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
     List<WorkerResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null)
+    Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
   }
   class PerformanceConfigurationRepository
     Octopus.Client.Repositories.IPerformanceConfigurationRepository
@@ -8067,15 +8064,15 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    Task<List<TAccount>> FindAllOfType(Object = null)
+    Task<List<TAccount>> FindAllOfType(Object)
     Task<TAccount> FindByNameOfType(String)
     Task<List<TAccount>> FindByNamesOfType(IEnumerable<String>)
-    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object = null)
-    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object = null)
+    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object)
+    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object)
     Task<AccountUsageResource> GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
     Task<TAccount> GetOfType(String)
     Task<List<TAccount>> GetOfType(String[])
-    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object = null)
+    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
     Task<TAccount> RefreshOfType(Octopus.Client.Repositories.Async.TAccount)
   }
   interface IActionTemplateRepository
@@ -8096,7 +8093,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ArchivedEventFileResource>
   {
     Task<Stream> GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
-    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32, Nullable<Int32>)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.Async.IPaginate<ArtifactResource>
@@ -8119,8 +8116,8 @@ Octopus.Client.Repositories.Async
     Task Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Task<OctopusPackageVersionBuildInformationMappedResource> Get(String)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32 = 0, Int32 = 30)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32 = 0, Int32 = 30)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32, Int32)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32, Int32)
     Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
     Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Boolean)
   }
@@ -8129,9 +8126,9 @@ Octopus.Client.Repositories.Async
     Task DeletePackage(Octopus.Client.Model.PackageResource)
     Task DeletePackages(IReadOnlyList<PackageResource>)
     Task<PackageFromBuiltInFeedResource> GetPackage(String, String)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32 = 0, Int32 = 30)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32 = 0, Int32 = 30)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean = False)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
@@ -8158,8 +8155,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<CertificateResource>
   {
     Task Archive(Octopus.Client.Model.CertificateResource)
-    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat> = null, String = null, Boolean = False)
-    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean = False, Octopus.Client.Model.CertificateExportPemOptions = PrimaryOnly)
+    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
+    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
     Task<CertificateConfigurationResource> GetOctopusCertificate()
     Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String)
     Task UnArchive(Octopus.Client.Model.CertificateResource)
@@ -8176,7 +8173,7 @@ Octopus.Client.Repositories.Async
     Task<ChannelResource> FindByName(Octopus.Client.Model.ProjectResource, String)
     Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ChannelResource)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ChannelResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32, Nullable<Int32>, String)
   }
   interface ICommunityActionTemplateRepository
     Octopus.Client.Repositories.Async.IGet<CommunityActionTemplateResource>
@@ -8192,7 +8189,7 @@ Octopus.Client.Repositories.Async
   }
   interface ICreate`1
   {
-    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object = null)
+    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object)
     Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, CancellationToken)
     Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object, CancellationToken)
   }
@@ -8204,7 +8201,7 @@ Octopus.Client.Repositories.Async
   interface IDashboardRepository
   {
     Task<DashboardResource> GetDashboard()
-    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions = IncludeCurrentDeploymentOnly)
+    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
   }
   interface IDefectsRepository
   {
@@ -8236,8 +8233,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.Async.IDelete<DeploymentResource>
   {
-    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32 = 0, Nullable<Int32> = null)
-    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32, Nullable<Int32>)
+    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32, Nullable<Int32>)
     Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource)
     Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
@@ -8267,9 +8264,9 @@ Octopus.Client.Repositories.Async
     Task<EnvironmentEditor> CreateOrModify(String)
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
-    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null)
+    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
     Task Sort(String[])
-    Task<EnvironmentsSummaryResource> Summary(String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, Nullable<Boolean> = False)
+    Task<EnvironmentsSummaryResource> Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
   }
   interface IEventRepository
     Octopus.Client.Repositories.Async.IGet<EventResource>
@@ -8279,8 +8276,8 @@ Octopus.Client.Repositories.Async
     Task<IReadOnlyList<EventCategoryResource>> GetCategories()
     Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes()
     Task<IReadOnlyList<EventGroupResource>> GetGroups()
-    Task<ResourceCollection<EventResource>> List(Int32 = 0, String = null, String = null, Boolean = False)
-    Task<ResourceCollection<EventResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Boolean = True, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null, Nullable<Int64> = null, Nullable<Int64> = null, String = null, String = null, String = null)
+    Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean)
+    Task<ResourceCollection<EventResource>> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -8301,10 +8298,10 @@ Octopus.Client.Repositories.Async
   interface IFindByName`1
     Octopus.Client.Repositories.Async.IPaginate<TResource>
   {
-    Task<TResource> FindByName(String, String = null, Object = null)
+    Task<TResource> FindByName(String, String, Object)
     Task<TResource> FindByName(String, CancellationToken)
     Task<TResource> FindByName(String, String, Object, CancellationToken)
-    Task<List<TResource>> FindByNames(IEnumerable<String>, String = null, Object = null)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object)
     Task<List<TResource>> FindByNames(IEnumerable<String>, CancellationToken)
     Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
@@ -8342,7 +8339,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<InterruptionResource>
   {
     Task<UserResource> GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Task<ResourceCollection<InterruptionResource>> List(Int32 = 0, Nullable<Int32> = null, Boolean = False, String = null)
+    Task<ResourceCollection<InterruptionResource>> List(Int32, Nullable<Int32>, Boolean, String)
     Task Submit(Octopus.Client.Model.InterruptionResource)
     Task TakeResponsibility(Octopus.Client.Model.InterruptionResource)
   }
@@ -8395,13 +8392,13 @@ Octopus.Client.Repositories.Async
   {
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineResource> Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
+    Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
     Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions)
     Task<List<MachineResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Task<ResourceCollection<MachineResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, String = null)
+    Task<ResourceCollection<MachineResource>> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
   }
   interface IMachineRoleRepository
   {
@@ -8429,16 +8426,16 @@ Octopus.Client.Repositories.Async
   }
   interface IPaginate`1
   {
-    Task<List<TResource>> FindAll(String = null, Object = null)
+    Task<List<TResource>> FindAll(String, Object)
     Task<List<TResource>> FindAll(CancellationToken)
     Task<List<TResource>> FindAll(String, Object, CancellationToken)
-    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String = null, Object = null)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, CancellationToken)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object, CancellationToken)
-    Task<TResource> FindOne(Func<TResource, Boolean>, String = null, Object = null)
+    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object)
     Task<TResource> FindOne(Func<TResource, Boolean>, CancellationToken)
     Task<TResource> FindOne(Func<TResource, Boolean>, String, Object, CancellationToken)
-    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String = null, Object = null)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object, CancellationToken)
   }
@@ -8479,7 +8476,7 @@ Octopus.Client.Repositories.Async
     Task<ConvertProjectToGitResponse> ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, CancellationToken)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -8504,19 +8501,19 @@ Octopus.Client.Repositories.Async
     Task<GitTagResource> GetGitTag(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource, CancellationToken)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32> = null)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32> = null)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32>)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32>)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
-    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
     Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
     Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
     Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
@@ -8550,12 +8547,12 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<ReleaseResource>
     Octopus.Client.Repositories.Async.IDelete<ReleaseResource>
   {
-    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean = False)
+    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean)
     Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean, CancellationToken)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, CancellationToken)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
-    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, CancellationToken)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
     Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
@@ -8573,7 +8570,7 @@ Octopus.Client.Repositories.Async
   }
   interface IRetentionPolicyRepository
   {
-    Task<TaskResource> ApplyNow(String = null)
+    Task<TaskResource> ApplyNow(String)
   }
   interface IRunbookProcessRepository
     Octopus.Client.Repositories.Async.IGet<RunbookProcessResource>
@@ -8603,7 +8600,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookRunResource>
   {
-    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
     Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
@@ -8616,9 +8613,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<RunbookSnapshotResource>
   {
     Task<RunbookSnapshotResource> Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
     Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
     Task<RunbookRunTemplateResource> GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
     Task<RunbookSnapshotResource> SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
   }
@@ -8689,28 +8686,28 @@ Octopus.Client.Repositories.Async
   {
     Task Cancel(Octopus.Client.Model.TaskResource)
     Task Cancel(Octopus.Client.Model.TaskResource, CancellationToken)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, CancellationToken, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
-    Task<TaskResource> ExecuteAdHocScript(String, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
-    Task<TaskResource> ExecuteAdHocScript(String, CancellationToken, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
-    Task<TaskResource> ExecuteBackup(String = null)
-    Task<TaskResource> ExecuteBackup(CancellationToken, String = null)
-    Task<TaskResource> ExecuteCalamariUpdate(String = null, String[] = null)
-    Task<TaskResource> ExecuteCalamariUpdate(CancellationToken, String = null, String[] = null)
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String = null)
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(CancellationToken, String = null)
-    Task<TaskResource> ExecuteHealthCheck(String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
-    Task<TaskResource> ExecuteHealthCheck(CancellationToken, String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
-    Task<TaskResource> ExecuteTentacleUpgrade(String = null, String = null, String[] = null, String = null, String = null, String[] = null)
-    Task<TaskResource> ExecuteTentacleUpgrade(CancellationToken, String = null, String = null, String[] = null, String = null, String = null, String[] = null)
-    Task<TaskResourceCollection> GetActiveWithSummary(Int32 = Int.MaxValue, Int32 = 0)
-    Task<TaskResourceCollection> GetActiveWithSummary(CancellationToken, Int32 = Int.MaxValue, Int32 = 0)
-    Task<List<TaskResource>> GetAllActive(Int32 = Int.MaxValue)
-    Task<List<TaskResource>> GetAllActive(CancellationToken, Int32 = Int.MaxValue)
-    Task<TaskResourceCollection> GetAllWithSummary(Int32 = Int.MaxValue, Int32 = 0)
-    Task<TaskResourceCollection> GetAllWithSummary(CancellationToken, Int32 = Int.MaxValue, Int32 = 0)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean> = null, Nullable<Int32> = null)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, CancellationToken, Nullable<Boolean> = null, Nullable<Int32> = null)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, CancellationToken, String[], String[], String[], String, Nullable<TargetType>)
+    Task<TaskResource> ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
+    Task<TaskResource> ExecuteAdHocScript(String, CancellationToken, String[], String[], String[], String, String, Nullable<TargetType>)
+    Task<TaskResource> ExecuteBackup(String)
+    Task<TaskResource> ExecuteBackup(CancellationToken, String)
+    Task<TaskResource> ExecuteCalamariUpdate(String, String[])
+    Task<TaskResource> ExecuteCalamariUpdate(CancellationToken, String, String[])
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String)
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(CancellationToken, String)
+    Task<TaskResource> ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
+    Task<TaskResource> ExecuteHealthCheck(CancellationToken, String, Int32, Int32, String, String[], String, String, String[])
+    Task<TaskResource> ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
+    Task<TaskResource> ExecuteTentacleUpgrade(CancellationToken, String, String, String[], String, String, String[])
+    Task<TaskResourceCollection> GetActiveWithSummary(Int32, Int32)
+    Task<TaskResourceCollection> GetActiveWithSummary(CancellationToken, Int32, Int32)
+    Task<List<TaskResource>> GetAllActive(Int32)
+    Task<List<TaskResource>> GetAllActive(CancellationToken, Int32)
+    Task<TaskResourceCollection> GetAllWithSummary(Int32, Int32)
+    Task<TaskResourceCollection> GetAllWithSummary(CancellationToken, Int32, Int32)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, CancellationToken, Nullable<Boolean>, Nullable<Int32>)
     Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
     Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource, CancellationToken)
     Task<String> GetRawOutputLog(Octopus.Client.Model.TaskResource)
@@ -8721,14 +8718,14 @@ Octopus.Client.Repositories.Async
     Task ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String, CancellationToken)
     Task Rerun(Octopus.Client.Model.TaskResource)
     Task Rerun(Octopus.Client.Model.TaskResource, CancellationToken)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, CancellationToken, Int32 = 4, Int32 = 0, Action<TaskResource[], CancellationToken> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Int32 = 0, Action<TaskResource[], CancellationToken> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Func<TaskResource[], Task> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Int32 = 0, Func<TaskResource[], CancellationToken, Task> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Nullable<TimeSpan> = null, Func<TaskResource[], Task> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Nullable<TimeSpan> = null, Func<TaskResource[], CancellationToken, Task> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, CancellationToken, Int32, Int32, Action<TaskResource[], CancellationToken>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Int32, Action<TaskResource[], CancellationToken>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Func<TaskResource[], Task>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Int32, Func<TaskResource[], CancellationToken, Task>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Func<TaskResource[], Task>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Nullable<TimeSpan>, Func<TaskResource[], CancellationToken, Task>)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.Async.ICreate<TeamResource>
@@ -8761,8 +8758,8 @@ Octopus.Client.Repositories.Async
     Task<TenantEditor> CreateOrModify(String)
     Task<TenantEditor> CreateOrModify(String, String)
     Task<TenantEditor> CreateOrModify(String, String, String)
-    Task<List<TenantResource>> FindAll(String, String[] = null, Int32 = Int.MaxValue)
-    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String = null, String = null, String = null)
+    Task<List<TenantResource>> FindAll(String, String[], Int32)
+    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String, String, String)
     Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource)
     Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
@@ -8799,8 +8796,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<UserResource>
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
-    Task<UserResource> Create(String, String, String = null, String = null)
-    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String = null, Nullable<DateTimeOffset> = null)
+    Task<UserResource> Create(String, String, String, String)
+    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -8812,7 +8809,7 @@ Octopus.Client.Repositories.Async
     Task RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     Task RevokeSessions(Octopus.Client.Model.UserResource)
     Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignIn(String, String, Boolean = False)
+    Task SignIn(String, String, Boolean)
     Task SignOut()
   }
   interface IUserRolesRepository
@@ -8834,15 +8831,15 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<VariableSetResource>
     Octopus.Client.Repositories.Async.IGetAll<VariableSetResource>
   {
-    Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String = null)
+    Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String)
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<String[]> GetVariableNames(String, String[], String = null)
+    Task<String[]> GetVariableNames(String, String[], String)
     Task<String[]> GetVariableNames(String, String[], CancellationToken)
     Task<String[]> GetVariableNames(String, String[], String, CancellationToken)
     Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String)
     Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String, CancellationToken)
-    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null)
+    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String, CancellationToken)
   }
@@ -8857,9 +8854,9 @@ Octopus.Client.Repositories.Async
   {
     Task<WorkerPoolEditor> CreateOrModify(String)
     Task<WorkerPoolEditor> CreateOrModify(String, String)
-    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, Nullable<Boolean> = False, String = null, String = null)
+    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
     Task Sort(String[])
-    Task<WorkerPoolsSummaryResource> Summary(String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, Nullable<Boolean> = False)
+    Task<WorkerPoolsSummaryResource> Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerResource>
@@ -8870,10 +8867,10 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<WorkerResource>
   {
     Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Task<WorkerResource> Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
+    Task<WorkerResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
     Task<List<WorkerResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Task<ResourceCollection<WorkerResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null)
+    Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
   }
   class SpaceScopedOperationOutsideOfCurrentSpaceContextException
     ISerializable

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -605,14 +605,17 @@ Octopus.Client
   {
     .ctor(String)
     .ctor(String, String)
-    .ctor(String, String, ICredentials)
-    .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
+    .ctor(String, String, ICredentials, Boolean)
+    .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean)
     String ApiKey { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.ILinkResolver OctopusServer { get; }
     IWebProxy Proxy { get; set; }
+    String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
   }
   class RepositoryScope
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -615,7 +615,7 @@ Octopus.Client
     IWebProxy Proxy { get; set; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
     static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String, ICredentials)
-    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String, ICredentials)
+    static Octopus.Client.OctopusServerEndpoint CreateWithBearerToken(String, String, ICredentials)
   }
   class RepositoryScope
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -605,8 +605,8 @@ Octopus.Client
   {
     .ctor(String)
     .ctor(String, String)
-    .ctor(String, String, ICredentials, Boolean)
-    .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean)
+    .ctor(String, String, ICredentials)
+    .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
     String ApiKey { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
@@ -614,8 +614,8 @@ Octopus.Client
     IWebProxy Proxy { get; set; }
     String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
-    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
-    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String, ICredentials)
+    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String, ICredentials)
   }
   class RepositoryScope
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -613,7 +613,7 @@ Octopus.Client
     IWebProxy Proxy { get; set; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
     static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String, ICredentials)
-    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String, ICredentials)
+    static Octopus.Client.OctopusServerEndpoint CreateWithBearerToken(String, String, ICredentials)
   }
   class RepositoryScope
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -603,8 +603,8 @@ Octopus.Client
   {
     .ctor(String)
     .ctor(String, String)
-    .ctor(String, String, ICredentials, Boolean)
-    .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean)
+    .ctor(String, String, ICredentials)
+    .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
     String ApiKey { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
@@ -612,8 +612,8 @@ Octopus.Client
     IWebProxy Proxy { get; set; }
     String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
-    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
-    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String, ICredentials)
+    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String, ICredentials)
   }
   class RepositoryScope
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -600,21 +600,21 @@ Octopus.Client
     Octopus.Client.TResponseResource ResponseResource { get; }
   }
   class OctopusServerEndpoint
-    {
-      .ctor(String)
-      .ctor(String, String)
-      .ctor(String, String, ICredentials, Boolean)
-      .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean)
-      String ApiKey { get; }
-      ICredentials Credentials { get; }
-      Boolean IsUsingSecureConnection { get; }
-      Octopus.Client.ILinkResolver OctopusServer { get; }
-      IWebProxy Proxy { get; set; }
-      String Token { get; }
-      Octopus.Client.OctopusServerEndpoint AsUser(String)
-      static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
-      static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
-    }
+  {
+    .ctor(String)
+    .ctor(String, String)
+    .ctor(String, String, ICredentials, Boolean)
+    .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean)
+    String ApiKey { get; }
+    ICredentials Credentials { get; }
+    Boolean IsUsingSecureConnection { get; }
+    Octopus.Client.ILinkResolver OctopusServer { get; }
+    IWebProxy Proxy { get; set; }
+    String Token { get; }
+    Octopus.Client.OctopusServerEndpoint AsUser(String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
+  }
   class RepositoryScope
   {
     Octopus.Client.T Apply(Func<SpaceResource, T>, Func<T>, Func<T>)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -600,18 +600,21 @@ Octopus.Client
     Octopus.Client.TResponseResource ResponseResource { get; }
   }
   class OctopusServerEndpoint
-  {
-    .ctor(String)
-    .ctor(String, String)
-    .ctor(String, String, ICredentials)
-    .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
-    String ApiKey { get; }
-    ICredentials Credentials { get; }
-    Boolean IsUsingSecureConnection { get; }
-    Octopus.Client.ILinkResolver OctopusServer { get; }
-    IWebProxy Proxy { get; set; }
-    Octopus.Client.OctopusServerEndpoint AsUser(String)
-  }
+    {
+      .ctor(String)
+      .ctor(String, String)
+      .ctor(String, String, ICredentials, Boolean)
+      .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean)
+      String ApiKey { get; }
+      ICredentials Credentials { get; }
+      Boolean IsUsingSecureConnection { get; }
+      Octopus.Client.ILinkResolver OctopusServer { get; }
+      IWebProxy Proxy { get; set; }
+      String Token { get; }
+      Octopus.Client.OctopusServerEndpoint AsUser(String)
+      static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
+      static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
+    }
   class RepositoryScope
   {
     Octopus.Client.T Apply(Func<SpaceResource, T>, Func<T>, Func<T>)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3,7 +3,7 @@ Octopus.Client
   class DefaultLinkResolver
     Octopus.Client.ILinkResolver
   {
-    .ctor(Uri, String = "/api")
+    .ctor(Uri, String)
     Boolean IsUsingSecureConnection { get; }
     Uri Resolve(String)
     String ToString()
@@ -30,54 +30,54 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Task<TResource> Create(String, Octopus.Client.TResource, Object = null)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task<TResource> Create(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task Delete(String, Object = null, Object = null)
+    Task Delete(String, Object, Object)
     Task Delete(String, CancellationToken)
     Task Delete(String, Object, Object, CancellationToken)
     Task<TResponse> Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object = null)
+    Task<TResource> Get(String, Object)
     Task<TResource> Get(String, CancellationToken)
     Task<TResource> Get(String, Object, CancellationToken)
-    Task<Stream> GetContent(String, Object = null)
+    Task<Stream> GetContent(String, Object)
     Task<Stream> GetContent(String, CancellationToken)
     Task<Stream> GetContent(String, Object, CancellationToken)
-    Task<ResourceCollection<TResource>> List(String, Object = null)
+    Task<ResourceCollection<TResource>> List(String, Object)
     Task<ResourceCollection<TResource>> List(String, CancellationToken)
     Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object = null)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object)
     Task<IReadOnlyList<TResource>> ListAll(String, CancellationToken)
     Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
-    Task Post(String, Octopus.Client.TResource, Object = null)
+    Task Post(String, Octopus.Client.TResource, Object)
     Task Post(String, Octopus.Client.TResource, CancellationToken)
     Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object = null)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
     Task<TResponse> Post(String, Octopus.Client.TResource, CancellationToken)
     Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Post(String)
     Task Post(String, CancellationToken)
     Task Put(String, Octopus.Client.TResource)
     Task Put(String, Octopus.Client.TResource, CancellationToken)
-    Task Put(String, Octopus.Client.TResource, Object = null)
+    Task Put(String, Octopus.Client.TResource, Object)
     Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Put(String)
     Task Put(String, CancellationToken)
     Task PutContent(String, Stream)
     Task PutContent(String, Stream, CancellationToken)
-    Uri QualifyUri(String, Object = null)
+    Uri QualifyUri(String, Object)
     Task<TResponse> Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
     Task SignOut()
     Task SignOut(CancellationToken)
-    Task<TResource> Update(String, Octopus.Client.TResource, Object = null)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object)
     Task<TResource> Update(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
@@ -95,34 +95,34 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object = null)
-    void Delete(String, Object = null, Object = null)
+    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
+    void Delete(String, Object, Object)
     Octopus.Client.TResponse Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
-    Octopus.Client.TResource Get(String, Object = null)
-    Stream GetContent(String, Object = null)
-    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object = null)
-    IReadOnlyList<TResource> ListAll(String, Object = null)
+    Octopus.Client.TResource Get(String, Object)
+    Stream GetContent(String, Object)
+    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object)
+    IReadOnlyList<TResource> ListAll(String, Object)
     void Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     void Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
-    void Post(String, Octopus.Client.TResource, Object = null)
-    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object = null)
+    void Post(String, Octopus.Client.TResource, Object)
+    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object)
     void Post(String)
     void Put(String, Octopus.Client.TResource)
     void Put(String)
-    void Put(String, Octopus.Client.TResource, Object = null)
+    void Put(String, Octopus.Client.TResource, Object)
     void PutContent(String, Stream)
-    Uri QualifyUri(String, Object = null)
+    Uri QualifyUri(String, Object)
     Octopus.Client.TResponse Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignOut()
-    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object = null)
+    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object)
   }
   interface IOctopusClientFactory
   {
-    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
-    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
   }
   interface IOctopusCommonAsyncRepository
   {
@@ -303,56 +303,56 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
-    Task<TResource> Create(String, Octopus.Client.TResource, Object = null)
+    static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object)
     Task<TResource> Create(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task Delete(String, Object = null, Object = null)
+    Task Delete(String, Object, Object)
     Task Delete(String, CancellationToken)
     Task Delete(String, Object, Object, CancellationToken)
     void Dispose()
     Task<TResponse> Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object = null)
+    Task<TResource> Get(String, Object)
     Task<TResource> Get(String, CancellationToken)
     Task<TResource> Get(String, Object, CancellationToken)
-    Task<Stream> GetContent(String, Object = null)
+    Task<Stream> GetContent(String, Object)
     Task<Stream> GetContent(String, CancellationToken)
     Task<Stream> GetContent(String, Object, CancellationToken)
-    Task<ResourceCollection<TResource>> List(String, Object = null)
+    Task<ResourceCollection<TResource>> List(String, Object)
     Task<ResourceCollection<TResource>> List(String, CancellationToken)
     Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object = null)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object)
     Task<IReadOnlyList<TResource>> ListAll(String, CancellationToken)
     Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
-    Task Post(String, Octopus.Client.TResource, Object = null)
+    Task Post(String, Octopus.Client.TResource, Object)
     Task Post(String, Octopus.Client.TResource, CancellationToken)
     Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object = null)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
     Task<TResponse> Post(String, Octopus.Client.TResource, CancellationToken)
     Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Post(String)
     Task Post(String, CancellationToken)
     Task Put(String, Octopus.Client.TResource)
     Task Put(String, Octopus.Client.TResource, CancellationToken)
-    Task Put(String, Octopus.Client.TResource, Object = null)
+    Task Put(String, Octopus.Client.TResource, Object)
     Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Put(String)
     Task Put(String, CancellationToken)
     Task PutContent(String, Stream)
     Task PutContent(String, Stream, CancellationToken)
-    Uri QualifyUri(String, Object = null)
+    Uri QualifyUri(String, Object)
     Task<TResponse> Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
     Task SignOut()
     Task SignOut(CancellationToken)
-    Task<TResource> Update(String, Octopus.Client.TResource, Object = null)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object)
     Task<TResource> Update(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
@@ -362,7 +362,7 @@ Octopus.Client
     Octopus.Client.IOctopusCommonAsyncRepository
     Octopus.Client.IOctopusSystemAsyncRepository
   {
-    .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope = null)
+    .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
     Octopus.Client.Repositories.Async.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.Async.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.Async.IArchivedEventFileRepository ArchivedEventFiles { get; }
@@ -444,42 +444,42 @@ Octopus.Client
     event Action<WebRequest> BeforeSendingHttpRequest
     event Action<OctopusResponse> ReceivedOctopusResponse
     event Action<OctopusRequest> SendingOctopusRequest
-    .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object = null)
-    void Delete(String, Object = null, Object = null)
+    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
+    void Delete(String, Object, Object)
     void Dispose()
     Octopus.Client.TResponse Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
-    Octopus.Client.TResource Get(String, Object = null)
-    Stream GetContent(String, Object = null)
+    Octopus.Client.TResource Get(String, Object)
+    Stream GetContent(String, Object)
     void Initialize()
-    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object = null)
-    IReadOnlyList<TResource> ListAll(String, Object = null)
+    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object)
+    IReadOnlyList<TResource> ListAll(String, Object)
     void Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     void Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
-    void Post(String, Octopus.Client.TResource, Object = null)
-    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object = null)
+    void Post(String, Octopus.Client.TResource, Object)
+    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object)
     void Post(String)
     void Put(String, Octopus.Client.TResource)
     void Put(String)
-    void Put(String, Octopus.Client.TResource, Object = null)
+    void Put(String, Octopus.Client.TResource, Object)
     void PutContent(String, Stream)
-    Uri QualifyUri(String, Object = null)
+    Uri QualifyUri(String, Object)
     Octopus.Client.TResponse Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignOut()
-    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object = null)
+    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object)
   }
   class OctopusClientFactory
     Octopus.Client.IOctopusClientFactory
   {
     .ctor()
-    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
-    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
   }
   class OctopusClientOptions
   {
@@ -499,7 +499,7 @@ Octopus.Client
   {
     .ctor(Octopus.Client.OctopusServerEndpoint)
     .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.RepositoryScope)
-    .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope = null)
+    .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope)
     Octopus.Client.Repositories.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.IArchivedEventFileRepository ArchivedEventFiles { get; }
@@ -572,7 +572,7 @@ Octopus.Client
   }
   abstract class OctopusRepositoryExtensions
   {
-    static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope = null)
+    static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
     static Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.IOctopusAsyncRepository, Octopus.Client.Model.SpaceResource)
     static Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.IOctopusRepository, Octopus.Client.Model.SpaceResource)
     static Octopus.Client.IOctopusSystemAsyncRepository ForSystem(Octopus.Client.IOctopusAsyncRepository)
@@ -580,7 +580,7 @@ Octopus.Client
   }
   class OctopusRequest
   {
-    .ctor(String, Uri, Object = null)
+    .ctor(String, Uri, Object)
     String Method { get; }
     Object RequestResource { get; }
     Uri Uri { get; }
@@ -603,17 +603,14 @@ Octopus.Client
   {
     .ctor(String)
     .ctor(String, String)
-    .ctor(String, String, ICredentials, Boolean = False)
-    .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean = False)
+    .ctor(String, String, ICredentials)
+    .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
     String ApiKey { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.ILinkResolver OctopusServer { get; }
     IWebProxy Proxy { get; set; }
-    String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
-    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
-    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
   }
   class RepositoryScope
   {
@@ -845,7 +842,7 @@ Octopus.Client.Editors
     .ctor(Octopus.Client.Repositories.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode> = null)
+    Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.MachineEditor Customize(Action<MachineResource>)
     Octopus.Client.Editors.MachineEditor Save()
   }
@@ -869,7 +866,7 @@ Octopus.Client.Editors
     Octopus.Client.Editors.VariableSetEditor Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
+    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Octopus.Client.Editors.ProjectEditor Customize(Action<ProjectResource>)
     Octopus.Client.Editors.ProjectEditor IncludingLibraryVariableSets(Octopus.Client.Model.LibraryVariableSetResource[])
     Octopus.Client.Editors.ProjectEditor Save()
@@ -952,7 +949,7 @@ Octopus.Client.Editors
   {
     .ctor(Octopus.Client.Repositories.ITagSetRepository)
     Octopus.Client.Model.TagSetResource Instance { get; }
-    Octopus.Client.Editors.TagSetEditor AddOrUpdateTag(String, String = null, String = "#6e6e6e")
+    Octopus.Client.Editors.TagSetEditor AddOrUpdateTag(String, String, String)
     Octopus.Client.Editors.TagSetEditor ClearTags()
     Octopus.Client.Editors.TagSetEditor CreateOrModify(String)
     Octopus.Client.Editors.TagSetEditor CreateOrModify(String, String)
@@ -971,7 +968,7 @@ Octopus.Client.Editors
     Octopus.Client.Editors.TenantEditor ClearTags()
     Octopus.Client.Editors.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
-    Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String = null)
+    Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String)
     Octopus.Client.Editors.TenantEditor Customize(Action<TenantResource>)
     Octopus.Client.Editors.TenantEditor Save()
     Octopus.Client.Editors.TenantEditor SetLogo(String)
@@ -1152,7 +1149,7 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IEnvironmentRepository)
     Octopus.Client.Model.EnvironmentResource Instance { get; }
     Task<EnvironmentEditor> CreateOrModify(String)
-    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean = False)
+    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Octopus.Client.Editors.Async.EnvironmentEditor Customize(Action<EnvironmentResource>)
     Task<EnvironmentEditor> Save()
@@ -1201,7 +1198,7 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode> = null)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.Async.MachineEditor Customize(Action<MachineResource>)
     Task<MachineEditor> Save()
   }
@@ -1225,7 +1222,7 @@ Octopus.Client.Editors.Async
     Task<VariableSetEditor> Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.ProjectEditor Customize(Action<ProjectResource>)
@@ -1310,7 +1307,7 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.ITagSetRepository)
     Octopus.Client.Model.TagSetResource Instance { get; }
-    Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String = null, String = "#6e6e6e")
+    Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String, String)
     Octopus.Client.Editors.Async.TagSetEditor ClearTags()
     Task<TagSetEditor> CreateOrModify(String)
     Task<TagSetEditor> CreateOrModify(String, String)
@@ -1329,7 +1326,7 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.TenantEditor ClearTags()
     Octopus.Client.Editors.Async.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Task<TenantEditor> CreateOrModify(String)
-    Task<TenantEditor> CreateOrModify(String, String, String = null)
+    Task<TenantEditor> CreateOrModify(String, String, String)
     Octopus.Client.Editors.Async.TenantEditor Customize(Action<TenantResource>)
     Task<TenantEditor> Save()
     Task<TenantEditor> SetLogo(String)
@@ -1653,7 +1650,7 @@ Octopus.Client.Logging
     .ctor(Object, IntPtr)
     IAsyncResult BeginInvoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception, Object[], AsyncCallback, Object)
     Boolean EndInvoke(IAsyncResult)
-    Boolean Invoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception = null, Object[])
+    Boolean Invoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception, Object[])
   }
   LogLevel
   {
@@ -2877,7 +2874,7 @@ Octopus.Client.Model
     Octopus.Client.Model.DeploymentStepResource ClearActions()
     Octopus.Client.Model.DeploymentActionResource FindAction(String)
     Octopus.Client.Model.DeploymentStepResource RemoveAction(String)
-    Octopus.Client.Model.DeploymentStepResource RequirePackagesToBeAcquired(Boolean = True)
+    Octopus.Client.Model.DeploymentStepResource RequirePackagesToBeAcquired(Boolean)
     Octopus.Client.Model.DeploymentStepResource TargetingRoles(String[])
     Octopus.Client.Model.DeploymentStepResource WithCondition(Octopus.Client.Model.DeploymentStepCondition)
     Octopus.Client.Model.DeploymentStepResource WithPackageRequirement(Octopus.Client.Model.DeploymentStepPackageRequirement)
@@ -3200,14 +3197,14 @@ Octopus.Client.Model
     void Clear()
     Boolean Contains(Octopus.Client.Model.GitDependencyResource)
     void CopyTo(Octopus.Client.Model.GitDependencyResource[], Int32)
-    Octopus.Client.Model.GitDependencyResource GetByName(String = "")
+    Octopus.Client.Model.GitDependencyResource GetByName(String)
     IEnumerator<GitDependencyResource> GetEnumerator()
     Boolean Remove(Octopus.Client.Model.GitDependencyResource)
     Boolean TryGetByName(String, Octopus.Client.Model.GitDependencyResource&)
   }
   class GitDependencyResource
   {
-    .ctor(String, String, String, String = null, String[] = null, String = null, String = null)
+    .ctor(String, String, String, String, String[], String, String)
     String DefaultBranch { get; }
     String[] FilePathFilters { get; }
     String GitCredentialId { get; }
@@ -5102,7 +5099,7 @@ Octopus.Client.Model
   {
     .ctor(String)
     .ctor(Octopus.Client.Model.SemanticVersion)
-    .ctor(Version, String = null, String = null)
+    .ctor(Version, String, String)
     .ctor(Int32, Int32, Int32)
     .ctor(Int32, Int32, Int32, String)
     .ctor(Int32, Int32, Int32, String, String)
@@ -5110,16 +5107,16 @@ Octopus.Client.Model
     .ctor(Int32, Int32, Int32, Int32)
     .ctor(Int32, Int32, Int32, Int32, String, String)
     .ctor(Int32, Int32, Int32, Int32, IEnumerable<String>, String)
-    .ctor(Version, IEnumerable<String>, String, String, Boolean = False)
+    .ctor(Version, IEnumerable<String>, String, String, Boolean)
     Boolean IsLegacyVersion { get; }
     Boolean IsSemVer2 { get; }
     String OriginalString { get; }
     Int32 Revision { get; }
     Version Version { get; }
     static String IncrementRelease(String)
-    static Octopus.Client.Model.SemanticVersion Parse(String, Boolean = False)
+    static Octopus.Client.Model.SemanticVersion Parse(String, Boolean)
     String ToString()
-    static Boolean TryParse(String, Octopus.Client.Model.SemanticVersion&, Boolean = False)
+    static Boolean TryParse(String, Octopus.Client.Model.SemanticVersion&, Boolean)
     static Boolean TryParseStrict(String, Octopus.Client.Model.SemanticVersion&)
   }
   class SemanticVersionComparer
@@ -5405,7 +5402,7 @@ Octopus.Client.Model
     Int32 SortOrder { get; set; }
     String SpaceId { get; set; }
     IList<TagResource> Tags { get; set; }
-    Octopus.Client.Model.TagSetResource AddOrUpdateTag(String, String = null, String = "#6e6e6e")
+    Octopus.Client.Model.TagSetResource AddOrUpdateTag(String, String, String)
     Octopus.Client.Model.TagSetResource RemoveTag(String)
   }
   TargetType
@@ -6373,7 +6370,7 @@ Octopus.Client.Model.DeploymentProcess
   class InlineScriptActionFromFileInAssembly
     Octopus.Client.Model.DeploymentProcess.ScriptAction
   {
-    .ctor(String, Assembly = null)
+    .ctor(String, Assembly)
     Assembly ResourceAssembly { get; }
     String ResourceName { get; }
     Octopus.Client.Model.DeploymentProcess.ScriptSource Source { get; }
@@ -6385,7 +6382,7 @@ Octopus.Client.Model.DeploymentProcess
     Octopus.Client.Model.DeploymentProcess.ScriptSource Source { get; }
     Octopus.Client.Model.ScriptSyntax Syntax { get; }
     static Octopus.Client.Model.DeploymentProcess.InlineScriptAction InlineScript(Octopus.Client.Model.ScriptSyntax, String)
-    static Octopus.Client.Model.DeploymentProcess.InlineScriptActionFromFileInAssembly InlineScriptFromFileInAssembly(String, Assembly = null)
+    static Octopus.Client.Model.DeploymentProcess.InlineScriptActionFromFileInAssembly InlineScriptFromFileInAssembly(String, Assembly)
   }
   class ScriptActionFromFileInPackage
     Octopus.Client.Model.DeploymentProcess.ScriptAction
@@ -6697,7 +6694,7 @@ Octopus.Client.Model.Forms
 {
   class Button
   {
-    .ctor(String, String = null)
+    .ctor(String, String)
     String Text { get; }
     Object Value { get; }
   }
@@ -6717,20 +6714,20 @@ Octopus.Client.Model.Forms
   class Form
   {
     .ctor()
-    .ctor(IEnumerable<FormElement> = null, IDictionary<String, String> = null)
+    .ctor(IEnumerable<FormElement>, IDictionary<String, String>)
     List<FormElement> Elements { get; }
     Dictionary<String, String> Values { get; }
   }
   class FormElement
   {
-    .ctor(String, Octopus.Client.Model.Forms.Control, Boolean = False)
+    .ctor(String, Octopus.Client.Model.Forms.Control, Boolean)
     Octopus.Client.Model.Forms.Control Control { get; }
     Boolean IsValueRequired { get; }
     String Name { get; }
   }
   abstract class FormExtensions
   {
-    static void AddElement(Octopus.Client.Model.Forms.Form, String, Octopus.Client.Model.Forms.Control, String = null, Boolean = False)
+    static void AddElement(Octopus.Client.Model.Forms.Form, String, Octopus.Client.Model.Forms.Control, String, Boolean)
     static Object GetCoercedValue(Octopus.Client.Model.Forms.Form, String)
     static void SetValue(Octopus.Client.Model.Forms.Form, String, String)
     static void UpdateValues(Octopus.Client.Model.Forms.Form, IDictionary<String, String>)
@@ -7352,8 +7349,8 @@ Octopus.Client.Repositories
     void Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     void DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Get(String)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32 = 0, Int32 = 30)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32, Int32)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
   }
@@ -7367,15 +7364,15 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    List<TAccount> FindAllOfType(Object = null)
+    List<TAccount> FindAllOfType(Object)
     Octopus.Client.Repositories.TAccount FindByNameOfType(String)
     List<TAccount> FindByNamesOfType(IEnumerable<String>)
-    List<TAccount> FindManyOfType(Func<TAccount, Boolean>, Object = null)
-    Octopus.Client.Repositories.TAccount FindOneOfType(Func<TAccount, Boolean>, Object = null)
+    List<TAccount> FindManyOfType(Func<TAccount, Boolean>, Object)
+    Octopus.Client.Repositories.TAccount FindOneOfType(Func<TAccount, Boolean>, Object)
     Octopus.Client.Model.Accounts.Usages.AccountUsageResource GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
     Octopus.Client.Repositories.TAccount GetOfType(String)
     List<TAccount> GetOfType(String[])
-    void PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object = null)
+    void PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
     Octopus.Client.Repositories.TAccount RefreshOfType(Octopus.Client.Repositories.TAccount)
   }
   interface IActionTemplateRepository
@@ -7396,7 +7393,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<ArchivedEventFileResource>
   {
     Stream GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
-    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32, Nullable<Int32>)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.IPaginate<ArtifactResource>
@@ -7419,8 +7416,8 @@ Octopus.Client.Repositories
     void Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     void DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Get(String)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32 = 0, Int32 = 30)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32, Int32)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation)
   }
@@ -7429,9 +7426,9 @@ Octopus.Client.Repositories
     void DeletePackage(Octopus.Client.Model.PackageResource)
     void DeletePackages(IReadOnlyList<PackageResource>)
     Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String, String)
-    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32 = 0, Int32 = 30)
-    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32 = 0, Int32 = 30)
-    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean = False)
+    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean, Boolean)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
@@ -7458,8 +7455,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<CertificateResource>
   {
     void Archive(Octopus.Client.Model.CertificateResource)
-    Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat> = null, String = null, Boolean = False)
-    Stream ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean = False, Octopus.Client.Model.CertificateExportPemOptions = PrimaryOnly)
+    Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
+    Stream ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
     Octopus.Client.Model.CertificateConfigurationResource GetOctopusCertificate()
     Octopus.Client.Model.CertificateResource Replace(Octopus.Client.Model.CertificateResource, String, String)
     void UnArchive(Octopus.Client.Model.CertificateResource)
@@ -7490,7 +7487,7 @@ Octopus.Client.Repositories
   }
   interface ICreate`1
   {
-    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object = null)
+    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object)
   }
   interface IDashboardConfigurationRepository
   {
@@ -7500,7 +7497,7 @@ Octopus.Client.Repositories
   interface IDashboardRepository
   {
     Octopus.Client.Model.DashboardResource GetDashboard()
-    Octopus.Client.Model.DashboardResource GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions = IncludeCurrentDeploymentOnly)
+    Octopus.Client.Model.DashboardResource GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
   }
   interface IDefectsRepository
   {
@@ -7527,8 +7524,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.IDelete<DeploymentResource>
   {
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindAll(String[], String[], Int32 = 0, Nullable<Int32> = null)
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindBy(String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindAll(String[], String[], Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindBy(String[], String[], Int32, Nullable<Int32>)
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.DeploymentResource)
     void Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     void Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
@@ -7553,9 +7550,9 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String)
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String, String)
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String, String, Boolean)
-    List<MachineResource> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null)
+    List<MachineResource> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
     void Sort(String[])
-    Octopus.Client.Model.EnvironmentsSummaryResource Summary(String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, Nullable<Boolean> = False)
+    Octopus.Client.Model.EnvironmentsSummaryResource Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
   }
   interface IEventRepository
     Octopus.Client.Repositories.IGet<EventResource>
@@ -7565,8 +7562,8 @@ Octopus.Client.Repositories
     IReadOnlyList<EventCategoryResource> GetCategories()
     IReadOnlyList<DocumentTypeResource> GetDocumentTypes()
     IReadOnlyList<EventGroupResource> GetGroups()
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32 = 0, String = null, String = null, Boolean = False)
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Boolean = True, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null, Nullable<Int64> = null, Nullable<Int64> = null, String = null, String = null, String = null)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, String, String, Boolean)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -7586,13 +7583,13 @@ Octopus.Client.Repositories
   interface IFindByName`1
     Octopus.Client.Repositories.IPaginate<TResource>
   {
-    Octopus.Client.Repositories.TResource FindByName(String, String = null, Object = null)
-    List<TResource> FindByNames(IEnumerable<String>, String = null, Object = null)
+    Octopus.Client.Repositories.TResource FindByName(String, String, Object)
+    List<TResource> FindByNames(IEnumerable<String>, String, Object)
   }
   interface IFindByPartialName`1
     Octopus.Client.Repositories.IPaginate<TResource>
   {
-    List<TResource> FindByPartialName(String, String = null, Object = null)
+    List<TResource> FindByPartialName(String, String, Object)
   }
   interface IGetAll`1
   {
@@ -7608,7 +7605,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<InterruptionResource>
   {
     Octopus.Client.Model.UserResource GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Octopus.Client.Model.ResourceCollection<InterruptionResource> List(Int32 = 0, Nullable<Int32> = null, Boolean = False, String = null)
+    Octopus.Client.Model.ResourceCollection<InterruptionResource> List(Int32, Nullable<Int32>, Boolean, String)
     void Submit(Octopus.Client.Model.InterruptionResource)
     void TakeResponsibility(Octopus.Client.Model.InterruptionResource)
   }
@@ -7662,13 +7659,13 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Octopus.Client.Model.MachineResource Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
+    Octopus.Client.Model.MachineResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
     Octopus.Client.Model.MachineResource Discover(Octopus.Client.Model.DiscoverMachineOptions)
     List<MachineResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.MachineResource)
-    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType> = null)
+    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType>)
     IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, String = null)
+    Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
   }
   interface IMachineRoleRepository
   {
@@ -7695,10 +7692,10 @@ Octopus.Client.Repositories
   }
   interface IPaginate`1
   {
-    List<TResource> FindAll(String = null, Object = null)
-    List<TResource> FindMany(Func<TResource, Boolean>, String = null, Object = null)
-    Octopus.Client.Repositories.TResource FindOne(Func<TResource, Boolean>, String = null, Object = null)
-    void Paginate(Func<ResourceCollection<TResource>, Boolean>, String = null, Object = null)
+    List<TResource> FindAll(String, Object)
+    List<TResource> FindMany(Func<TResource, Boolean>, String, Object)
+    Octopus.Client.Repositories.TResource FindOne(Func<TResource, Boolean>, String, Object)
+    void Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
   }
   interface IPerformanceConfigurationRepository
   {
@@ -7730,7 +7727,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.Git.ConvertProjectToGitResponse ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String)
     Octopus.Client.Model.Git.ConvertProjectToGitResponse ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String, String)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
+    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource)
     IReadOnlyList<ReleaseResource> GetAllReleases(Octopus.Client.Model.ProjectResource)
     IReadOnlyList<RunbookResource> GetAllRunbooks(Octopus.Client.Model.ProjectResource)
@@ -7744,10 +7741,10 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<GitTagResource> GetGitTags(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ProgressionResource GetProgression(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ReleaseResource GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
-    Octopus.Client.Model.ResourceCollection<RunbookResource> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Octopus.Client.Model.ResourceCollection<RunbookResource> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Octopus.Client.Model.RunbookSnapshotResource GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> GetTriggers(Octopus.Client.Model.ProjectResource)
     void SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
   }
@@ -7777,9 +7774,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IModify<ReleaseResource>
     Octopus.Client.Repositories.IDelete<ReleaseResource>
   {
-    Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean = False)
-    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean)
+    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.DeploymentPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
     Octopus.Client.Model.LifecycleProgressionResource GetProgression(Octopus.Client.Model.ReleaseResource)
     Octopus.Client.Model.DeploymentTemplateResource GetTemplate(Octopus.Client.Model.ReleaseResource)
@@ -7821,7 +7818,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.IDelete<RunbookRunResource>
   {
-    Octopus.Client.Model.ResourceCollection<RunbookRunResource> FindBy(String[], String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<RunbookRunResource> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.RunbookRunResource)
     void Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     void Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
@@ -7834,9 +7831,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<RunbookSnapshotResource>
   {
     Octopus.Client.Model.RunbookSnapshotResource Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.RunbookRunPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Octopus.Client.Model.ResourceCollection<RunbookRunResource> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<RunbookRunResource> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
     Octopus.Client.Model.RunbookRunTemplateResource GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
     Octopus.Client.Model.RunbookSnapshotResource SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
   }
@@ -7906,25 +7903,25 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICanExtendSpaceContext<ITaskRepository>
   {
     void Cancel(Octopus.Client.Model.TaskResource)
-    Octopus.Client.Model.TaskResource ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
-    Octopus.Client.Model.TaskResource ExecuteAdHocScript(String, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
-    Octopus.Client.Model.TaskResource ExecuteBackup(String = null)
-    Octopus.Client.Model.TaskResource ExecuteCalamariUpdate(String = null, String[] = null)
-    Octopus.Client.Model.TaskResource ExecuteCommunityActionTemplatesSynchronisation(String = null)
-    Octopus.Client.Model.TaskResource ExecuteHealthCheck(String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
-    Octopus.Client.Model.TaskResource ExecuteTentacleUpgrade(String = null, String = null, String[] = null, String = null, String = null, String[] = null)
-    Octopus.Client.Model.TaskResourceCollection GetActiveWithSummary(Int32 = Int.MaxValue, Int32 = 0)
-    List<TaskResource> GetAllActive(Int32 = Int.MaxValue)
-    Octopus.Client.Model.TaskResourceCollection GetAllWithSummary(Int32 = Int.MaxValue, Int32 = 0)
-    Octopus.Client.Model.TaskDetailsResource GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean> = null, Nullable<Int32> = null)
+    Octopus.Client.Model.TaskResource ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
+    Octopus.Client.Model.TaskResource ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
+    Octopus.Client.Model.TaskResource ExecuteBackup(String)
+    Octopus.Client.Model.TaskResource ExecuteCalamariUpdate(String, String[])
+    Octopus.Client.Model.TaskResource ExecuteCommunityActionTemplatesSynchronisation(String)
+    Octopus.Client.Model.TaskResource ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
+    Octopus.Client.Model.TaskResource ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
+    Octopus.Client.Model.TaskResourceCollection GetActiveWithSummary(Int32, Int32)
+    List<TaskResource> GetAllActive(Int32)
+    Octopus.Client.Model.TaskResourceCollection GetAllWithSummary(Int32, Int32)
+    Octopus.Client.Model.TaskDetailsResource GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
     IReadOnlyList<TaskResource> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
     String GetRawOutputLog(Octopus.Client.Model.TaskResource)
     Octopus.Client.Model.TaskTypeResource[] GetTaskTypes()
     void ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String)
     void Rerun(Octopus.Client.Model.TaskResource)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource, Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Nullable<TimeSpan> = null, Action<TaskResource[]> = null)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Action<TaskResource[]>)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.ICreate<TeamResource>
@@ -7957,8 +7954,8 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String)
-    List<TenantResource> FindAll(String, String[] = null, Int32 = Int.MaxValue)
-    List<TenantsMissingVariablesResource> GetMissingVariables(String = null, String = null, String = null)
+    List<TenantResource> FindAll(String, String[], Int32)
+    List<TenantsMissingVariablesResource> GetMissingVariables(String, String, String)
     Octopus.Client.Model.TenantVariableResource GetVariables(Octopus.Client.Model.TenantResource)
     Octopus.Client.Model.TenantVariableResource ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     void SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
@@ -7994,8 +7991,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<UserResource>
     Octopus.Client.Repositories.ICreate<UserResource>
   {
-    Octopus.Client.Model.UserResource Create(String, String, String = null, String = null)
-    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String = null, Nullable<DateTimeOffset> = null)
+    Octopus.Client.Model.UserResource Create(String, String, String, String)
+    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     Octopus.Client.Model.UserResource FindByUsername(String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -8007,7 +8004,7 @@ Octopus.Client.Repositories
     void RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     void RevokeSessions(Octopus.Client.Model.UserResource)
     void SignIn(Octopus.Client.Model.LoginCommand)
-    void SignIn(String, String, Boolean = False)
+    void SignIn(String, String, Boolean)
     void SignOut()
   }
   interface IUserRolesRepository
@@ -8029,10 +8026,10 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IModify<VariableSetResource>
     Octopus.Client.Repositories.IGetAll<VariableSetResource>
   {
-    Octopus.Client.Model.VariableSetResource Get(Octopus.Client.Model.ProjectResource, String = null)
-    String[] GetVariableNames(String, String[], String = null)
+    Octopus.Client.Model.VariableSetResource Get(Octopus.Client.Model.ProjectResource, String)
+    String[] GetVariableNames(String, String[], String)
     Octopus.Client.Model.VariableSetResource GetVariablePreview(String, String, String, String, String, String, String, String)
-    Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null)
+    Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
@@ -8045,9 +8042,9 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.WorkerPoolEditor CreateOrModify(String)
     Octopus.Client.Editors.WorkerPoolEditor CreateOrModify(String, String)
-    List<WorkerResource> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, Nullable<Boolean> = False, String = null, String = null)
+    List<WorkerResource> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
     void Sort(String[])
-    Octopus.Client.Model.WorkerPoolsSummaryResource Summary(String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, Nullable<Boolean> = False)
+    Octopus.Client.Model.WorkerPoolsSummaryResource Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.IFindByName<WorkerResource>
@@ -8058,10 +8055,10 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<WorkerResource>
   {
     Octopus.Client.Editors.WorkerEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Octopus.Client.Model.WorkerResource Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
+    Octopus.Client.Model.WorkerResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
     List<WorkerResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null)
+    Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
   }
   class PerformanceConfigurationRepository
     Octopus.Client.Repositories.IPerformanceConfigurationRepository
@@ -8092,15 +8089,15 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    Task<List<TAccount>> FindAllOfType(Object = null)
+    Task<List<TAccount>> FindAllOfType(Object)
     Task<TAccount> FindByNameOfType(String)
     Task<List<TAccount>> FindByNamesOfType(IEnumerable<String>)
-    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object = null)
-    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object = null)
+    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object)
+    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object)
     Task<AccountUsageResource> GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
     Task<TAccount> GetOfType(String)
     Task<List<TAccount>> GetOfType(String[])
-    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object = null)
+    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
     Task<TAccount> RefreshOfType(Octopus.Client.Repositories.Async.TAccount)
   }
   interface IActionTemplateRepository
@@ -8121,7 +8118,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ArchivedEventFileResource>
   {
     Task<Stream> GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
-    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32, Nullable<Int32>)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.Async.IPaginate<ArtifactResource>
@@ -8144,8 +8141,8 @@ Octopus.Client.Repositories.Async
     Task Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Task<OctopusPackageVersionBuildInformationMappedResource> Get(String)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32 = 0, Int32 = 30)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32 = 0, Int32 = 30)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32, Int32)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32, Int32)
     Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
     Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Boolean)
   }
@@ -8154,9 +8151,9 @@ Octopus.Client.Repositories.Async
     Task DeletePackage(Octopus.Client.Model.PackageResource)
     Task DeletePackages(IReadOnlyList<PackageResource>)
     Task<PackageFromBuiltInFeedResource> GetPackage(String, String)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32 = 0, Int32 = 30)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32 = 0, Int32 = 30)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean = False)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
@@ -8183,8 +8180,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<CertificateResource>
   {
     Task Archive(Octopus.Client.Model.CertificateResource)
-    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat> = null, String = null, Boolean = False)
-    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean = False, Octopus.Client.Model.CertificateExportPemOptions = PrimaryOnly)
+    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
+    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
     Task<CertificateConfigurationResource> GetOctopusCertificate()
     Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String)
     Task UnArchive(Octopus.Client.Model.CertificateResource)
@@ -8201,7 +8198,7 @@ Octopus.Client.Repositories.Async
     Task<ChannelResource> FindByName(Octopus.Client.Model.ProjectResource, String)
     Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ChannelResource)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ChannelResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32, Nullable<Int32>, String)
   }
   interface ICommunityActionTemplateRepository
     Octopus.Client.Repositories.Async.IGet<CommunityActionTemplateResource>
@@ -8217,7 +8214,7 @@ Octopus.Client.Repositories.Async
   }
   interface ICreate`1
   {
-    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object = null)
+    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object)
     Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, CancellationToken)
     Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object, CancellationToken)
   }
@@ -8229,7 +8226,7 @@ Octopus.Client.Repositories.Async
   interface IDashboardRepository
   {
     Task<DashboardResource> GetDashboard()
-    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions = IncludeCurrentDeploymentOnly)
+    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
   }
   interface IDefectsRepository
   {
@@ -8261,8 +8258,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.Async.IDelete<DeploymentResource>
   {
-    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32 = 0, Nullable<Int32> = null)
-    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32, Nullable<Int32>)
+    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32, Nullable<Int32>)
     Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource)
     Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
@@ -8292,9 +8289,9 @@ Octopus.Client.Repositories.Async
     Task<EnvironmentEditor> CreateOrModify(String)
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
-    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null)
+    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
     Task Sort(String[])
-    Task<EnvironmentsSummaryResource> Summary(String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, Nullable<Boolean> = False)
+    Task<EnvironmentsSummaryResource> Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
   }
   interface IEventRepository
     Octopus.Client.Repositories.Async.IGet<EventResource>
@@ -8304,8 +8301,8 @@ Octopus.Client.Repositories.Async
     Task<IReadOnlyList<EventCategoryResource>> GetCategories()
     Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes()
     Task<IReadOnlyList<EventGroupResource>> GetGroups()
-    Task<ResourceCollection<EventResource>> List(Int32 = 0, String = null, String = null, Boolean = False)
-    Task<ResourceCollection<EventResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Boolean = True, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null, Nullable<Int64> = null, Nullable<Int64> = null, String = null, String = null, String = null)
+    Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean)
+    Task<ResourceCollection<EventResource>> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -8326,10 +8323,10 @@ Octopus.Client.Repositories.Async
   interface IFindByName`1
     Octopus.Client.Repositories.Async.IPaginate<TResource>
   {
-    Task<TResource> FindByName(String, String = null, Object = null)
+    Task<TResource> FindByName(String, String, Object)
     Task<TResource> FindByName(String, CancellationToken)
     Task<TResource> FindByName(String, String, Object, CancellationToken)
-    Task<List<TResource>> FindByNames(IEnumerable<String>, String = null, Object = null)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object)
     Task<List<TResource>> FindByNames(IEnumerable<String>, CancellationToken)
     Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
@@ -8367,7 +8364,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<InterruptionResource>
   {
     Task<UserResource> GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Task<ResourceCollection<InterruptionResource>> List(Int32 = 0, Nullable<Int32> = null, Boolean = False, String = null)
+    Task<ResourceCollection<InterruptionResource>> List(Int32, Nullable<Int32>, Boolean, String)
     Task Submit(Octopus.Client.Model.InterruptionResource)
     Task TakeResponsibility(Octopus.Client.Model.InterruptionResource)
   }
@@ -8420,13 +8417,13 @@ Octopus.Client.Repositories.Async
   {
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineResource> Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
+    Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
     Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions)
     Task<List<MachineResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Task<ResourceCollection<MachineResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, String = null)
+    Task<ResourceCollection<MachineResource>> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
   }
   interface IMachineRoleRepository
   {
@@ -8454,16 +8451,16 @@ Octopus.Client.Repositories.Async
   }
   interface IPaginate`1
   {
-    Task<List<TResource>> FindAll(String = null, Object = null)
+    Task<List<TResource>> FindAll(String, Object)
     Task<List<TResource>> FindAll(CancellationToken)
     Task<List<TResource>> FindAll(String, Object, CancellationToken)
-    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String = null, Object = null)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, CancellationToken)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object, CancellationToken)
-    Task<TResource> FindOne(Func<TResource, Boolean>, String = null, Object = null)
+    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object)
     Task<TResource> FindOne(Func<TResource, Boolean>, CancellationToken)
     Task<TResource> FindOne(Func<TResource, Boolean>, String, Object, CancellationToken)
-    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String = null, Object = null)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object, CancellationToken)
   }
@@ -8504,7 +8501,7 @@ Octopus.Client.Repositories.Async
     Task<ConvertProjectToGitResponse> ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, CancellationToken)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -8529,19 +8526,19 @@ Octopus.Client.Repositories.Async
     Task<GitTagResource> GetGitTag(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource, CancellationToken)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32> = null)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32> = null)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32>)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32>)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
-    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
     Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
     Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
     Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
@@ -8575,12 +8572,12 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<ReleaseResource>
     Octopus.Client.Repositories.Async.IDelete<ReleaseResource>
   {
-    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean = False)
+    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean)
     Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean, CancellationToken)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, CancellationToken)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
-    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, CancellationToken)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
     Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
@@ -8598,7 +8595,7 @@ Octopus.Client.Repositories.Async
   }
   interface IRetentionPolicyRepository
   {
-    Task<TaskResource> ApplyNow(String = null)
+    Task<TaskResource> ApplyNow(String)
   }
   interface IRunbookProcessRepository
     Octopus.Client.Repositories.Async.IGet<RunbookProcessResource>
@@ -8628,7 +8625,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookRunResource>
   {
-    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
     Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
@@ -8641,9 +8638,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<RunbookSnapshotResource>
   {
     Task<RunbookSnapshotResource> Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
     Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
     Task<RunbookRunTemplateResource> GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
     Task<RunbookSnapshotResource> SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
   }
@@ -8714,28 +8711,28 @@ Octopus.Client.Repositories.Async
   {
     Task Cancel(Octopus.Client.Model.TaskResource)
     Task Cancel(Octopus.Client.Model.TaskResource, CancellationToken)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, CancellationToken, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
-    Task<TaskResource> ExecuteAdHocScript(String, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
-    Task<TaskResource> ExecuteAdHocScript(String, CancellationToken, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
-    Task<TaskResource> ExecuteBackup(String = null)
-    Task<TaskResource> ExecuteBackup(CancellationToken, String = null)
-    Task<TaskResource> ExecuteCalamariUpdate(String = null, String[] = null)
-    Task<TaskResource> ExecuteCalamariUpdate(CancellationToken, String = null, String[] = null)
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String = null)
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(CancellationToken, String = null)
-    Task<TaskResource> ExecuteHealthCheck(String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
-    Task<TaskResource> ExecuteHealthCheck(CancellationToken, String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
-    Task<TaskResource> ExecuteTentacleUpgrade(String = null, String = null, String[] = null, String = null, String = null, String[] = null)
-    Task<TaskResource> ExecuteTentacleUpgrade(CancellationToken, String = null, String = null, String[] = null, String = null, String = null, String[] = null)
-    Task<TaskResourceCollection> GetActiveWithSummary(Int32 = Int.MaxValue, Int32 = 0)
-    Task<TaskResourceCollection> GetActiveWithSummary(CancellationToken, Int32 = Int.MaxValue, Int32 = 0)
-    Task<List<TaskResource>> GetAllActive(Int32 = Int.MaxValue)
-    Task<List<TaskResource>> GetAllActive(CancellationToken, Int32 = Int.MaxValue)
-    Task<TaskResourceCollection> GetAllWithSummary(Int32 = Int.MaxValue, Int32 = 0)
-    Task<TaskResourceCollection> GetAllWithSummary(CancellationToken, Int32 = Int.MaxValue, Int32 = 0)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean> = null, Nullable<Int32> = null)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, CancellationToken, Nullable<Boolean> = null, Nullable<Int32> = null)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, CancellationToken, String[], String[], String[], String, Nullable<TargetType>)
+    Task<TaskResource> ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
+    Task<TaskResource> ExecuteAdHocScript(String, CancellationToken, String[], String[], String[], String, String, Nullable<TargetType>)
+    Task<TaskResource> ExecuteBackup(String)
+    Task<TaskResource> ExecuteBackup(CancellationToken, String)
+    Task<TaskResource> ExecuteCalamariUpdate(String, String[])
+    Task<TaskResource> ExecuteCalamariUpdate(CancellationToken, String, String[])
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String)
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(CancellationToken, String)
+    Task<TaskResource> ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
+    Task<TaskResource> ExecuteHealthCheck(CancellationToken, String, Int32, Int32, String, String[], String, String, String[])
+    Task<TaskResource> ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
+    Task<TaskResource> ExecuteTentacleUpgrade(CancellationToken, String, String, String[], String, String, String[])
+    Task<TaskResourceCollection> GetActiveWithSummary(Int32, Int32)
+    Task<TaskResourceCollection> GetActiveWithSummary(CancellationToken, Int32, Int32)
+    Task<List<TaskResource>> GetAllActive(Int32)
+    Task<List<TaskResource>> GetAllActive(CancellationToken, Int32)
+    Task<TaskResourceCollection> GetAllWithSummary(Int32, Int32)
+    Task<TaskResourceCollection> GetAllWithSummary(CancellationToken, Int32, Int32)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, CancellationToken, Nullable<Boolean>, Nullable<Int32>)
     Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
     Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource, CancellationToken)
     Task<String> GetRawOutputLog(Octopus.Client.Model.TaskResource)
@@ -8746,14 +8743,14 @@ Octopus.Client.Repositories.Async
     Task ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String, CancellationToken)
     Task Rerun(Octopus.Client.Model.TaskResource)
     Task Rerun(Octopus.Client.Model.TaskResource, CancellationToken)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, CancellationToken, Int32 = 4, Int32 = 0, Action<TaskResource[], CancellationToken> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Int32 = 0, Action<TaskResource[], CancellationToken> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Func<TaskResource[], Task> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Int32 = 0, Func<TaskResource[], CancellationToken, Task> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Nullable<TimeSpan> = null, Func<TaskResource[], Task> = null)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Nullable<TimeSpan> = null, Func<TaskResource[], CancellationToken, Task> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, CancellationToken, Int32, Int32, Action<TaskResource[], CancellationToken>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Int32, Action<TaskResource[], CancellationToken>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Func<TaskResource[], Task>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Int32, Func<TaskResource[], CancellationToken, Task>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Func<TaskResource[], Task>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Nullable<TimeSpan>, Func<TaskResource[], CancellationToken, Task>)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.Async.ICreate<TeamResource>
@@ -8786,8 +8783,8 @@ Octopus.Client.Repositories.Async
     Task<TenantEditor> CreateOrModify(String)
     Task<TenantEditor> CreateOrModify(String, String)
     Task<TenantEditor> CreateOrModify(String, String, String)
-    Task<List<TenantResource>> FindAll(String, String[] = null, Int32 = Int.MaxValue)
-    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String = null, String = null, String = null)
+    Task<List<TenantResource>> FindAll(String, String[], Int32)
+    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String, String, String)
     Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource)
     Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
@@ -8824,8 +8821,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<UserResource>
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
-    Task<UserResource> Create(String, String, String = null, String = null)
-    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String = null, Nullable<DateTimeOffset> = null)
+    Task<UserResource> Create(String, String, String, String)
+    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -8837,7 +8834,7 @@ Octopus.Client.Repositories.Async
     Task RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     Task RevokeSessions(Octopus.Client.Model.UserResource)
     Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignIn(String, String, Boolean = False)
+    Task SignIn(String, String, Boolean)
     Task SignOut()
   }
   interface IUserRolesRepository
@@ -8859,15 +8856,15 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<VariableSetResource>
     Octopus.Client.Repositories.Async.IGetAll<VariableSetResource>
   {
-    Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String = null)
+    Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String)
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<String[]> GetVariableNames(String, String[], String = null)
+    Task<String[]> GetVariableNames(String, String[], String)
     Task<String[]> GetVariableNames(String, String[], CancellationToken)
     Task<String[]> GetVariableNames(String, String[], String, CancellationToken)
     Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String)
     Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String, CancellationToken)
-    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null)
+    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String, CancellationToken)
   }
@@ -8882,9 +8879,9 @@ Octopus.Client.Repositories.Async
   {
     Task<WorkerPoolEditor> CreateOrModify(String)
     Task<WorkerPoolEditor> CreateOrModify(String, String)
-    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, Nullable<Boolean> = False, String = null, String = null)
+    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
     Task Sort(String[])
-    Task<WorkerPoolsSummaryResource> Summary(String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, Nullable<Boolean> = False)
+    Task<WorkerPoolsSummaryResource> Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerResource>
@@ -8895,10 +8892,10 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<WorkerResource>
   {
     Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Task<WorkerResource> Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
+    Task<WorkerResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
     Task<List<WorkerResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Task<ResourceCollection<WorkerResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null)
+    Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
   }
   class SpaceScopedOperationOutsideOfCurrentSpaceContextException
     ISerializable

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3,7 +3,7 @@ Octopus.Client
   class DefaultLinkResolver
     Octopus.Client.ILinkResolver
   {
-    .ctor(Uri, String)
+    .ctor(Uri, String = "/api")
     Boolean IsUsingSecureConnection { get; }
     Uri Resolve(String)
     String ToString()
@@ -30,54 +30,54 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Task<TResource> Create(String, Octopus.Client.TResource, Object)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object = null)
     Task<TResource> Create(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task Delete(String, Object, Object)
+    Task Delete(String, Object = null, Object = null)
     Task Delete(String, CancellationToken)
     Task Delete(String, Object, Object, CancellationToken)
     Task<TResponse> Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object)
+    Task<TResource> Get(String, Object = null)
     Task<TResource> Get(String, CancellationToken)
     Task<TResource> Get(String, Object, CancellationToken)
-    Task<Stream> GetContent(String, Object)
+    Task<Stream> GetContent(String, Object = null)
     Task<Stream> GetContent(String, CancellationToken)
     Task<Stream> GetContent(String, Object, CancellationToken)
-    Task<ResourceCollection<TResource>> List(String, Object)
+    Task<ResourceCollection<TResource>> List(String, Object = null)
     Task<ResourceCollection<TResource>> List(String, CancellationToken)
     Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object = null)
     Task<IReadOnlyList<TResource>> ListAll(String, CancellationToken)
     Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
-    Task Post(String, Octopus.Client.TResource, Object)
+    Task Post(String, Octopus.Client.TResource, Object = null)
     Task Post(String, Octopus.Client.TResource, CancellationToken)
     Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object = null)
     Task<TResponse> Post(String, Octopus.Client.TResource, CancellationToken)
     Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Post(String)
     Task Post(String, CancellationToken)
     Task Put(String, Octopus.Client.TResource)
     Task Put(String, Octopus.Client.TResource, CancellationToken)
-    Task Put(String, Octopus.Client.TResource, Object)
+    Task Put(String, Octopus.Client.TResource, Object = null)
     Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Put(String)
     Task Put(String, CancellationToken)
     Task PutContent(String, Stream)
     Task PutContent(String, Stream, CancellationToken)
-    Uri QualifyUri(String, Object)
+    Uri QualifyUri(String, Object = null)
     Task<TResponse> Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
     Task SignOut()
     Task SignOut(CancellationToken)
-    Task<TResource> Update(String, Octopus.Client.TResource, Object)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object = null)
     Task<TResource> Update(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
@@ -95,34 +95,34 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
-    void Delete(String, Object, Object)
+    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object = null)
+    void Delete(String, Object = null, Object = null)
     Octopus.Client.TResponse Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
-    Octopus.Client.TResource Get(String, Object)
-    Stream GetContent(String, Object)
-    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object)
-    IReadOnlyList<TResource> ListAll(String, Object)
+    Octopus.Client.TResource Get(String, Object = null)
+    Stream GetContent(String, Object = null)
+    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object = null)
+    IReadOnlyList<TResource> ListAll(String, Object = null)
     void Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     void Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
-    void Post(String, Octopus.Client.TResource, Object)
-    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object)
+    void Post(String, Octopus.Client.TResource, Object = null)
+    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object = null)
     void Post(String)
     void Put(String, Octopus.Client.TResource)
     void Put(String)
-    void Put(String, Octopus.Client.TResource, Object)
+    void Put(String, Octopus.Client.TResource, Object = null)
     void PutContent(String, Stream)
-    Uri QualifyUri(String, Object)
+    Uri QualifyUri(String, Object = null)
     Octopus.Client.TResponse Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignOut()
-    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object)
+    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object = null)
   }
   interface IOctopusClientFactory
   {
-    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
-    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
   }
   interface IOctopusCommonAsyncRepository
   {
@@ -303,56 +303,56 @@ Octopus.Client
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusAsyncRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
-    Task<TResource> Create(String, Octopus.Client.TResource, Object)
+    static Task<IOctopusAsyncClient> Create(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Task<TResource> Create(String, Octopus.Client.TResource, Object = null)
     Task<TResource> Create(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Create(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task Delete(String, Object, Object)
+    Task Delete(String, Object = null, Object = null)
     Task Delete(String, CancellationToken)
     Task Delete(String, Object, Object, CancellationToken)
     void Dispose()
     Task<TResponse> Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
-    Task<TResource> Get(String, Object)
+    Task<TResource> Get(String, Object = null)
     Task<TResource> Get(String, CancellationToken)
     Task<TResource> Get(String, Object, CancellationToken)
-    Task<Stream> GetContent(String, Object)
+    Task<Stream> GetContent(String, Object = null)
     Task<Stream> GetContent(String, CancellationToken)
     Task<Stream> GetContent(String, Object, CancellationToken)
-    Task<ResourceCollection<TResource>> List(String, Object)
+    Task<ResourceCollection<TResource>> List(String, Object = null)
     Task<ResourceCollection<TResource>> List(String, CancellationToken)
     Task<ResourceCollection<TResource>> List(String, Object, CancellationToken)
-    Task<IReadOnlyList<TResource>> ListAll(String, Object)
+    Task<IReadOnlyList<TResource>> ListAll(String, Object = null)
     Task<IReadOnlyList<TResource>> ListAll(String, CancellationToken)
     Task<IReadOnlyList<TResource>> ListAll(String, Object, CancellationToken)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
     Task Paginate(String, Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
-    Task Post(String, Octopus.Client.TResource, Object)
+    Task Post(String, Octopus.Client.TResource, Object = null)
     Task Post(String, Octopus.Client.TResource, CancellationToken)
     Task Post(String, Octopus.Client.TResource, Object, CancellationToken)
-    Task<TResponse> Post(String, Octopus.Client.TResource, Object)
+    Task<TResponse> Post(String, Octopus.Client.TResource, Object = null)
     Task<TResponse> Post(String, Octopus.Client.TResource, CancellationToken)
     Task<TResponse> Post(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Post(String)
     Task Post(String, CancellationToken)
     Task Put(String, Octopus.Client.TResource)
     Task Put(String, Octopus.Client.TResource, CancellationToken)
-    Task Put(String, Octopus.Client.TResource, Object)
+    Task Put(String, Octopus.Client.TResource, Object = null)
     Task Put(String, Octopus.Client.TResource, Object, CancellationToken)
     Task Put(String)
     Task Put(String, CancellationToken)
     Task PutContent(String, Stream)
     Task PutContent(String, Stream, CancellationToken)
-    Uri QualifyUri(String, Object)
+    Uri QualifyUri(String, Object = null)
     Task<TResponse> Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     Task SignIn(Octopus.Client.Model.LoginCommand)
     Task SignIn(Octopus.Client.Model.LoginCommand, CancellationToken)
     Task SignOut()
     Task SignOut(CancellationToken)
-    Task<TResource> Update(String, Octopus.Client.TResource, Object)
+    Task<TResource> Update(String, Octopus.Client.TResource, Object = null)
     Task<TResource> Update(String, Octopus.Client.TResource, CancellationToken)
     Task<TResource> Update(String, Octopus.Client.TResource, Object, CancellationToken)
   }
@@ -362,7 +362,7 @@ Octopus.Client
     Octopus.Client.IOctopusCommonAsyncRepository
     Octopus.Client.IOctopusSystemAsyncRepository
   {
-    .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
+    .ctor(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope = null)
     Octopus.Client.Repositories.Async.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.Async.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.Async.IArchivedEventFileRepository ArchivedEventFiles { get; }
@@ -444,42 +444,42 @@ Octopus.Client
     event Action<WebRequest> BeforeSendingHttpRequest
     event Action<OctopusResponse> ReceivedOctopusResponse
     event Action<OctopusRequest> SendingOctopusRequest
-    .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.IOctopusRepository Repository { get; }
     Octopus.Client.Model.RootResource RootDocument { get; }
-    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object)
-    void Delete(String, Object, Object)
+    Octopus.Client.TResource Create(String, Octopus.Client.TResource, Object = null)
+    void Delete(String, Object = null, Object = null)
     void Dispose()
     Octopus.Client.TResponse Do(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>, CancellationToken)
     Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
     Octopus.Client.IOctopusSystemRepository ForSystem()
-    Octopus.Client.TResource Get(String, Object)
-    Stream GetContent(String, Object)
+    Octopus.Client.TResource Get(String, Object = null)
+    Stream GetContent(String, Object = null)
     void Initialize()
-    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object)
-    IReadOnlyList<TResource> ListAll(String, Object)
+    Octopus.Client.Model.ResourceCollection<TResource> List(String, Object = null)
+    IReadOnlyList<TResource> ListAll(String, Object = null)
     void Paginate(String, Object, Func<ResourceCollection<TResource>, Boolean>)
     void Paginate(String, Func<ResourceCollection<TResource>, Boolean>)
-    void Post(String, Octopus.Client.TResource, Object)
-    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object)
+    void Post(String, Octopus.Client.TResource, Object = null)
+    Octopus.Client.TResponse Post(String, Octopus.Client.TResource, Object = null)
     void Post(String)
     void Put(String, Octopus.Client.TResource)
     void Put(String)
-    void Put(String, Octopus.Client.TResource, Object)
+    void Put(String, Octopus.Client.TResource, Object = null)
     void PutContent(String, Stream)
-    Uri QualifyUri(String, Object)
+    Uri QualifyUri(String, Object = null)
     Octopus.Client.TResponse Request(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>, CancellationToken)
     void SignIn(Octopus.Client.Model.LoginCommand)
     void SignOut()
-    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object)
+    Octopus.Client.TResource Update(String, Octopus.Client.TResource, Object = null)
   }
   class OctopusClientFactory
     Octopus.Client.IOctopusClientFactory
   {
     .ctor()
-    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
-    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions)
+    Task<IOctopusAsyncClient> CreateAsyncClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
+    Octopus.Client.IOctopusClient CreateClient(Octopus.Client.OctopusServerEndpoint, Octopus.Client.OctopusClientOptions = null)
   }
   class OctopusClientOptions
   {
@@ -499,7 +499,7 @@ Octopus.Client
   {
     .ctor(Octopus.Client.OctopusServerEndpoint)
     .ctor(Octopus.Client.OctopusServerEndpoint, Octopus.Client.RepositoryScope)
-    .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope)
+    .ctor(Octopus.Client.IOctopusClient, Octopus.Client.RepositoryScope = null)
     Octopus.Client.Repositories.IAccountRepository Accounts { get; }
     Octopus.Client.Repositories.IActionTemplateRepository ActionTemplates { get; }
     Octopus.Client.Repositories.IArchivedEventFileRepository ArchivedEventFiles { get; }
@@ -572,7 +572,7 @@ Octopus.Client
   }
   abstract class OctopusRepositoryExtensions
   {
-    static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
+    static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope = null)
     static Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.IOctopusAsyncRepository, Octopus.Client.Model.SpaceResource)
     static Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.IOctopusRepository, Octopus.Client.Model.SpaceResource)
     static Octopus.Client.IOctopusSystemAsyncRepository ForSystem(Octopus.Client.IOctopusAsyncRepository)
@@ -580,7 +580,7 @@ Octopus.Client
   }
   class OctopusRequest
   {
-    .ctor(String, Uri, Object)
+    .ctor(String, Uri, Object = null)
     String Method { get; }
     Object RequestResource { get; }
     Uri Uri { get; }
@@ -603,14 +603,17 @@ Octopus.Client
   {
     .ctor(String)
     .ctor(String, String)
-    .ctor(String, String, ICredentials)
-    .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
+    .ctor(String, String, ICredentials, Boolean = False)
+    .ctor(Octopus.Client.ILinkResolver, String, ICredentials, Boolean = False)
     String ApiKey { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.ILinkResolver OctopusServer { get; }
     IWebProxy Proxy { get; set; }
+    String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String)
+    static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String)
   }
   class RepositoryScope
   {
@@ -842,7 +845,7 @@ Octopus.Client.Editors
     .ctor(Octopus.Client.Repositories.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
+    Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode> = null)
     Octopus.Client.Editors.MachineEditor Customize(Action<MachineResource>)
     Octopus.Client.Editors.MachineEditor Save()
   }
@@ -866,7 +869,7 @@ Octopus.Client.Editors
     Octopus.Client.Editors.VariableSetEditor Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
     Octopus.Client.Editors.ProjectEditor Customize(Action<ProjectResource>)
     Octopus.Client.Editors.ProjectEditor IncludingLibraryVariableSets(Octopus.Client.Model.LibraryVariableSetResource[])
     Octopus.Client.Editors.ProjectEditor Save()
@@ -949,7 +952,7 @@ Octopus.Client.Editors
   {
     .ctor(Octopus.Client.Repositories.ITagSetRepository)
     Octopus.Client.Model.TagSetResource Instance { get; }
-    Octopus.Client.Editors.TagSetEditor AddOrUpdateTag(String, String, String)
+    Octopus.Client.Editors.TagSetEditor AddOrUpdateTag(String, String = null, String = "#6e6e6e")
     Octopus.Client.Editors.TagSetEditor ClearTags()
     Octopus.Client.Editors.TagSetEditor CreateOrModify(String)
     Octopus.Client.Editors.TagSetEditor CreateOrModify(String, String)
@@ -968,7 +971,7 @@ Octopus.Client.Editors
     Octopus.Client.Editors.TenantEditor ClearTags()
     Octopus.Client.Editors.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
-    Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String)
+    Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String = null)
     Octopus.Client.Editors.TenantEditor Customize(Action<TenantResource>)
     Octopus.Client.Editors.TenantEditor Save()
     Octopus.Client.Editors.TenantEditor SetLogo(String)
@@ -1149,7 +1152,7 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IEnvironmentRepository)
     Octopus.Client.Model.EnvironmentResource Instance { get; }
     Task<EnvironmentEditor> CreateOrModify(String)
-    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
+    Task<EnvironmentEditor> CreateOrModify(String, String, Boolean = False)
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Octopus.Client.Editors.Async.EnvironmentEditor Customize(Action<EnvironmentResource>)
     Task<EnvironmentEditor> Save()
@@ -1198,7 +1201,7 @@ Octopus.Client.Editors.Async
     .ctor(Octopus.Client.Repositories.Async.IMachineRepository)
     Octopus.Client.Model.MachineResource Instance { get; }
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
+    Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode> = null)
     Octopus.Client.Editors.Async.MachineEditor Customize(Action<MachineResource>)
     Task<MachineEditor> Save()
   }
@@ -1222,7 +1225,7 @@ Octopus.Client.Editors.Async
     Task<VariableSetEditor> Variables { get; }
     Octopus.Client.Model.IVariableTemplateContainerEditor<ProjectResource> VariableTemplates { get; }
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Octopus.Client.Editors.Async.ProjectEditor Customize(Action<ProjectResource>)
@@ -1307,7 +1310,7 @@ Octopus.Client.Editors.Async
   {
     .ctor(Octopus.Client.Repositories.Async.ITagSetRepository)
     Octopus.Client.Model.TagSetResource Instance { get; }
-    Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String, String)
+    Octopus.Client.Editors.Async.TagSetEditor AddOrUpdateTag(String, String = null, String = "#6e6e6e")
     Octopus.Client.Editors.Async.TagSetEditor ClearTags()
     Task<TagSetEditor> CreateOrModify(String)
     Task<TagSetEditor> CreateOrModify(String, String)
@@ -1326,7 +1329,7 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.TenantEditor ClearTags()
     Octopus.Client.Editors.Async.TenantEditor ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Task<TenantEditor> CreateOrModify(String)
-    Task<TenantEditor> CreateOrModify(String, String, String)
+    Task<TenantEditor> CreateOrModify(String, String, String = null)
     Octopus.Client.Editors.Async.TenantEditor Customize(Action<TenantResource>)
     Task<TenantEditor> Save()
     Task<TenantEditor> SetLogo(String)
@@ -1650,7 +1653,7 @@ Octopus.Client.Logging
     .ctor(Object, IntPtr)
     IAsyncResult BeginInvoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception, Object[], AsyncCallback, Object)
     Boolean EndInvoke(IAsyncResult)
-    Boolean Invoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception, Object[])
+    Boolean Invoke(Octopus.Client.Logging.LogLevel, Func<String>, Exception = null, Object[])
   }
   LogLevel
   {
@@ -2874,7 +2877,7 @@ Octopus.Client.Model
     Octopus.Client.Model.DeploymentStepResource ClearActions()
     Octopus.Client.Model.DeploymentActionResource FindAction(String)
     Octopus.Client.Model.DeploymentStepResource RemoveAction(String)
-    Octopus.Client.Model.DeploymentStepResource RequirePackagesToBeAcquired(Boolean)
+    Octopus.Client.Model.DeploymentStepResource RequirePackagesToBeAcquired(Boolean = True)
     Octopus.Client.Model.DeploymentStepResource TargetingRoles(String[])
     Octopus.Client.Model.DeploymentStepResource WithCondition(Octopus.Client.Model.DeploymentStepCondition)
     Octopus.Client.Model.DeploymentStepResource WithPackageRequirement(Octopus.Client.Model.DeploymentStepPackageRequirement)
@@ -3197,14 +3200,14 @@ Octopus.Client.Model
     void Clear()
     Boolean Contains(Octopus.Client.Model.GitDependencyResource)
     void CopyTo(Octopus.Client.Model.GitDependencyResource[], Int32)
-    Octopus.Client.Model.GitDependencyResource GetByName(String)
+    Octopus.Client.Model.GitDependencyResource GetByName(String = "")
     IEnumerator<GitDependencyResource> GetEnumerator()
     Boolean Remove(Octopus.Client.Model.GitDependencyResource)
     Boolean TryGetByName(String, Octopus.Client.Model.GitDependencyResource&)
   }
   class GitDependencyResource
   {
-    .ctor(String, String, String, String, String[], String, String)
+    .ctor(String, String, String, String = null, String[] = null, String = null, String = null)
     String DefaultBranch { get; }
     String[] FilePathFilters { get; }
     String GitCredentialId { get; }
@@ -5099,7 +5102,7 @@ Octopus.Client.Model
   {
     .ctor(String)
     .ctor(Octopus.Client.Model.SemanticVersion)
-    .ctor(Version, String, String)
+    .ctor(Version, String = null, String = null)
     .ctor(Int32, Int32, Int32)
     .ctor(Int32, Int32, Int32, String)
     .ctor(Int32, Int32, Int32, String, String)
@@ -5107,16 +5110,16 @@ Octopus.Client.Model
     .ctor(Int32, Int32, Int32, Int32)
     .ctor(Int32, Int32, Int32, Int32, String, String)
     .ctor(Int32, Int32, Int32, Int32, IEnumerable<String>, String)
-    .ctor(Version, IEnumerable<String>, String, String, Boolean)
+    .ctor(Version, IEnumerable<String>, String, String, Boolean = False)
     Boolean IsLegacyVersion { get; }
     Boolean IsSemVer2 { get; }
     String OriginalString { get; }
     Int32 Revision { get; }
     Version Version { get; }
     static String IncrementRelease(String)
-    static Octopus.Client.Model.SemanticVersion Parse(String, Boolean)
+    static Octopus.Client.Model.SemanticVersion Parse(String, Boolean = False)
     String ToString()
-    static Boolean TryParse(String, Octopus.Client.Model.SemanticVersion&, Boolean)
+    static Boolean TryParse(String, Octopus.Client.Model.SemanticVersion&, Boolean = False)
     static Boolean TryParseStrict(String, Octopus.Client.Model.SemanticVersion&)
   }
   class SemanticVersionComparer
@@ -5402,7 +5405,7 @@ Octopus.Client.Model
     Int32 SortOrder { get; set; }
     String SpaceId { get; set; }
     IList<TagResource> Tags { get; set; }
-    Octopus.Client.Model.TagSetResource AddOrUpdateTag(String, String, String)
+    Octopus.Client.Model.TagSetResource AddOrUpdateTag(String, String = null, String = "#6e6e6e")
     Octopus.Client.Model.TagSetResource RemoveTag(String)
   }
   TargetType
@@ -6370,7 +6373,7 @@ Octopus.Client.Model.DeploymentProcess
   class InlineScriptActionFromFileInAssembly
     Octopus.Client.Model.DeploymentProcess.ScriptAction
   {
-    .ctor(String, Assembly)
+    .ctor(String, Assembly = null)
     Assembly ResourceAssembly { get; }
     String ResourceName { get; }
     Octopus.Client.Model.DeploymentProcess.ScriptSource Source { get; }
@@ -6382,7 +6385,7 @@ Octopus.Client.Model.DeploymentProcess
     Octopus.Client.Model.DeploymentProcess.ScriptSource Source { get; }
     Octopus.Client.Model.ScriptSyntax Syntax { get; }
     static Octopus.Client.Model.DeploymentProcess.InlineScriptAction InlineScript(Octopus.Client.Model.ScriptSyntax, String)
-    static Octopus.Client.Model.DeploymentProcess.InlineScriptActionFromFileInAssembly InlineScriptFromFileInAssembly(String, Assembly)
+    static Octopus.Client.Model.DeploymentProcess.InlineScriptActionFromFileInAssembly InlineScriptFromFileInAssembly(String, Assembly = null)
   }
   class ScriptActionFromFileInPackage
     Octopus.Client.Model.DeploymentProcess.ScriptAction
@@ -6694,7 +6697,7 @@ Octopus.Client.Model.Forms
 {
   class Button
   {
-    .ctor(String, String)
+    .ctor(String, String = null)
     String Text { get; }
     Object Value { get; }
   }
@@ -6714,20 +6717,20 @@ Octopus.Client.Model.Forms
   class Form
   {
     .ctor()
-    .ctor(IEnumerable<FormElement>, IDictionary<String, String>)
+    .ctor(IEnumerable<FormElement> = null, IDictionary<String, String> = null)
     List<FormElement> Elements { get; }
     Dictionary<String, String> Values { get; }
   }
   class FormElement
   {
-    .ctor(String, Octopus.Client.Model.Forms.Control, Boolean)
+    .ctor(String, Octopus.Client.Model.Forms.Control, Boolean = False)
     Octopus.Client.Model.Forms.Control Control { get; }
     Boolean IsValueRequired { get; }
     String Name { get; }
   }
   abstract class FormExtensions
   {
-    static void AddElement(Octopus.Client.Model.Forms.Form, String, Octopus.Client.Model.Forms.Control, String, Boolean)
+    static void AddElement(Octopus.Client.Model.Forms.Form, String, Octopus.Client.Model.Forms.Control, String = null, Boolean = False)
     static Object GetCoercedValue(Octopus.Client.Model.Forms.Form, String)
     static void SetValue(Octopus.Client.Model.Forms.Form, String, String)
     static void UpdateValues(Octopus.Client.Model.Forms.Form, IDictionary<String, String>)
@@ -7349,8 +7352,8 @@ Octopus.Client.Repositories
     void Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     void DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Get(String)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32, Int32)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32 = 0, Int32 = 30)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
   }
@@ -7364,15 +7367,15 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    List<TAccount> FindAllOfType(Object)
+    List<TAccount> FindAllOfType(Object = null)
     Octopus.Client.Repositories.TAccount FindByNameOfType(String)
     List<TAccount> FindByNamesOfType(IEnumerable<String>)
-    List<TAccount> FindManyOfType(Func<TAccount, Boolean>, Object)
-    Octopus.Client.Repositories.TAccount FindOneOfType(Func<TAccount, Boolean>, Object)
+    List<TAccount> FindManyOfType(Func<TAccount, Boolean>, Object = null)
+    Octopus.Client.Repositories.TAccount FindOneOfType(Func<TAccount, Boolean>, Object = null)
     Octopus.Client.Model.Accounts.Usages.AccountUsageResource GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
     Octopus.Client.Repositories.TAccount GetOfType(String)
     List<TAccount> GetOfType(String[])
-    void PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
+    void PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object = null)
     Octopus.Client.Repositories.TAccount RefreshOfType(Octopus.Client.Repositories.TAccount)
   }
   interface IActionTemplateRepository
@@ -7393,7 +7396,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<ArchivedEventFileResource>
   {
     Stream GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
-    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<ArchivedEventFileResource> List(Int32 = 0, Nullable<Int32> = null)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.IPaginate<ArtifactResource>
@@ -7416,8 +7419,8 @@ Octopus.Client.Repositories
     void Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     void DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Get(String)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32, Int32)
-    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32, Int32)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> LatestBuilds(Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<OctopusPackageVersionBuildInformationMappedResource> ListBuilds(String, Int32 = 0, Int32 = 30)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation)
   }
@@ -7426,9 +7429,9 @@ Octopus.Client.Repositories
     void DeletePackage(Octopus.Client.Model.PackageResource)
     void DeletePackages(IReadOnlyList<PackageResource>)
     Octopus.Client.Model.PackageFromBuiltInFeedResource GetPackage(String, String)
-    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32, Int32)
-    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32, Int32)
-    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean)
+    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> LatestPackages(Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.ResourceCollection<PackageFromBuiltInFeedResource> ListPackages(String, Int32 = 0, Int32 = 30)
+    Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean = False)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Boolean, Boolean)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
     Octopus.Client.Model.PackageFromBuiltInFeedResource PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
@@ -7455,8 +7458,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<CertificateResource>
   {
     void Archive(Octopus.Client.Model.CertificateResource)
-    Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
-    Stream ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
+    Stream Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat> = null, String = null, Boolean = False)
+    Stream ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean = False, Octopus.Client.Model.CertificateExportPemOptions = PrimaryOnly)
     Octopus.Client.Model.CertificateConfigurationResource GetOctopusCertificate()
     Octopus.Client.Model.CertificateResource Replace(Octopus.Client.Model.CertificateResource, String, String)
     void UnArchive(Octopus.Client.Model.CertificateResource)
@@ -7487,7 +7490,7 @@ Octopus.Client.Repositories
   }
   interface ICreate`1
   {
-    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object)
+    Octopus.Client.Repositories.TResource Create(Octopus.Client.Repositories.TResource, Object = null)
   }
   interface IDashboardConfigurationRepository
   {
@@ -7497,7 +7500,7 @@ Octopus.Client.Repositories
   interface IDashboardRepository
   {
     Octopus.Client.Model.DashboardResource GetDashboard()
-    Octopus.Client.Model.DashboardResource GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
+    Octopus.Client.Model.DashboardResource GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions = IncludeCurrentDeploymentOnly)
   }
   interface IDefectsRepository
   {
@@ -7524,8 +7527,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.IDelete<DeploymentResource>
   {
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindAll(String[], String[], Int32, Nullable<Int32>)
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindBy(String[], String[], Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindAll(String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> FindBy(String[], String[], Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.DeploymentResource)
     void Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     void Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
@@ -7550,9 +7553,9 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String)
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String, String)
     Octopus.Client.Editors.EnvironmentEditor CreateOrModify(String, String, Boolean)
-    List<MachineResource> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
+    List<MachineResource> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null)
     void Sort(String[])
-    Octopus.Client.Model.EnvironmentsSummaryResource Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
+    Octopus.Client.Model.EnvironmentsSummaryResource Summary(String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, Nullable<Boolean> = False)
   }
   interface IEventRepository
     Octopus.Client.Repositories.IGet<EventResource>
@@ -7562,8 +7565,8 @@ Octopus.Client.Repositories
     IReadOnlyList<EventCategoryResource> GetCategories()
     IReadOnlyList<DocumentTypeResource> GetDocumentTypes()
     IReadOnlyList<EventGroupResource> GetGroups()
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, String, String, Boolean)
-    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32 = 0, String = null, String = null, Boolean = False)
+    Octopus.Client.Model.ResourceCollection<EventResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Boolean = True, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null, Nullable<Int64> = null, Nullable<Int64> = null, String = null, String = null, String = null)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -7583,13 +7586,13 @@ Octopus.Client.Repositories
   interface IFindByName`1
     Octopus.Client.Repositories.IPaginate<TResource>
   {
-    Octopus.Client.Repositories.TResource FindByName(String, String, Object)
-    List<TResource> FindByNames(IEnumerable<String>, String, Object)
+    Octopus.Client.Repositories.TResource FindByName(String, String = null, Object = null)
+    List<TResource> FindByNames(IEnumerable<String>, String = null, Object = null)
   }
   interface IFindByPartialName`1
     Octopus.Client.Repositories.IPaginate<TResource>
   {
-    List<TResource> FindByPartialName(String, String, Object)
+    List<TResource> FindByPartialName(String, String = null, Object = null)
   }
   interface IGetAll`1
   {
@@ -7605,7 +7608,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IGet<InterruptionResource>
   {
     Octopus.Client.Model.UserResource GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Octopus.Client.Model.ResourceCollection<InterruptionResource> List(Int32, Nullable<Int32>, Boolean, String)
+    Octopus.Client.Model.ResourceCollection<InterruptionResource> List(Int32 = 0, Nullable<Int32> = null, Boolean = False, String = null)
     void Submit(Octopus.Client.Model.InterruptionResource)
     void TakeResponsibility(Octopus.Client.Model.InterruptionResource)
   }
@@ -7659,13 +7662,13 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Octopus.Client.Editors.MachineEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Octopus.Client.Model.MachineResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Octopus.Client.Model.MachineResource Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
     Octopus.Client.Model.MachineResource Discover(Octopus.Client.Model.DiscoverMachineOptions)
     List<MachineResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.MachineResource)
-    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType>)
+    IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Nullable<DeploymentTargetTaskType> = null)
     IReadOnlyList<TaskResource> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
+    Octopus.Client.Model.ResourceCollection<MachineResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, String = null)
   }
   interface IMachineRoleRepository
   {
@@ -7692,10 +7695,10 @@ Octopus.Client.Repositories
   }
   interface IPaginate`1
   {
-    List<TResource> FindAll(String, Object)
-    List<TResource> FindMany(Func<TResource, Boolean>, String, Object)
-    Octopus.Client.Repositories.TResource FindOne(Func<TResource, Boolean>, String, Object)
-    void Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
+    List<TResource> FindAll(String = null, Object = null)
+    List<TResource> FindMany(Func<TResource, Boolean>, String = null, Object = null)
+    Octopus.Client.Repositories.TResource FindOne(Func<TResource, Boolean>, String = null, Object = null)
+    void Paginate(Func<ResourceCollection<TResource>, Boolean>, String = null, Object = null)
   }
   interface IPerformanceConfigurationRepository
   {
@@ -7727,7 +7730,7 @@ Octopus.Client.Repositories
     Octopus.Client.Model.Git.ConvertProjectToGitResponse ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String)
     Octopus.Client.Model.Git.ConvertProjectToGitResponse ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String, String)
     Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
-    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Octopus.Client.Editors.ProjectEditor CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
     IReadOnlyList<ChannelResource> GetAllChannels(Octopus.Client.Model.ProjectResource)
     IReadOnlyList<ReleaseResource> GetAllReleases(Octopus.Client.Model.ProjectResource)
     IReadOnlyList<RunbookResource> GetAllRunbooks(Octopus.Client.Model.ProjectResource)
@@ -7741,10 +7744,10 @@ Octopus.Client.Repositories
     Octopus.Client.Model.ResourceCollection<GitTagResource> GetGitTags(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ProgressionResource GetProgression(Octopus.Client.Model.ProjectResource)
     Octopus.Client.Model.ReleaseResource GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
-    Octopus.Client.Model.ResourceCollection<RunbookResource> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Octopus.Client.Model.ResourceCollection<ReleaseResource> GetReleases(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
+    Octopus.Client.Model.ResourceCollection<RunbookResource> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Octopus.Client.Model.RunbookSnapshotResource GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
-    Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Octopus.Client.Model.ResourceCollection<RunbookSnapshotResource> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Octopus.Client.Model.ResourceCollection<ProjectTriggerResource> GetTriggers(Octopus.Client.Model.ProjectResource)
     void SetLogo(Octopus.Client.Model.ProjectResource, String, Stream)
   }
@@ -7774,9 +7777,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IModify<ReleaseResource>
     Octopus.Client.Repositories.IDelete<ReleaseResource>
   {
-    Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean)
-    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
-    Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ReleaseResource Create(Octopus.Client.Model.ReleaseResource, Boolean = False)
+    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
+    Octopus.Client.Model.ResourceCollection<DeploymentResource> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.DeploymentPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
     Octopus.Client.Model.LifecycleProgressionResource GetProgression(Octopus.Client.Model.ReleaseResource)
     Octopus.Client.Model.DeploymentTemplateResource GetTemplate(Octopus.Client.Model.ReleaseResource)
@@ -7818,7 +7821,7 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.IDelete<RunbookRunResource>
   {
-    Octopus.Client.Model.ResourceCollection<RunbookRunResource> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<RunbookRunResource> FindBy(String[], String[], String[], Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.TaskResource GetTask(Octopus.Client.Model.RunbookRunResource)
     void Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     void Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
@@ -7831,9 +7834,9 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<RunbookSnapshotResource>
   {
     Octopus.Client.Model.RunbookSnapshotResource Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<ArtifactResource> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.RunbookRunPreviewResource GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Octopus.Client.Model.ResourceCollection<RunbookRunResource> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
+    Octopus.Client.Model.ResourceCollection<RunbookRunResource> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
     Octopus.Client.Model.RunbookRunTemplateResource GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
     Octopus.Client.Model.RunbookSnapshotResource SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
   }
@@ -7903,25 +7906,25 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.ICanExtendSpaceContext<ITaskRepository>
   {
     void Cancel(Octopus.Client.Model.TaskResource)
-    Octopus.Client.Model.TaskResource ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
-    Octopus.Client.Model.TaskResource ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
-    Octopus.Client.Model.TaskResource ExecuteBackup(String)
-    Octopus.Client.Model.TaskResource ExecuteCalamariUpdate(String, String[])
-    Octopus.Client.Model.TaskResource ExecuteCommunityActionTemplatesSynchronisation(String)
-    Octopus.Client.Model.TaskResource ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
-    Octopus.Client.Model.TaskResource ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
-    Octopus.Client.Model.TaskResourceCollection GetActiveWithSummary(Int32, Int32)
-    List<TaskResource> GetAllActive(Int32)
-    Octopus.Client.Model.TaskResourceCollection GetAllWithSummary(Int32, Int32)
-    Octopus.Client.Model.TaskDetailsResource GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
+    Octopus.Client.Model.TaskResource ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
+    Octopus.Client.Model.TaskResource ExecuteAdHocScript(String, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
+    Octopus.Client.Model.TaskResource ExecuteBackup(String = null)
+    Octopus.Client.Model.TaskResource ExecuteCalamariUpdate(String = null, String[] = null)
+    Octopus.Client.Model.TaskResource ExecuteCommunityActionTemplatesSynchronisation(String = null)
+    Octopus.Client.Model.TaskResource ExecuteHealthCheck(String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
+    Octopus.Client.Model.TaskResource ExecuteTentacleUpgrade(String = null, String = null, String[] = null, String = null, String = null, String[] = null)
+    Octopus.Client.Model.TaskResourceCollection GetActiveWithSummary(Int32 = Int.MaxValue, Int32 = 0)
+    List<TaskResource> GetAllActive(Int32 = Int.MaxValue)
+    Octopus.Client.Model.TaskResourceCollection GetAllWithSummary(Int32 = Int.MaxValue, Int32 = 0)
+    Octopus.Client.Model.TaskDetailsResource GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean> = null, Nullable<Int32> = null)
     IReadOnlyList<TaskResource> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
     String GetRawOutputLog(Octopus.Client.Model.TaskResource)
     Octopus.Client.Model.TaskTypeResource[] GetTaskTypes()
     void ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String)
     void Rerun(Octopus.Client.Model.TaskResource)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
-    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Action<TaskResource[]>)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource, Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
+    void WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Nullable<TimeSpan> = null, Action<TaskResource[]> = null)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.ICreate<TeamResource>
@@ -7954,8 +7957,8 @@ Octopus.Client.Repositories
     Octopus.Client.Editors.TenantEditor CreateOrModify(String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String)
     Octopus.Client.Editors.TenantEditor CreateOrModify(String, String, String)
-    List<TenantResource> FindAll(String, String[], Int32)
-    List<TenantsMissingVariablesResource> GetMissingVariables(String, String, String)
+    List<TenantResource> FindAll(String, String[] = null, Int32 = Int.MaxValue)
+    List<TenantsMissingVariablesResource> GetMissingVariables(String = null, String = null, String = null)
     Octopus.Client.Model.TenantVariableResource GetVariables(Octopus.Client.Model.TenantResource)
     Octopus.Client.Model.TenantVariableResource ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     void SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
@@ -7991,8 +7994,8 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<UserResource>
     Octopus.Client.Repositories.ICreate<UserResource>
   {
-    Octopus.Client.Model.UserResource Create(String, String, String, String)
-    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
+    Octopus.Client.Model.UserResource Create(String, String, String = null, String = null)
+    Octopus.Client.Model.ApiKeyCreatedResource CreateApiKey(Octopus.Client.Model.UserResource, String = null, Nullable<DateTimeOffset> = null)
     Octopus.Client.Model.UserResource CreateServiceAccount(String, String)
     Octopus.Client.Model.UserResource FindByUsername(String)
     List<ApiKeyResource> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -8004,7 +8007,7 @@ Octopus.Client.Repositories
     void RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     void RevokeSessions(Octopus.Client.Model.UserResource)
     void SignIn(Octopus.Client.Model.LoginCommand)
-    void SignIn(String, String, Boolean)
+    void SignIn(String, String, Boolean = False)
     void SignOut()
   }
   interface IUserRolesRepository
@@ -8026,10 +8029,10 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IModify<VariableSetResource>
     Octopus.Client.Repositories.IGetAll<VariableSetResource>
   {
-    Octopus.Client.Model.VariableSetResource Get(Octopus.Client.Model.ProjectResource, String)
-    String[] GetVariableNames(String, String[], String)
+    Octopus.Client.Model.VariableSetResource Get(Octopus.Client.Model.ProjectResource, String = null)
+    String[] GetVariableNames(String, String[], String = null)
     Octopus.Client.Model.VariableSetResource GetVariablePreview(String, String, String, String, String, String, String, String)
-    Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
+    Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null)
   }
   interface IWorkerPoolRepository
     Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
@@ -8042,9 +8045,9 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Editors.WorkerPoolEditor CreateOrModify(String)
     Octopus.Client.Editors.WorkerPoolEditor CreateOrModify(String, String)
-    List<WorkerResource> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
+    List<WorkerResource> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, Nullable<Boolean> = False, String = null, String = null)
     void Sort(String[])
-    Octopus.Client.Model.WorkerPoolsSummaryResource Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
+    Octopus.Client.Model.WorkerPoolsSummaryResource Summary(String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, Nullable<Boolean> = False)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.IFindByName<WorkerResource>
@@ -8055,10 +8058,10 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IDelete<WorkerResource>
   {
     Octopus.Client.Editors.WorkerEditor CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Octopus.Client.Model.WorkerResource Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Octopus.Client.Model.WorkerResource Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
     List<WorkerResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+    Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null)
   }
   class PerformanceConfigurationRepository
     Octopus.Client.Repositories.IPerformanceConfigurationRepository
@@ -8089,15 +8092,15 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<AccountResource>
   {
     Octopus.Client.Model.Accounts.AccountType DetermineAccountType()
-    Task<List<TAccount>> FindAllOfType(Object)
+    Task<List<TAccount>> FindAllOfType(Object = null)
     Task<TAccount> FindByNameOfType(String)
     Task<List<TAccount>> FindByNamesOfType(IEnumerable<String>)
-    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object)
-    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object)
+    Task<List<TAccount>> FindManyOfType(Func<TAccount, Boolean>, Object = null)
+    Task<TAccount> FindOneOfType(Func<TAccount, Boolean>, Object = null)
     Task<AccountUsageResource> GetAccountUsage(Octopus.Client.Model.Accounts.AccountResource)
     Task<TAccount> GetOfType(String)
     Task<List<TAccount>> GetOfType(String[])
-    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object)
+    Task PaginateOfType(Func<ResourceCollection<TAccount>, Boolean>, Object = null)
     Task<TAccount> RefreshOfType(Octopus.Client.Repositories.Async.TAccount)
   }
   interface IActionTemplateRepository
@@ -8118,7 +8121,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<ArchivedEventFileResource>
   {
     Task<Stream> GetContent(Octopus.Client.Model.EventRetention.ArchivedEventFileResource)
-    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32, Nullable<Int32>)
+    Task<ResourceCollection<ArchivedEventFileResource>> List(Int32 = 0, Nullable<Int32> = null)
   }
   interface IArtifactRepository
     Octopus.Client.Repositories.Async.IPaginate<ArtifactResource>
@@ -8141,8 +8144,8 @@ Octopus.Client.Repositories.Async
     Task Delete(Octopus.Client.Model.BuildInformation.OctopusPackageVersionBuildInformationMappedResource)
     Task DeleteBuilds(IReadOnlyList<OctopusPackageVersionBuildInformationMappedResource>)
     Task<OctopusPackageVersionBuildInformationMappedResource> Get(String)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32, Int32)
-    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32, Int32)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> LatestBuilds(Int32 = 0, Int32 = 30)
+    Task<ResourceCollection<OctopusPackageVersionBuildInformationMappedResource>> ListBuilds(String, Int32 = 0, Int32 = 30)
     Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Octopus.Client.Model.OverwriteMode)
     Task<OctopusPackageVersionBuildInformationMappedResource> Push(String, String, Octopus.Client.Model.BuildInformation.OctopusBuildInformation, Boolean)
   }
@@ -8151,9 +8154,9 @@ Octopus.Client.Repositories.Async
     Task DeletePackage(Octopus.Client.Model.PackageResource)
     Task DeletePackages(IReadOnlyList<PackageResource>)
     Task<PackageFromBuiltInFeedResource> GetPackage(String, String)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32, Int32)
-    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32, Int32)
-    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> LatestPackages(Int32 = 0, Int32 = 30)
+    Task<ResourceCollection<PackageFromBuiltInFeedResource>> ListPackages(String, Int32 = 0, Int32 = 30)
+    Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean = False)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Boolean, Boolean)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode)
     Task<PackageFromBuiltInFeedResource> PushPackage(String, Stream, Octopus.Client.Model.OverwriteMode, Boolean)
@@ -8180,8 +8183,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<CertificateResource>
   {
     Task Archive(Octopus.Client.Model.CertificateResource)
-    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat>, String, Boolean)
-    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean, Octopus.Client.Model.CertificateExportPemOptions)
+    Task<Stream> Export(Octopus.Client.Model.CertificateResource, Nullable<CertificateFormat> = null, String = null, Boolean = False)
+    Task<Stream> ExportAsPem(Octopus.Client.Model.CertificateResource, Boolean = False, Octopus.Client.Model.CertificateExportPemOptions = PrimaryOnly)
     Task<CertificateConfigurationResource> GetOctopusCertificate()
     Task<CertificateResource> Replace(Octopus.Client.Model.CertificateResource, String, String)
     Task UnArchive(Octopus.Client.Model.CertificateResource)
@@ -8198,7 +8201,7 @@ Octopus.Client.Repositories.Async
     Task<ChannelResource> FindByName(Octopus.Client.Model.ProjectResource, String)
     Task<IReadOnlyList<ReleaseResource>> GetAllReleases(Octopus.Client.Model.ChannelResource)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ChannelResource, String)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32, Nullable<Int32>, String)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ChannelResource, Int32 = 0, Nullable<Int32> = null, String = null)
   }
   interface ICommunityActionTemplateRepository
     Octopus.Client.Repositories.Async.IGet<CommunityActionTemplateResource>
@@ -8214,7 +8217,7 @@ Octopus.Client.Repositories.Async
   }
   interface ICreate`1
   {
-    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object)
+    Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object = null)
     Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, CancellationToken)
     Task<TResource> Create(Octopus.Client.Repositories.Async.TResource, Object, CancellationToken)
   }
@@ -8226,7 +8229,7 @@ Octopus.Client.Repositories.Async
   interface IDashboardRepository
   {
     Task<DashboardResource> GetDashboard()
-    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions)
+    Task<DashboardResource> GetDynamicDashboard(String[], String[], Octopus.Client.Model.DashboardItemsOptions = IncludeCurrentDeploymentOnly)
   }
   interface IDefectsRepository
   {
@@ -8258,8 +8261,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<DeploymentResource>
     Octopus.Client.Repositories.Async.IDelete<DeploymentResource>
   {
-    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32, Nullable<Int32>)
-    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32, Nullable<Int32>)
+    Task<ResourceCollection<DeploymentResource>> FindAll(String[], String[], Int32 = 0, Nullable<Int32> = null)
+    Task<ResourceCollection<DeploymentResource>> FindBy(String[], String[], Int32 = 0, Nullable<Int32> = null)
     Task<TaskResource> GetTask(Octopus.Client.Model.DeploymentResource)
     Task Paginate(String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<DeploymentResource>, Boolean>)
@@ -8289,9 +8292,9 @@ Octopus.Client.Repositories.Async
     Task<EnvironmentEditor> CreateOrModify(String)
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Task<EnvironmentEditor> CreateOrModify(String, String, Boolean)
-    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32>, Nullable<Int32>, String, String, Nullable<Boolean>, String, String, String, String)
+    Task<List<MachineResource>> GetMachines(Octopus.Client.Model.EnvironmentResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null)
     Task Sort(String[])
-    Task<EnvironmentsSummaryResource> Summary(String, String, String, String, Nullable<Boolean>, String, String, String, String, Nullable<Boolean>)
+    Task<EnvironmentsSummaryResource> Summary(String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, Nullable<Boolean> = False)
   }
   interface IEventRepository
     Octopus.Client.Repositories.Async.IGet<EventResource>
@@ -8301,8 +8304,8 @@ Octopus.Client.Repositories.Async
     Task<IReadOnlyList<EventCategoryResource>> GetCategories()
     Task<IReadOnlyList<DocumentTypeResource>> GetDocumentTypes()
     Task<IReadOnlyList<EventGroupResource>> GetGroups()
-    Task<ResourceCollection<EventResource>> List(Int32, String, String, Boolean)
-    Task<ResourceCollection<EventResource>> List(Int32, Nullable<Int32>, String, String, String, String, Boolean, String, String, String, String, String, String, String, String, Nullable<Int64>, Nullable<Int64>, String, String, String)
+    Task<ResourceCollection<EventResource>> List(Int32 = 0, String = null, String = null, Boolean = False)
+    Task<ResourceCollection<EventResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Boolean = True, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null, Nullable<Int64> = null, Nullable<Int64> = null, String = null, String = null, String = null)
   }
   interface IFeaturesConfigurationRepository
   {
@@ -8323,10 +8326,10 @@ Octopus.Client.Repositories.Async
   interface IFindByName`1
     Octopus.Client.Repositories.Async.IPaginate<TResource>
   {
-    Task<TResource> FindByName(String, String, Object)
+    Task<TResource> FindByName(String, String = null, Object = null)
     Task<TResource> FindByName(String, CancellationToken)
     Task<TResource> FindByName(String, String, Object, CancellationToken)
-    Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object)
+    Task<List<TResource>> FindByNames(IEnumerable<String>, String = null, Object = null)
     Task<List<TResource>> FindByNames(IEnumerable<String>, CancellationToken)
     Task<List<TResource>> FindByNames(IEnumerable<String>, String, Object, CancellationToken)
   }
@@ -8364,7 +8367,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<InterruptionResource>
   {
     Task<UserResource> GetResponsibleUser(Octopus.Client.Model.InterruptionResource)
-    Task<ResourceCollection<InterruptionResource>> List(Int32, Nullable<Int32>, Boolean, String)
+    Task<ResourceCollection<InterruptionResource>> List(Int32 = 0, Nullable<Int32> = null, Boolean = False, String = null)
     Task Submit(Octopus.Client.Model.InterruptionResource)
     Task TakeResponsibility(Octopus.Client.Model.InterruptionResource)
   }
@@ -8417,13 +8420,13 @@ Octopus.Client.Repositories.Async
   {
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[], Octopus.Client.Model.TenantResource[], Octopus.Client.Model.TagResource[], Nullable<TenantedDeploymentMode>)
     Task<MachineEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.EnvironmentResource[], String[])
-    Task<MachineResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Task<MachineResource> Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
     Task<MachineResource> Discover(Octopus.Client.Model.DiscoverMachineOptions)
     Task<List<MachineResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource)
     Task<IReadOnlyList<TaskResource>> GetTasks(Octopus.Client.Model.MachineResource, Object)
-    Task<ResourceCollection<MachineResource>> List(Int32, Nullable<Int32>, String, String, String, String, Nullable<Boolean>, String, String, String, String, String)
+    Task<ResourceCollection<MachineResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null, String = null, String = null)
   }
   interface IMachineRoleRepository
   {
@@ -8451,16 +8454,16 @@ Octopus.Client.Repositories.Async
   }
   interface IPaginate`1
   {
-    Task<List<TResource>> FindAll(String, Object)
+    Task<List<TResource>> FindAll(String = null, Object = null)
     Task<List<TResource>> FindAll(CancellationToken)
     Task<List<TResource>> FindAll(String, Object, CancellationToken)
-    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object)
+    Task<List<TResource>> FindMany(Func<TResource, Boolean>, String = null, Object = null)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, CancellationToken)
     Task<List<TResource>> FindMany(Func<TResource, Boolean>, String, Object, CancellationToken)
-    Task<TResource> FindOne(Func<TResource, Boolean>, String, Object)
+    Task<TResource> FindOne(Func<TResource, Boolean>, String = null, Object = null)
     Task<TResource> FindOne(Func<TResource, Boolean>, CancellationToken)
     Task<TResource> FindOne(Func<TResource, Boolean>, String, Object, CancellationToken)
-    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object)
+    Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String = null, Object = null)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, CancellationToken)
     Task Paginate(Func<ResourceCollection<TResource>, Boolean>, String, Object, CancellationToken)
   }
@@ -8501,7 +8504,7 @@ Octopus.Client.Repositories.Async
     Task<ConvertProjectToGitResponse> ConvertToGit(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.GitPersistenceSettingsResource, String, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, CancellationToken)
-    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String)
+    Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String = null)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, CancellationToken)
     Task<ProjectEditor> CreateOrModify(String, Octopus.Client.Model.ProjectGroupResource, Octopus.Client.Model.LifecycleResource, String, String, CancellationToken)
     Task<IReadOnlyList<ChannelResource>> GetAllChannels(Octopus.Client.Model.ProjectResource)
@@ -8526,19 +8529,19 @@ Octopus.Client.Repositories.Async
     Task<GitTagResource> GetGitTag(Octopus.Client.Model.ProjectResource, String, CancellationToken)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource)
     Task<ResourceCollection<GitTagResource>> GetGitTags(Octopus.Client.Model.ProjectResource, CancellationToken)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32>)
-    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32>)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, Nullable<Int32> = null)
+    Task<ProgressionResource> GetProgression(Octopus.Client.Model.ProjectResource, CancellationToken, Nullable<Int32> = null)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String)
     Task<ReleaseResource> GetReleaseByVersion(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<ReleaseResource>> GetReleases(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
-    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<RunbookResource>> GetRunbooks(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
     Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String)
     Task<RunbookSnapshotResource> GetRunbookSnapshotByName(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String)
+    Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32 = 0, Nullable<Int32> = null, String = null)
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<ResourceCollection<RunbookSnapshotResource>> GetRunbookSnapshots(Octopus.Client.Model.ProjectResource, Int32, Nullable<Int32>, String, CancellationToken)
     Task<ResourceCollection<ProjectTriggerResource>> GetTriggers(Octopus.Client.Model.ProjectResource)
@@ -8572,12 +8575,12 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<ReleaseResource>
     Octopus.Client.Repositories.Async.IDelete<ReleaseResource>
   {
-    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean)
+    Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean = False)
     Task<ReleaseResource> Create(Octopus.Client.Model.ReleaseResource, Boolean, CancellationToken)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, CancellationToken)
     Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
-    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32 = 0, Nullable<Int32> = null)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, CancellationToken)
     Task<ResourceCollection<DeploymentResource>> GetDeployments(Octopus.Client.Model.ReleaseResource, Int32, Nullable<Int32>, CancellationToken)
     Task<DeploymentPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
@@ -8595,7 +8598,7 @@ Octopus.Client.Repositories.Async
   }
   interface IRetentionPolicyRepository
   {
-    Task<TaskResource> ApplyNow(String)
+    Task<TaskResource> ApplyNow(String = null)
   }
   interface IRunbookProcessRepository
     Octopus.Client.Repositories.Async.IGet<RunbookProcessResource>
@@ -8625,7 +8628,7 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IPaginate<RunbookRunResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookRunResource>
   {
-    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32, Nullable<Int32>)
+    Task<ResourceCollection<RunbookRunResource>> FindBy(String[], String[], String[], Int32 = 0, Nullable<Int32> = null)
     Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
@@ -8638,9 +8641,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<RunbookSnapshotResource>
   {
     Task<RunbookSnapshotResource> Create(Octopus.Client.Model.RunbookSnapshotResource)
-    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<ArtifactResource>> GetArtifacts(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
     Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32, Nullable<Int32>)
+    Task<ResourceCollection<RunbookRunResource>> GetRunbookRuns(Octopus.Client.Model.RunbookSnapshotResource, Int32 = 0, Nullable<Int32> = null)
     Task<RunbookRunTemplateResource> GetTemplate(Octopus.Client.Model.RunbookSnapshotResource)
     Task<RunbookSnapshotResource> SnapshotVariables(Octopus.Client.Model.RunbookSnapshotResource)
   }
@@ -8711,28 +8714,28 @@ Octopus.Client.Repositories.Async
   {
     Task Cancel(Octopus.Client.Model.TaskResource)
     Task Cancel(Octopus.Client.Model.TaskResource, CancellationToken)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[], String[], String[], String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, CancellationToken, String[], String[], String[], String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteAdHocScript(String, String[], String[], String[], String, String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteAdHocScript(String, CancellationToken, String[], String[], String[], String, String, Nullable<TargetType>)
-    Task<TaskResource> ExecuteBackup(String)
-    Task<TaskResource> ExecuteBackup(CancellationToken, String)
-    Task<TaskResource> ExecuteCalamariUpdate(String, String[])
-    Task<TaskResource> ExecuteCalamariUpdate(CancellationToken, String, String[])
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String)
-    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(CancellationToken, String)
-    Task<TaskResource> ExecuteHealthCheck(String, Int32, Int32, String, String[], String, String, String[])
-    Task<TaskResource> ExecuteHealthCheck(CancellationToken, String, Int32, Int32, String, String[], String, String, String[])
-    Task<TaskResource> ExecuteTentacleUpgrade(String, String, String[], String, String, String[])
-    Task<TaskResource> ExecuteTentacleUpgrade(CancellationToken, String, String, String[], String, String, String[])
-    Task<TaskResourceCollection> GetActiveWithSummary(Int32, Int32)
-    Task<TaskResourceCollection> GetActiveWithSummary(CancellationToken, Int32, Int32)
-    Task<List<TaskResource>> GetAllActive(Int32)
-    Task<List<TaskResource>> GetAllActive(CancellationToken, Int32)
-    Task<TaskResourceCollection> GetAllWithSummary(Int32, Int32)
-    Task<TaskResourceCollection> GetAllWithSummary(CancellationToken, Int32, Int32)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean>, Nullable<Int32>)
-    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, CancellationToken, Nullable<Boolean>, Nullable<Int32>)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
+    Task<TaskResource> ExecuteActionTemplate(Octopus.Client.Model.ActionTemplateResource, Dictionary<String, PropertyValueResource>, CancellationToken, String[] = null, String[] = null, String[] = null, String = null, Nullable<TargetType> = null)
+    Task<TaskResource> ExecuteAdHocScript(String, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
+    Task<TaskResource> ExecuteAdHocScript(String, CancellationToken, String[] = null, String[] = null, String[] = null, String = null, String = "PowerShell", Nullable<TargetType> = null)
+    Task<TaskResource> ExecuteBackup(String = null)
+    Task<TaskResource> ExecuteBackup(CancellationToken, String = null)
+    Task<TaskResource> ExecuteCalamariUpdate(String = null, String[] = null)
+    Task<TaskResource> ExecuteCalamariUpdate(CancellationToken, String = null, String[] = null)
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(String = null)
+    Task<TaskResource> ExecuteCommunityActionTemplatesSynchronisation(CancellationToken, String = null)
+    Task<TaskResource> ExecuteHealthCheck(String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
+    Task<TaskResource> ExecuteHealthCheck(CancellationToken, String = null, Int32 = 5, Int32 = 1, String = null, String[] = null, String = null, String = null, String[] = null)
+    Task<TaskResource> ExecuteTentacleUpgrade(String = null, String = null, String[] = null, String = null, String = null, String[] = null)
+    Task<TaskResource> ExecuteTentacleUpgrade(CancellationToken, String = null, String = null, String[] = null, String = null, String = null, String[] = null)
+    Task<TaskResourceCollection> GetActiveWithSummary(Int32 = Int.MaxValue, Int32 = 0)
+    Task<TaskResourceCollection> GetActiveWithSummary(CancellationToken, Int32 = Int.MaxValue, Int32 = 0)
+    Task<List<TaskResource>> GetAllActive(Int32 = Int.MaxValue)
+    Task<List<TaskResource>> GetAllActive(CancellationToken, Int32 = Int.MaxValue)
+    Task<TaskResourceCollection> GetAllWithSummary(Int32 = Int.MaxValue, Int32 = 0)
+    Task<TaskResourceCollection> GetAllWithSummary(CancellationToken, Int32 = Int.MaxValue, Int32 = 0)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, Nullable<Boolean> = null, Nullable<Int32> = null)
+    Task<TaskDetailsResource> GetDetails(Octopus.Client.Model.TaskResource, CancellationToken, Nullable<Boolean> = null, Nullable<Int32> = null)
     Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource)
     Task<IReadOnlyList<TaskResource>> GetQueuedBehindTasks(Octopus.Client.Model.TaskResource, CancellationToken)
     Task<String> GetRawOutputLog(Octopus.Client.Model.TaskResource)
@@ -8743,14 +8746,14 @@ Octopus.Client.Repositories.Async
     Task ModifyState(Octopus.Client.Model.TaskResource, Octopus.Client.Model.TaskState, String, CancellationToken)
     Task Rerun(Octopus.Client.Model.TaskResource)
     Task Rerun(Octopus.Client.Model.TaskResource, CancellationToken)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32, Int32, Action<TaskResource[]>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource, CancellationToken, Int32, Int32, Action<TaskResource[], CancellationToken>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Action<TaskResource[]>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Int32, Action<TaskResource[], CancellationToken>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Int32, Func<TaskResource[], Task>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Int32, Func<TaskResource[], CancellationToken, Task>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32, Nullable<TimeSpan>, Func<TaskResource[], Task>)
-    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32, Nullable<TimeSpan>, Func<TaskResource[], CancellationToken, Task>)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource, CancellationToken, Int32 = 4, Int32 = 0, Action<TaskResource[], CancellationToken> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Action<TaskResource[]> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Int32 = 0, Action<TaskResource[], CancellationToken> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Int32 = 0, Func<TaskResource[], Task> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Int32 = 0, Func<TaskResource[], CancellationToken, Task> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], Int32 = 4, Nullable<TimeSpan> = null, Func<TaskResource[], Task> = null)
+    Task WaitForCompletion(Octopus.Client.Model.TaskResource[], CancellationToken, Int32 = 4, Nullable<TimeSpan> = null, Func<TaskResource[], CancellationToken, Task> = null)
   }
   interface ITeamsRepository
     Octopus.Client.Repositories.Async.ICreate<TeamResource>
@@ -8783,8 +8786,8 @@ Octopus.Client.Repositories.Async
     Task<TenantEditor> CreateOrModify(String)
     Task<TenantEditor> CreateOrModify(String, String)
     Task<TenantEditor> CreateOrModify(String, String, String)
-    Task<List<TenantResource>> FindAll(String, String[], Int32)
-    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String, String, String)
+    Task<List<TenantResource>> FindAll(String, String[] = null, Int32 = Int.MaxValue)
+    Task<List<TenantsMissingVariablesResource>> GetMissingVariables(String = null, String = null, String = null)
     Task<TenantVariableResource> GetVariables(Octopus.Client.Model.TenantResource)
     Task<TenantVariableResource> ModifyVariables(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantVariableResource)
     Task SetLogo(Octopus.Client.Model.TenantResource, String, Stream)
@@ -8821,8 +8824,8 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<UserResource>
     Octopus.Client.Repositories.Async.ICreate<UserResource>
   {
-    Task<UserResource> Create(String, String, String, String)
-    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
+    Task<UserResource> Create(String, String, String = null, String = null)
+    Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String = null, Nullable<DateTimeOffset> = null)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
@@ -8834,7 +8837,7 @@ Octopus.Client.Repositories.Async
     Task RevokeApiKey(Octopus.Client.Model.ApiKeyResourceBase)
     Task RevokeSessions(Octopus.Client.Model.UserResource)
     Task SignIn(Octopus.Client.Model.LoginCommand)
-    Task SignIn(String, String, Boolean)
+    Task SignIn(String, String, Boolean = False)
     Task SignOut()
   }
   interface IUserRolesRepository
@@ -8856,15 +8859,15 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<VariableSetResource>
     Octopus.Client.Repositories.Async.IGetAll<VariableSetResource>
   {
-    Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String)
+    Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String = null)
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<VariableSetResource> Get(Octopus.Client.Model.ProjectResource, String, CancellationToken)
-    Task<String[]> GetVariableNames(String, String[], String)
+    Task<String[]> GetVariableNames(String, String[], String = null)
     Task<String[]> GetVariableNames(String, String[], CancellationToken)
     Task<String[]> GetVariableNames(String, String[], String, CancellationToken)
     Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String)
     Task<VariableSetResource> GetVariablePreview(String, String, String, String, String, String, String, String, CancellationToken)
-    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
+    Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String = null, String = null, String = null, String = null, String = null, String = null, String = null, String = null)
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, CancellationToken)
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String, CancellationToken)
   }
@@ -8879,9 +8882,9 @@ Octopus.Client.Repositories.Async
   {
     Task<WorkerPoolEditor> CreateOrModify(String)
     Task<WorkerPoolEditor> CreateOrModify(String, String)
-    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32>, Nullable<Int32>, String, Nullable<Boolean>, String, String)
+    Task<List<WorkerResource>> GetMachines(Octopus.Client.Model.WorkerPoolResource, Nullable<Int32> = 0, Nullable<Int32> = null, String = null, Nullable<Boolean> = False, String = null, String = null)
     Task Sort(String[])
-    Task<WorkerPoolsSummaryResource> Summary(String, String, String, Nullable<Boolean>, String, String, Nullable<Boolean>)
+    Task<WorkerPoolsSummaryResource> Summary(String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, Nullable<Boolean> = False)
   }
   interface IWorkerRepository
     Octopus.Client.Repositories.Async.IFindByName<WorkerResource>
@@ -8892,10 +8895,10 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IDelete<WorkerResource>
   {
     Task<WorkerEditor> CreateOrModify(String, Octopus.Client.Model.Endpoints.EndpointResource, Octopus.Client.Model.WorkerPoolResource[])
-    Task<WorkerResource> Discover(String, Int32, Nullable<DiscoverableEndpointType>)
+    Task<WorkerResource> Discover(String, Int32 = 10933, Nullable<DiscoverableEndpointType> = null)
     Task<List<WorkerResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource)
-    Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+    Task<ResourceCollection<WorkerResource>> List(Int32 = 0, Nullable<Int32> = null, String = null, String = null, String = null, Nullable<Boolean> = False, String = null, String = null, String = null)
   }
   class SpaceScopedOperationOutsideOfCurrentSpaceContextException
     ISerializable

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -606,11 +606,11 @@ Octopus.Client
     .ctor(String, String, ICredentials)
     .ctor(Octopus.Client.ILinkResolver, String, ICredentials)
     String ApiKey { get; }
+    String BearerToken { get; }
     ICredentials Credentials { get; }
     Boolean IsUsingSecureConnection { get; }
     Octopus.Client.ILinkResolver OctopusServer { get; }
     IWebProxy Proxy { get; set; }
-    String Token { get; }
     Octopus.Client.OctopusServerEndpoint AsUser(String)
     static Octopus.Client.OctopusServerEndpoint CreateWithApiKey(String, String, ICredentials)
     static Octopus.Client.OctopusServerEndpoint CreateWithToken(String, String, ICredentials)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
@@ -171,6 +171,8 @@ namespace Octopus.Client.Tests
                 {
                     null => "null",
                     string stringValue => $"\"{stringValue}\"",
+                    int integer when integer == int.MaxValue => "Int.MaxValue",
+                    int integer when integer == int.MinValue => "Int.MinValue",
                     _ => defaultValue.ToString()
                 };
 

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
@@ -129,7 +129,7 @@ namespace Octopus.Client.Tests
             if (c.IsStatic)
                 return new string[0];
 
-            var parameters = c.GetParameters().Select(p => FormatTypeName(p.ParameterType));
+            var parameters = c.GetParameters().Select(p => FormatTypeName(p.ParameterType, isOptional: p.IsOptional, defaultValue:p.DefaultValue));
             return $"{c.Name}({parameters.CommaSeperate()})".InArray();
         }
 
@@ -138,12 +138,12 @@ namespace Octopus.Client.Tests
             if (m.IsSpecialName)
                 return new string[0];
 
-            var properties = m.GetParameters().Select(p => $"{FormatTypeName(p.ParameterType)}").ToArray();
+            var properties = m.GetParameters().Select(p => $"{FormatTypeName(p.ParameterType, isOptional: p.IsOptional, defaultValue:p.DefaultValue)}").ToArray();
 
             return $"{Static(m.IsStatic)}{FormatTypeName(m.ReturnType)} {m.Name}({properties.CommaSeperate()})".InArray();
         }
 
-        string FormatTypeName(Type type, bool shortName = false)
+        string FormatTypeName(Type type, bool shortName = false, bool isOptional = false, object defaultValue = null)
         {
             if (type == typeof(void))
                 return "void";
@@ -154,11 +154,28 @@ namespace Octopus.Client.Tests
                 name = type.Namespace + "." + name;
 
             if (!type.GetTypeInfo().IsGenericType)
-                return name;
+                return AddDefaultValue(name);
 
             name = name.Substring(0, name.IndexOf('`'));
             var args = type.GetGenericArguments().Select(a => FormatTypeName(a, true));
-            return $"{name}<{args.CommaSeperate()}>";
+            return AddDefaultValue($"{name}<{args.CommaSeperate()}>");
+
+            string AddDefaultValue(string typeName)
+            {
+                if (!isOptional)
+                {
+                    return typeName;
+                }
+
+                string defaultValueString = defaultValue switch
+                {
+                    null => "null",
+                    string stringValue => $"\"{stringValue}\"",
+                    _ => defaultValue.ToString()
+                };
+
+                return $"{typeName} = {defaultValueString}";
+            }
         }
     }
 }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
@@ -171,8 +171,6 @@ namespace Octopus.Client.Tests
                 {
                     null => "null",
                     string stringValue => $"\"{stringValue}\"",
-                    int integer when integer == int.MaxValue => "Int.MaxValue",
-                    int integer when integer == int.MinValue => "Int.MinValue",
                     _ => defaultValue.ToString()
                 };
 

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.cs
@@ -129,7 +129,7 @@ namespace Octopus.Client.Tests
             if (c.IsStatic)
                 return new string[0];
 
-            var parameters = c.GetParameters().Select(p => FormatTypeName(p.ParameterType, isOptional: p.IsOptional, defaultValue:p.DefaultValue));
+            var parameters = c.GetParameters().Select(p => FormatTypeName(p.ParameterType));
             return $"{c.Name}({parameters.CommaSeperate()})".InArray();
         }
 
@@ -138,12 +138,12 @@ namespace Octopus.Client.Tests
             if (m.IsSpecialName)
                 return new string[0];
 
-            var properties = m.GetParameters().Select(p => $"{FormatTypeName(p.ParameterType, isOptional: p.IsOptional, defaultValue:p.DefaultValue)}").ToArray();
+            var properties = m.GetParameters().Select(p => $"{FormatTypeName(p.ParameterType)}").ToArray();
 
             return $"{Static(m.IsStatic)}{FormatTypeName(m.ReturnType)} {m.Name}({properties.CommaSeperate()})".InArray();
         }
 
-        string FormatTypeName(Type type, bool shortName = false, bool isOptional = false, object defaultValue = null)
+        string FormatTypeName(Type type, bool shortName = false)
         {
             if (type == typeof(void))
                 return "void";
@@ -154,28 +154,11 @@ namespace Octopus.Client.Tests
                 name = type.Namespace + "." + name;
 
             if (!type.GetTypeInfo().IsGenericType)
-                return AddDefaultValue(name);
+                return name;
 
             name = name.Substring(0, name.IndexOf('`'));
             var args = type.GetGenericArguments().Select(a => FormatTypeName(a, true));
-            return AddDefaultValue($"{name}<{args.CommaSeperate()}>");
-
-            string AddDefaultValue(string typeName)
-            {
-                if (!isOptional)
-                {
-                    return typeName;
-                }
-
-                string defaultValueString = defaultValue switch
-                {
-                    null => "null",
-                    string stringValue => $"\"{stringValue}\"",
-                    _ => defaultValue.ToString()
-                };
-
-                return $"{typeName} = {defaultValueString}";
-            }
+            return $"{name}<{args.CommaSeperate()}>";
         }
     }
 }

--- a/source/Octopus.Server.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncClient.cs
@@ -78,7 +78,14 @@ namespace Octopus.Client
             client = new HttpClient(handler, true);
             client.Timeout = clientOptions.Timeout;
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Add(ApiConstants.ApiKeyHttpHeaderName, serverEndpoint.ApiKey);
+            if (serverEndpoint.ApiKey != null)
+            {
+                client.DefaultRequestHeaders.Add(ApiConstants.ApiKeyHttpHeaderName, serverEndpoint.ApiKey);
+            }
+            if (serverEndpoint.Token != null)
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", serverEndpoint.Token);
+            }
             client.DefaultRequestHeaders.Add("User-Agent", new OctopusCustomHeaders(requestingTool).UserAgent);
             Repository = new OctopusAsyncRepository(this);
         }

--- a/source/Octopus.Server.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncClient.cs
@@ -82,9 +82,9 @@ namespace Octopus.Client
             {
                 client.DefaultRequestHeaders.Add(ApiConstants.ApiKeyHttpHeaderName, serverEndpoint.ApiKey);
             }
-            if (serverEndpoint.Token != null)
+            if (serverEndpoint.BearerToken != null)
             {
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", serverEndpoint.Token);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", serverEndpoint.BearerToken);
             }
             client.DefaultRequestHeaders.Add("User-Agent", new OctopusCustomHeaders(requestingTool).UserAgent);
             Repository = new OctopusAsyncRepository(this);

--- a/source/Octopus.Server.Client/OctopusClient.cs
+++ b/source/Octopus.Server.Client/OctopusClient.cs
@@ -457,7 +457,14 @@ namespace Octopus.Client
             webRequest.Timeout = ApiConstants.DefaultClientRequestTimeout;
             webRequest.Credentials = serverEndpoint.Credentials ?? CredentialCache.DefaultNetworkCredentials;
             webRequest.Method = request.Method;
-            webRequest.Headers[ApiConstants.ApiKeyHttpHeaderName] = serverEndpoint.ApiKey;
+            if (serverEndpoint.ApiKey != null)
+            {
+                webRequest.Headers[ApiConstants.ApiKeyHttpHeaderName] = serverEndpoint.ApiKey;
+            }
+            if (serverEndpoint.Token != null)
+            {
+                webRequest.Headers["Authorization"] = $"Bearer {serverEndpoint.Token}";
+            }
             webRequest.UserAgent = octopusCustomHeaders.UserAgent;
 
             if (webRequest.Method == "PUT")

--- a/source/Octopus.Server.Client/OctopusClient.cs
+++ b/source/Octopus.Server.Client/OctopusClient.cs
@@ -461,9 +461,9 @@ namespace Octopus.Client
             {
                 webRequest.Headers[ApiConstants.ApiKeyHttpHeaderName] = serverEndpoint.ApiKey;
             }
-            if (serverEndpoint.Token != null)
+            if (serverEndpoint.BearerToken != null)
             {
-                webRequest.Headers["Authorization"] = $"Bearer {serverEndpoint.Token}";
+                webRequest.Headers["Authorization"] = $"Bearer {serverEndpoint.BearerToken}";
             }
             webRequest.UserAgent = octopusCustomHeaders.UserAgent;
 

--- a/source/Octopus.Server.Client/OctopusServerEndpoint.cs
+++ b/source/Octopus.Server.Client/OctopusServerEndpoint.cs
@@ -11,9 +11,9 @@ namespace Octopus.Client
         /// <summary>
         /// Create an instance with a Token to authenticate.
         /// </summary>
-        public static OctopusServerEndpoint CreateWithToken(string octopusServerAddress, string token, ICredentials credentials = null)
+        public static OctopusServerEndpoint CreateWithToken(string octopusServerAddress, string bearerToken, ICredentials credentials = null)
         {
-            return new OctopusServerEndpoint(octopusServerAddress, new TokenValue(token), credentials);
+            return new OctopusServerEndpoint(octopusServerAddress, new BearerTokenValue(bearerToken), credentials);
         }
 
         /// <summary>
@@ -24,13 +24,13 @@ namespace Octopus.Client
             return new OctopusServerEndpoint(octopusServerAddress, apiKey, credentials);
         }
 
-        private OctopusServerEndpoint(string octopusServerAddress, TokenValue token, ICredentials credentials)
+        private OctopusServerEndpoint(string octopusServerAddress, BearerTokenValue bearerTokenValue, ICredentials credentials)
         {
-            if (string.IsNullOrWhiteSpace(token.Value))
+            if (string.IsNullOrWhiteSpace(bearerTokenValue.Value))
                 throw new ArgumentException("Token is required.");
 
             OctopusServer = GetLinkResolverFromServerUrl(octopusServerAddress);
-            Token = token.Value;
+            BearerToken = bearerTokenValue.Value;
             Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
         }
 
@@ -132,9 +132,9 @@ namespace Octopus.Client
         public string ApiKey { get; }
 
         /// <summary>
-        /// A JWT Token that can be used to authenticate calls to the Server.
+        /// A Bearer Token that can be used to authenticate calls to the Server.
         /// </summary>
-        public string Token { get; }
+        public string BearerToken { get; }
 
         /// <summary>
         /// Gets the additional credentials to use when communicating to servers that require integrated/basic authentication.
@@ -167,9 +167,9 @@ namespace Octopus.Client
             return new DefaultLinkResolver(new Uri(octopusServerAddress));
         }
 
-        private class TokenValue
+        private class BearerTokenValue
         {
-            public TokenValue(string value)
+            public BearerTokenValue(string value)
             {
                 Value = value;
             }

--- a/source/Octopus.Server.Client/OctopusServerEndpoint.cs
+++ b/source/Octopus.Server.Client/OctopusServerEndpoint.cs
@@ -31,7 +31,7 @@ namespace Octopus.Client
 
             OctopusServer = GetLinkResolverFromServerUrl(octopusServerAddress);
             Token = token.Value;
-            Credentials = credentials;
+            Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
         }
 
         /// <summary>
@@ -83,8 +83,11 @@ namespace Octopus.Client
         /// Additional credentials to use when communicating to servers that require integrated/basic
         /// authentication.
         /// </param>
-        public OctopusServerEndpoint(string octopusServerAddress, string apiKey, ICredentials credentials) : this(GetLinkResolverFromServerUrl(octopusServerAddress), apiKey, credentials ?? CredentialCache.DefaultNetworkCredentials)
+        public OctopusServerEndpoint(string octopusServerAddress, string apiKey, ICredentials credentials)
         {
+            OctopusServer = GetLinkResolverFromServerUrl(octopusServerAddress);
+            ApiKey = apiKey;
+            Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
         }
 
         /// <summary>

--- a/source/Octopus.Server.Client/OctopusServerEndpoint.cs
+++ b/source/Octopus.Server.Client/OctopusServerEndpoint.cs
@@ -8,94 +8,117 @@ namespace Octopus.Client
     /// </summary>
     public class OctopusServerEndpoint
     {
-        public static OctopusServerEndpoint CreateWithToken(string octopusServerAddress, string token)
-        {
-            return new OctopusServerEndpoint(octopusServerAddress, token, null, isToken: true);
-        }
+        readonly ILinkResolver octopusServer;
+        readonly string apiKey;
+        readonly ICredentials credentials;
 
-        public static OctopusServerEndpoint CreateWithApiKey(string octopusServerAddress, string apiKey)
-        {
-            return new OctopusServerEndpoint(octopusServerAddress, apiKey);
-        }
-
-        /// <remarks>
-        /// Since no API key is provided, only very limited functionality will be available.
-        /// </remarks>
-        /// <param name="octopusServerAddress"><inheritdoc cref="OctopusServer" path="summary/"/></param>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusServerEndpoint" /> class. Since no API key is provided, only
+        /// very limited functionality will be available.
+        /// </summary>
+        /// <param name="octopusServerAddress">
+        /// The URI of the Octopus Server. Ideally this should end with <c>/api</c>. If it ends with any other segment, the
+        /// client
+        /// will assume Octopus runs under a virtual directory.
+        /// </param>
         public OctopusServerEndpoint(string octopusServerAddress)
+            : this(octopusServerAddress, null)
         {
-            OctopusServer = ParseOctopusServerAddress(octopusServerAddress);
         }
 
-        /// <param name="octopusServerAddress"><inheritdoc cref="OctopusServer" path="summary/"/></param>
-        /// <param name="apiKey"><inheritdoc cref="ApiKey" path="summary/"/></param>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusServerEndpoint" /> class.
+        /// </summary>
+        /// <param name="octopusServerAddress">
+        /// The URI of the Octopus Server. Ideally this should end with <c>/api</c>. If it ends with any other segment, the
+        /// client
+        /// will assume Octopus runs under a virtual directory.
+        /// </param>
+        /// <param name="apiKey">
+        /// The API key to use when connecting to the Octopus Server. For more information on API keys, please
+        /// see the API documentation on authentication
+        /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
+        /// </param>
         public OctopusServerEndpoint(string octopusServerAddress, string apiKey)
             : this(octopusServerAddress, apiKey, null)
         {
         }
 
-        /// <param name="octopusServerAddress"><inheritdoc cref="OctopusServer" path="summary/"/></param>
-        /// <param name="apiKeyOrToken">
-        /// API Key or Token used for authentication.
-        /// See <see cref="ApiKey"/> and <see cref="Token"/>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusServerEndpoint" /> class.
+        /// </summary>
+        /// <param name="octopusServerAddress">
+        /// The URI of the Octopus Server. Ideally this should end with <c>/api</c>. If it ends with any other segment, the
+        /// client
+        /// will assume Octopus runs under a virtual directory.
         /// </param>
-        /// <param name="credentials"><inheritdoc cref="Credentials" path="summary/"/></param>
-        /// <param name="isToken">
-        /// Indicates if <see langword="apiKeyOrToken"/> is a token or not. The default is <see langword="false"/>.
+        /// <param name="apiKey">
+        /// The API key to use when connecting to the Octopus Server. For more information on API keys, please
+        /// see the API documentation on authentication
+        /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
         /// </param>
-        public OctopusServerEndpoint(string octopusServerAddress, string apiKeyOrToken, ICredentials credentials, bool isToken = false)
-        : this(ParseOctopusServerAddress(octopusServerAddress), apiKeyOrToken, credentials, isToken)
+        /// <param name="credentials">
+        /// Additional credentials to use when communicating to servers that require integrated/basic
+        /// authentication.
+        /// </param>
+        public OctopusServerEndpoint(string octopusServerAddress, string apiKey, ICredentials credentials)
         {
+            if (string.IsNullOrWhiteSpace(octopusServerAddress))
+                throw new ArgumentException("An Octopus Server URI was not specified.");
+
+            if (!Uri.TryCreate(octopusServerAddress, UriKind.Absolute, out var uri) || !uri.Scheme.StartsWith("http"))
+                throw new ArgumentException($"The Octopus Server URI '{octopusServerAddress}' is invalid. The URI should start with http:// or https:// and be a valid URI.");
+
+            octopusServer = new DefaultLinkResolver(new Uri(octopusServerAddress));
+            this.apiKey = apiKey;
+            this.credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
         }
 
-        /// <param name="octopusServer"><inheritdoc cref="OctopusServer" path="summary/"/></param>
-        /// <param name="apiKeyOrToken">
-        /// API Key or Token used for authentication.
-        /// See <see cref="ApiKey"/> and <see cref="Token"/>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusServerEndpoint" /> class.
+        /// </summary>
+        /// <param name="octopusServer">The resolver that should be used to turn relative links into full URIs.</param>
+        /// <param name="apiKey">
+        /// The API key to use when connecting to the Octopus Server. For more information on API keys, please
+        /// see the API documentation on authentication
+        /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
         /// </param>
-        /// <param name="credentials"><inheritdoc cref="Credentials" path="summary/"/></param>
-        /// <param name="isToken">
-        /// Indicates if <see langword="apiKeyOrToken"/> is a token or not. The default is <see langword="false"/>.
+        /// <param name="credentials">
+        /// Additional credentials to use when communicating to servers that require integrated/basic
+        /// authentication.
         /// </param>
-        public OctopusServerEndpoint(ILinkResolver octopusServer, string apiKeyOrToken, ICredentials credentials, bool isToken = false)
+        public OctopusServerEndpoint(ILinkResolver octopusServer, string apiKey, ICredentials credentials)
         {
-            if (string.IsNullOrWhiteSpace(apiKeyOrToken))
-                throw new ArgumentException($"{(isToken ? "A Token" : "An API key")} was not specified but is required. If you This can be gotten from your user profile page under the Octopus web portal.");
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentException("An API key was not specified. Please set an API key using the ApiKey property. This can be gotten from your user profile page under the Octopus web portal.");
 
-            OctopusServer = octopusServer;
-            ApiKey = !isToken ? apiKeyOrToken : null;
-            Token = isToken ? apiKeyOrToken : null;
-            Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
+            this.octopusServer = octopusServer;
+            this.apiKey = apiKey;
+            this.credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
         }
 
         /// <summary>
         /// The URI of the Octopus Server. Ideally this should end with <c>/api</c>. If it ends with any other segment, the
         /// client  will assume Octopus runs under a virtual directory.
         /// </summary>
-        public ILinkResolver OctopusServer { get; }
+        public ILinkResolver OctopusServer => octopusServer;
 
         /// <summary>
         /// Indicates whether a secure (SSL) connection is being used to communicate with the server.
         /// </summary>
-        public bool IsUsingSecureConnection => OctopusServer.IsUsingSecureConnection;
+        public bool IsUsingSecureConnection => octopusServer.IsUsingSecureConnection;
 
         /// <summary>
-        /// The API key to use when connecting to the Octopus Server.
-        ///
-        /// For more information on API keys, please see the API documentation on authentication
+        /// Gets the API key to use when connecting to the Octopus Server. For more information on API keys, please see the API
+        /// documentation on authentication
         /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
         /// </summary>
-        public string ApiKey { get; }
+        public string ApiKey => apiKey;
 
         /// <summary>
-        /// The JWT Token to use when connecting to the Octopus Server.
+        /// Gets the additional credentials to use when communicating to servers that require integrated/basic authentication.
         /// </summary>
-        public string Token { get; }
-
-        /// <summary>
-        /// The additional credentials to use when communicating to servers that require integrated/basic authentication.
-        /// </summary>
-        public ICredentials Credentials { get; }
+        public ICredentials Credentials => credentials;
 
         /// <summary>
         /// Recreates the endpoint using the API key of a new user.
@@ -104,23 +127,12 @@ namespace Octopus.Client
         /// <returns>An endpoint with a new user.</returns>
         public OctopusServerEndpoint AsUser(string newUserApiKey)
         {
-            return new OctopusServerEndpoint(OctopusServer, newUserApiKey, Credentials);
+            return new OctopusServerEndpoint(octopusServer, newUserApiKey, credentials);
         }
 
         /// <summary>
         /// A proxy that should be used to connect to the endpoint.
         /// </summary>
         public IWebProxy Proxy { get; set; }
-
-        private static DefaultLinkResolver ParseOctopusServerAddress(string address)
-        {
-            if (string.IsNullOrWhiteSpace(address))
-                throw new ArgumentException("An Octopus Server URI was not specified.");
-
-            if (!Uri.TryCreate(address, UriKind.Absolute, out var uri) || !uri.Scheme.StartsWith("http"))
-                throw new ArgumentException($"The Octopus Server URI '{address}' is invalid. The URI should start with http:// or https:// and be a valid URI.");
-
-            return new DefaultLinkResolver(new Uri(address));
-        }
     }
 }

--- a/source/Octopus.Server.Client/OctopusServerEndpoint.cs
+++ b/source/Octopus.Server.Client/OctopusServerEndpoint.cs
@@ -11,7 +11,7 @@ namespace Octopus.Client
         /// <summary>
         /// Create an instance with a Token to authenticate.
         /// </summary>
-        public static OctopusServerEndpoint CreateWithToken(string octopusServerAddress, string bearerToken, ICredentials credentials = null)
+        public static OctopusServerEndpoint CreateWithBearerToken(string octopusServerAddress, string bearerToken, ICredentials credentials = null)
         {
             return new OctopusServerEndpoint(octopusServerAddress, new BearerTokenValue(bearerToken), credentials);
         }
@@ -27,7 +27,7 @@ namespace Octopus.Client
         private OctopusServerEndpoint(string octopusServerAddress, BearerTokenValue bearerTokenValue, ICredentials credentials)
         {
             if (string.IsNullOrWhiteSpace(bearerTokenValue.Value))
-                throw new ArgumentException("Token is required.");
+                throw new ArgumentException("BearerToken is required.");
 
             OctopusServer = GetLinkResolverFromServerUrl(octopusServerAddress);
             BearerToken = bearerTokenValue.Value;

--- a/source/Octopus.Server.Client/OctopusServerEndpoint.cs
+++ b/source/Octopus.Server.Client/OctopusServerEndpoint.cs
@@ -8,9 +8,31 @@ namespace Octopus.Client
     /// </summary>
     public class OctopusServerEndpoint
     {
-        readonly ILinkResolver octopusServer;
-        readonly string apiKey;
-        readonly ICredentials credentials;
+        /// <summary>
+        /// Create an instance with a Token to authenticate.
+        /// </summary>
+        public static OctopusServerEndpoint CreateWithToken(string octopusServerAddress, string token, ICredentials credentials = null)
+        {
+            return new OctopusServerEndpoint(octopusServerAddress, new TokenValue(token), credentials);
+        }
+
+        /// <summary>
+        /// Create an instance with an API Key to authenticate.
+        /// </summary>
+        public static OctopusServerEndpoint CreateWithApiKey(string octopusServerAddress, string apiKey, ICredentials credentials = null)
+        {
+            return new OctopusServerEndpoint(octopusServerAddress, apiKey, credentials);
+        }
+
+        private OctopusServerEndpoint(string octopusServerAddress, TokenValue token, ICredentials credentials)
+        {
+            if (string.IsNullOrWhiteSpace(token.Value))
+                throw new ArgumentException("Token is required.");
+
+            OctopusServer = GetLinkResolverFromServerUrl(octopusServerAddress);
+            Token = token.Value;
+            Credentials = credentials;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OctopusServerEndpoint" /> class. Since no API key is provided, only
@@ -22,8 +44,8 @@ namespace Octopus.Client
         /// will assume Octopus runs under a virtual directory.
         /// </param>
         public OctopusServerEndpoint(string octopusServerAddress)
-            : this(octopusServerAddress, null)
         {
+            OctopusServer = GetLinkResolverFromServerUrl(octopusServerAddress);
         }
 
         /// <summary>
@@ -61,17 +83,8 @@ namespace Octopus.Client
         /// Additional credentials to use when communicating to servers that require integrated/basic
         /// authentication.
         /// </param>
-        public OctopusServerEndpoint(string octopusServerAddress, string apiKey, ICredentials credentials)
+        public OctopusServerEndpoint(string octopusServerAddress, string apiKey, ICredentials credentials) : this(GetLinkResolverFromServerUrl(octopusServerAddress), apiKey, credentials ?? CredentialCache.DefaultNetworkCredentials)
         {
-            if (string.IsNullOrWhiteSpace(octopusServerAddress))
-                throw new ArgumentException("An Octopus Server URI was not specified.");
-
-            if (!Uri.TryCreate(octopusServerAddress, UriKind.Absolute, out var uri) || !uri.Scheme.StartsWith("http"))
-                throw new ArgumentException($"The Octopus Server URI '{octopusServerAddress}' is invalid. The URI should start with http:// or https:// and be a valid URI.");
-
-            octopusServer = new DefaultLinkResolver(new Uri(octopusServerAddress));
-            this.apiKey = apiKey;
-            this.credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
         }
 
         /// <summary>
@@ -92,33 +105,38 @@ namespace Octopus.Client
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new ArgumentException("An API key was not specified. Please set an API key using the ApiKey property. This can be gotten from your user profile page under the Octopus web portal.");
 
-            this.octopusServer = octopusServer;
-            this.apiKey = apiKey;
-            this.credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
+            OctopusServer = octopusServer;
+            ApiKey = apiKey;
+            Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials;
         }
 
         /// <summary>
         /// The URI of the Octopus Server. Ideally this should end with <c>/api</c>. If it ends with any other segment, the
         /// client  will assume Octopus runs under a virtual directory.
         /// </summary>
-        public ILinkResolver OctopusServer => octopusServer;
+        public ILinkResolver OctopusServer { get; }
 
         /// <summary>
         /// Indicates whether a secure (SSL) connection is being used to communicate with the server.
         /// </summary>
-        public bool IsUsingSecureConnection => octopusServer.IsUsingSecureConnection;
+        public bool IsUsingSecureConnection => OctopusServer.IsUsingSecureConnection;
 
         /// <summary>
         /// Gets the API key to use when connecting to the Octopus Server. For more information on API keys, please see the API
         /// documentation on authentication
         /// (https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/sections/authentication.md).
         /// </summary>
-        public string ApiKey => apiKey;
+        public string ApiKey { get; }
+
+        /// <summary>
+        /// A JWT Token that can be used to authenticate calls to the Server.
+        /// </summary>
+        public string Token { get; }
 
         /// <summary>
         /// Gets the additional credentials to use when communicating to servers that require integrated/basic authentication.
         /// </summary>
-        public ICredentials Credentials => credentials;
+        public ICredentials Credentials { get; }
 
         /// <summary>
         /// Recreates the endpoint using the API key of a new user.
@@ -127,12 +145,35 @@ namespace Octopus.Client
         /// <returns>An endpoint with a new user.</returns>
         public OctopusServerEndpoint AsUser(string newUserApiKey)
         {
-            return new OctopusServerEndpoint(octopusServer, newUserApiKey, credentials);
+            return new OctopusServerEndpoint(OctopusServer, newUserApiKey, Credentials);
         }
 
         /// <summary>
         /// A proxy that should be used to connect to the endpoint.
         /// </summary>
         public IWebProxy Proxy { get; set; }
+
+        private static DefaultLinkResolver GetLinkResolverFromServerUrl(string octopusServerAddress)
+        {
+            if (string.IsNullOrWhiteSpace(octopusServerAddress))
+                throw new ArgumentException("An Octopus Server URI was not specified.");
+
+            if (!Uri.TryCreate(octopusServerAddress, UriKind.Absolute, out var uri) || !uri.Scheme.StartsWith("http"))
+                throw new ArgumentException($"The Octopus Server URI '{octopusServerAddress}' is invalid. The URI should start with http:// or https:// and be a valid URI.");
+
+            return new DefaultLinkResolver(new Uri(octopusServerAddress));
+        }
+
+        private class TokenValue
+        {
+            public TokenValue(string value)
+            {
+                Value = value;
+            }
+
+            public string Value { get; }
+        }
     }
+
+
 }


### PR DESCRIPTION
Adding the ability for OctopusClient to use Tokens for authentication.

This does not include the ability for OctopusClient to facilitate a OIDC Token Exchange, and just allows the client to use a valid JWT Token that it is given.

This is being added so that Tentacle can use a Token to register itself as part of work over in [#project-k8s-agent](https://octopusdeploy.slack.com/archives/C05KK1G85J5). We want to be able to generate a token on server as part of generating a command for the user to run to install the Tentacle on their kubernetes cluster. This means for our use-case, Tentacle does not need to generate its own token and this update can be used instead.

[sc-60667]