### PR TITLE
Fix Dockerfiles by making dotnet install more reliable

### DIFF
--- a/build/containers/test-base/amazon2/Dockerfile
+++ b/build/containers/test-base/amazon2/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install \
         gzip \
         icu
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/amazon2/Dockerfile
+++ b/build/containers/test-base/amazon2/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install \
         gzip \
         icu
 
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/amazon2/Dockerfile
+++ b/build/containers/test-base/amazon2/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install \
         gzip \
         icu
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/centos7/Dockerfile
+++ b/build/containers/test-base/centos7/Dockerfile
@@ -12,9 +12,7 @@ RUN yum install \
         libunwind \
     -y
 
-RUN yum update curl -y
-
-RUN curl -sSLk https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/centos7/Dockerfile
+++ b/build/containers/test-base/centos7/Dockerfile
@@ -12,6 +12,10 @@ RUN yum install \
         libunwind \
     -y
 
+# Centos seems to ship with a version of curl which doesn't work with the https://dot.net url below.
+# Updating it seems to fix the issue.
+RUN yum update curl -y
+
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.

--- a/build/containers/test-base/centos7/Dockerfile
+++ b/build/containers/test-base/centos7/Dockerfile
@@ -12,7 +12,7 @@ RUN yum install \
         libunwind \
     -y
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/centos7/Dockerfile
+++ b/build/containers/test-base/centos7/Dockerfile
@@ -12,7 +12,7 @@ RUN yum install \
         libunwind \
     -y
 
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/centos7/Dockerfile
+++ b/build/containers/test-base/centos7/Dockerfile
@@ -12,11 +12,9 @@ RUN yum install \
         libunwind \
     -y
 
-# Centos seems to ship with a version of curl which doesn't work with the https://dot.net url below.
-# Updating it seems to fix the issue.
 RUN yum update curl -y
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSLk https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/debianBuster/Dockerfile
+++ b/build/containers/test-base/debianBuster/Dockerfile
@@ -22,7 +22,7 @@ RUN unlink /etc/localtime && ln -s /usr/share/zoneinfo/Australia/Brisbane /etc/l
     chmod -R g+rwx /etc/octopus
 
 # Install .NET SDKs
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1

--- a/build/containers/test-base/debianBuster/Dockerfile
+++ b/build/containers/test-base/debianBuster/Dockerfile
@@ -22,7 +22,7 @@ RUN unlink /etc/localtime && ln -s /usr/share/zoneinfo/Australia/Brisbane /etc/l
     chmod -R g+rwx /etc/octopus
 
 # Install .NET SDKs
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1

--- a/build/containers/test-base/debianBuster/Dockerfile
+++ b/build/containers/test-base/debianBuster/Dockerfile
@@ -22,7 +22,7 @@ RUN unlink /etc/localtime && ln -s /usr/share/zoneinfo/Australia/Brisbane /etc/l
     chmod -R g+rwx /etc/octopus
 
 # Install .NET SDKs
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1

--- a/build/containers/test-base/fedora35/Dockerfile
+++ b/build/containers/test-base/fedora35/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install \
         libunwind \
     -y
 
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY  Dockerfile /

--- a/build/containers/test-base/fedora35/Dockerfile
+++ b/build/containers/test-base/fedora35/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install \
         libunwind \
     -y
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
-COPY Dockerfile /
+COPY  Dockerfile /

--- a/build/containers/test-base/fedora35/Dockerfile
+++ b/build/containers/test-base/fedora35/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install \
         libunwind \
     -y
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY  Dockerfile /

--- a/build/containers/test-base/openSuseLeap15/Dockerfile
+++ b/build/containers/test-base/openSuseLeap15/Dockerfile
@@ -13,7 +13,7 @@ RUN zypper --non-interactive install \
         icu \
         curl
 
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/openSuseLeap15/Dockerfile
+++ b/build/containers/test-base/openSuseLeap15/Dockerfile
@@ -13,7 +13,7 @@ RUN zypper --non-interactive install \
         icu \
         curl
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/openSuseLeap15/Dockerfile
+++ b/build/containers/test-base/openSuseLeap15/Dockerfile
@@ -13,7 +13,7 @@ RUN zypper --non-interactive install \
         icu \
         curl
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/openSuseTumbleweed/Dockerfile
+++ b/build/containers/test-base/openSuseTumbleweed/Dockerfile
@@ -12,7 +12,7 @@ RUN zypper --non-interactive install \
         gzip \
         icu
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/openSuseTumbleweed/Dockerfile
+++ b/build/containers/test-base/openSuseTumbleweed/Dockerfile
@@ -12,7 +12,7 @@ RUN zypper --non-interactive install \
         gzip \
         icu
 
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/openSuseTumbleweed/Dockerfile
+++ b/build/containers/test-base/openSuseTumbleweed/Dockerfile
@@ -12,7 +12,7 @@ RUN zypper --non-interactive install \
         gzip \
         icu
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/rhel9/Dockerfile
+++ b/build/containers/test-base/rhel9/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install \
         compat-openssl11 \
     -y
 
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/rhel9/Dockerfile
+++ b/build/containers/test-base/rhel9/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install \
         compat-openssl11 \
     -y
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/rhel9/Dockerfile
+++ b/build/containers/test-base/rhel9/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install \
         compat-openssl11 \
     -y
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/rocky9/Dockerfile
+++ b/build/containers/test-base/rocky9/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf install \
         gzip \
     -y
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/rocky9/Dockerfile
+++ b/build/containers/test-base/rocky9/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf install \
         gzip \
     -y
 
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/rocky9/Dockerfile
+++ b/build/containers/test-base/rocky9/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf install \
         gzip \
     -y
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu16/Dockerfile
+++ b/build/containers/test-base/ubuntu16/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 
 # Install .NET SDKs
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu16/Dockerfile
+++ b/build/containers/test-base/ubuntu16/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 
 # Install .NET SDKs
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu16/Dockerfile
+++ b/build/containers/test-base/ubuntu16/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 
 # Install .NET SDKs
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu18/Dockerfile
+++ b/build/containers/test-base/ubuntu18/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu18/Dockerfile
+++ b/build/containers/test-base/ubuntu18/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu18/Dockerfile
+++ b/build/containers/test-base/ubuntu18/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu20/Dockerfile
+++ b/build/containers/test-base/ubuntu20/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu20/Dockerfile
+++ b/build/containers/test-base/ubuntu20/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /

--- a/build/containers/test-base/ubuntu20/Dockerfile
+++ b/build/containers/test-base/ubuntu20/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV PATH=/usr/share/dotnet:${PATH}
-RUN curl -sSL http://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet
+RUN curl -sSL http://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /usr/share/dotnet
 
 # Convention to allow users of this tool container to easily see how it was created.
 COPY Dockerfile /


### PR DESCRIPTION
After much fiddling it seems that making it install `dotnet` using the insecure `http://` makes it a lot more reliable as we seem to consistently get SSL issues causing the curl command to fail.

I'm just not sure if this is acceptable?