### PR TITLE
Add new net48 build target

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,6 +58,14 @@ jobs:
           path: ./TestResults/Win_net462_*.trx
           reporter: dotnet-trx
           fail-on-error: true
+      - name: Windows .Net 4.8 unit test report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Windows.Net 4.8 unit test results
+          path: ./TestResults/Win_net48_*.trx
+          reporter: dotnet-trx
+          fail-on-error: true
       - name: Windows .Net 6.0 unit test report
         uses: dorny/test-reporter@v1
         if: success() || failure()    # run this step even if previous step failed
@@ -72,6 +80,14 @@ jobs:
         with:
           name: Windows .Net 4.62 E2E test results
           path: ./TestResults/Win-E2E_net462_*.trx
+          reporter: dotnet-trx
+          fail-on-error: true
+      - name: Windows .Net 4.8 E2E test report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Windows .Net 4.8 E2E test results
+          path: ./TestResults/Win-E2E_net48_*.trx
           reporter: dotnet-trx
           fail-on-error: true
       - name: Windows .Net 6.0 E2E test report

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -104,7 +104,7 @@ class Build : NukeBuild
         .DependsOn(Compile)
         .Executes(() =>
         {
-            foreach (var target in new[] {"net462", "netstandard2.0"})
+            foreach (var target in new[] {"net462", "net48","netstandard2.0"})
             {
                 var inputFolder = OctopusClientFolder / "bin" / Configuration / target;
                 var outputFolder = OctopusClientFolder / "bin" / Configuration / $"{target}Merged";
@@ -230,12 +230,12 @@ class Build : NukeBuild
         .Executes(() =>
         {
             EnsureCleanDirectory(RootDirectory / "TestResults");
-            
+
             DockerComposeBuild(RootDirectory / "docker-compose.build.yml", "--no-cache");
             DockerComposeUp(RootDirectory / "docker-compose.test.yml");
             DockerComposeDown(RootDirectory / "docker-compose.test.yml");
 
-            var unitTestResultFiles =  Directory.GetFiles(RootDirectory / "TestResults", "*.trx"); 
+            var unitTestResultFiles =  Directory.GetFiles(RootDirectory / "TestResults", "*.trx");
 
             Assert.Count(unitTestResultFiles, 11, "Incorrect number of results files found");
         });
@@ -309,7 +309,7 @@ class Build : NukeBuild
 
         Log.Information($"Finished signing {files.Length} files.");
     }
-    
+
     void SignWithAzureSignTool(AbsolutePath[] files, string timestampUrl)
     {
         Log.Information("Signing files using azuresigntool and the production code signing certificate.");

--- a/source/Octopus.Client.E2ETests/NuSpecDependenciesFixture.cs
+++ b/source/Octopus.Client.E2ETests/NuSpecDependenciesFixture.cs
@@ -75,7 +75,7 @@ namespace Octopus.Client.E2ETests
         public void NuSpecFileShouldHaveADependencyGroupForEachTargetFramework()
         {
             var dependencyGroups = nuSpecFile.SelectNodes("//ns:package/ns:metadata/ns:dependencies/ns:group", nameSpaceManager);
-            dependencyGroups.Count.Should().Be(2, "Should have 2 dependency groups");
+            dependencyGroups.Count.Should().Be(3, "Should have 3 dependency groups");
         }
 
         public static TestCaseData[] DependencyExpectations =
@@ -156,13 +156,13 @@ namespace Octopus.Client.E2ETests
         public void NuSpecFileShouldOnlyHaveFrameworkAssembliesForNetFramework()
         {
             var dependencies = nuSpecFile.SelectNodes(
-                "//ns:package/ns:metadata/ns:frameworkAssemblies/ns:frameworkAssembly[@targetFramework != '.NETFramework4.6.2']",
+                "//ns:package/ns:metadata/ns:frameworkAssemblies/ns:frameworkAssembly[@targetFramework != '.NETFramework4.6.2' and @targetFramework != '.NETFramework4.8']",
                 nameSpaceManager);
-            dependencies.Count.Should().Be(0, "There should be only be frameworkAssemblies listed for .NETFramework4.6.2");
+            dependencies.Count.Should().Be(0, "There should be only be frameworkAssemblies listed for .NETFramework4.6.2 and .NETFramework4.8");
         }
 
         [Test]
-        public void NuSpecFileShouldHave3FrameworkAssembliesForNetFramework()
+        public void NuSpecFileShouldHave3FrameworkAssembliesForNetFramework462()
         {
             var dependencies = nuSpecFile.SelectNodes(
                 "//ns:package/ns:metadata/ns:frameworkAssemblies/ns:frameworkAssembly[@targetFramework = '.NETFramework4.6.2']",
@@ -171,15 +171,36 @@ namespace Octopus.Client.E2ETests
         }
 
         [Test]
+        public void NuSpecFileShouldHave3FrameworkAssembliesForNetFramework48()
+        {
+            var dependencies = nuSpecFile.SelectNodes(
+                "//ns:package/ns:metadata/ns:frameworkAssemblies/ns:frameworkAssembly[@targetFramework = '.NETFramework4.8']",
+                nameSpaceManager);
+            dependencies.Count.Should().Be(3, "There should be 3 frameworkAssemblies listed for .NETFramework4.8");
+        }
+
+        [Test]
         [TestCase("System.ComponentModel.DataAnnotations")]
         [TestCase("System.Net.Http")]
         [TestCase("System.Numerics")]
-        public void NuSpecFileShouldHaveSystemComponentModelDataAnnotationsFrameworkAssemblyForNetFramework(string assemblyName)
+        public void NuSpecFileShouldHaveSystemComponentModelDataAnnotationsFrameworkAssemblyForNetFramework462(string assemblyName)
         {
             var frameworkAssembly = nuSpecFile.SelectSingleNode(
                 $"//ns:package/ns:metadata/ns:frameworkAssemblies/ns:frameworkAssembly[@targetFramework = '.NETFramework4.6.2' and @assemblyName = '{assemblyName}']",
                 nameSpaceManager);
             frameworkAssembly.Should().NotBeNull($"Should have a frameworkAssembly node for '{assemblyName}' for .NETFramework4.6.2");
+        }
+
+        [Test]
+        [TestCase("System.ComponentModel.DataAnnotations")]
+        [TestCase("System.Net.Http")]
+        [TestCase("System.Numerics")]
+        public void NuSpecFileShouldHaveSystemComponentModelDataAnnotationsFrameworkAssemblyForNetFramework48(string assemblyName)
+        {
+            var frameworkAssembly = nuSpecFile.SelectSingleNode(
+                $"//ns:package/ns:metadata/ns:frameworkAssemblies/ns:frameworkAssembly[@targetFramework = '.NETFramework4.8' and @assemblyName = '{assemblyName}']",
+                nameSpaceManager);
+            frameworkAssembly.Should().NotBeNull($"Should have a frameworkAssembly node for '{assemblyName}' for .NETFramework4.8");
         }
     }
 }

--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -34,7 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="System.IO.Compression" />
+        <Reference Include="System.IO.Compression" />
+        <Reference Include="System.Net.Http" />
     </ItemGroup>
 
 </Project>

--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -10,7 +10,7 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net462;net6.0</TargetFrameworks>
+        <TargetFrameworks>net462;net48;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFrameworks>net6.0</TargetFrameworks>

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -12,13 +12,13 @@
     <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net48;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net48' ">
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier> <!-- So that libuv is copied correctly -->
     <BaseNuGetRuntimeIdentifier>win7-x86</BaseNuGetRuntimeIdentifier> <!-- So that libuv is copied correctly -->
   </PropertyGroup>
@@ -55,7 +55,7 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="Libuv" Version="1.10.0" />
     <PackageReference Include="Best.Conventional" Version="1.3.0.122" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -47,7 +47,6 @@
     <PackageReference Include="Nancy" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="Serilog" Version="2.3.0" />
-
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0" />
@@ -60,6 +59,7 @@
     <PackageReference Include="Best.Conventional" Version="1.3.0.122" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/source/Octopus.Client/Octopus.Client.csproj
+++ b/source/Octopus.Client/Octopus.Client.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-		<TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net462;net48</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">

--- a/source/Octopus.Client/Octopus.Client.csproj
+++ b/source/Octopus.Client/Octopus.Client.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-		<TargetFrameworks>netstandard2.0;net462;net48</TargetFrameworks>
+		<TargetFrameworks>net462;net48;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">

--- a/source/Octopus.Client/Octopus.Client.nuspec
+++ b/source/Octopus.Client/Octopus.Client.nuspec
@@ -16,6 +16,8 @@
         <dependencies>
             <group targetFramework=".NETFramework4.6.2">
             </group>
+            <group targetFramework=".NETFramework4.8">
+            </group>
 
             <group targetFramework=".NETStandard2.0">
                 <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
@@ -27,12 +29,18 @@
             <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework=".NETFramework4.6.2" />
             <frameworkAssembly assemblyName="System.Net.Http" targetFramework=".NETFramework4.6.2" />
             <frameworkAssembly assemblyName="System.Numerics" targetFramework=".NETFramework4.6.2" />
+
+            <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework=".NETFramework4.8" />
+            <frameworkAssembly assemblyName="System.Net.Http" targetFramework=".NETFramework4.8" />
+            <frameworkAssembly assemblyName="System.Numerics" targetFramework=".NETFramework4.8" />
         </frameworkAssemblies>
     </metadata>
     <files>
         <file src="icon.png" target="images\" />
         <file src="bin\release\net462\Octopus.Client.dll" target="lib\net462" />
         <file src="bin\release\net462\Octopus.Client.xml" target="lib\net462" />
+        <file src="bin\release\net48\Octopus.Client.dll" target="lib\net48" />
+        <file src="bin\release\net48\Octopus.Client.xml" target="lib\net48" />
         <file src="bin\release\netstandard2.0\Octopus.Client.dll" target="lib\netstandard2.0" />
         <file src="bin\release\netstandard2.0\Octopus.Client.xml" target="lib\netstandard2.0" />
     </files>

--- a/source/Octopus.Server.Client/Octopus.Server.Client.csproj
+++ b/source/Octopus.Server.Client/Octopus.Server.Client.csproj
@@ -20,19 +20,19 @@ This package contains the non-ILmerged client library for the HTTP API in Octopu
 	  <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net48</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net48' ">
     <DebugType>embedded</DebugType>
     <DefineConstants>$(DefineConstants);FULL_FRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS;LIBLOG_PORTABLE</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net48' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Net.Http" />

--- a/source/Octopus.Server.Client/Octopus.Server.Client.csproj
+++ b/source/Octopus.Server.Client/Octopus.Server.Client.csproj
@@ -20,7 +20,7 @@ This package contains the non-ILmerged client library for the HTTP API in Octopu
 	  <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>netstandard2.0;net462;net48</TargetFrameworks>
+    <TargetFrameworks>net462;net48;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
To allow us to upgrade `OctopusClient` in `OctopusTentacle`, we need to support .Net Framework 4.8

Unfortunately when we try and use the .Net Framework 4.6.2 we get some versioning issues with `System.Net.Http`.

In testing, creating a .Net Framework 4.8 version in the Nuget package eliminated the issues.