### PR TITLE
Update EndpointResources and add interfaces

### DIFF
--- a/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
@@ -95,7 +95,7 @@ namespace Octopus.Client.Tests.Operations
 
             await client.Received().Create("/api/machines", Arg.Is<MachineResource>(m =>
                     m.Name == "Mymachine"
-                    && ((ListeningTentacleEndpointResource)m.Endpoint).Uri == "https://mymachine.test.com:10930/"
+                    && ((IListeningTentacleEndpointResource)m.Endpoint).Uri == "https://mymachine.test.com:10930/"
                     && m.EnvironmentIds.First() == "environments-2"),
                     Arg.Any<object>(), Arg.Any<CancellationToken>())
                 .ConfigureAwait(false);
@@ -165,7 +165,7 @@ namespace Octopus.Client.Tests.Operations
 
             await client.Received().Create("/api/machines", Arg.Is<MachineResource>(m =>
                 m.Name == "Mymachine"
-                && ((ListeningTentacleEndpointResource)m.Endpoint).Uri == "https://mymachine.test.com:10930/"
+                && ((IListeningTentacleEndpointResource)m.Endpoint).Uri == "https://mymachine.test.com:10930/"
                 && m.EnvironmentIds.First() == "environments-2"),
                 Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6460,6 +6460,22 @@ Octopus.Client.Model.Endpoints
   {
     String AuthenticationType { get; }
   }
+  interface IListeningTentacleEndpointResource
+    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
+  {
+    String ProxyId { get; set; }
+  }
+  interface IPollingTentacleEndpointResource
+    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
+  {
+  }
+  interface ITentacleEndpointResource
+  {
+    String CertificateSignatureAlgorithm { get; set; }
+    Octopus.Client.Model.Endpoints.TentacleDetailsResource TentacleVersionDetails { get; set; }
+    String Thumbprint { get; set; }
+    String Uri { get; set; }
+  }
   class KubernetesAwsAuthenticationResource
     Octopus.Client.Model.Endpoints.IEndpointWithMultipleAuthenticationResource
     Octopus.Client.Model.Endpoints.KubernetesStandardAccountAuthenticationResource
@@ -6538,12 +6554,13 @@ Octopus.Client.Model.Endpoints
   class ListeningTentacleEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
+    Octopus.Client.Model.Endpoints.IListeningTentacleEndpointResource
     Octopus.Client.Model.Endpoints.TentacleEndpointResource
   {
     .ctor()
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
     String ProxyId { get; set; }
-    String Uri { get; set; }
   }
   class OfflineDropDestinationResource
   {
@@ -6572,11 +6589,12 @@ Octopus.Client.Model.Endpoints
   class PollingTentacleEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
+    Octopus.Client.Model.Endpoints.IPollingTentacleEndpointResource
     Octopus.Client.Model.Endpoints.TentacleEndpointResource
   {
     .ctor()
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
-    String Uri { get; set; }
   }
   class ServiceFabricEndpointResource
     Octopus.Client.Extensibility.IResource
@@ -6641,11 +6659,13 @@ Octopus.Client.Model.Endpoints
   abstract class TentacleEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
     Octopus.Client.Model.Endpoints.EndpointResource
   {
     String CertificateSignatureAlgorithm { get; set; }
     Octopus.Client.Model.Endpoints.TentacleDetailsResource TentacleVersionDetails { get; set; }
     String Thumbprint { get; set; }
+    String Uri { get; set; }
   }
 }
 Octopus.Client.Model.EventRetention

--- a/source/Octopus.Server.Client/Model/Endpoints/IListeningTentacleEndpointResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/IListeningTentacleEndpointResource.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model.Endpoints
+{
+    public interface IListeningTentacleEndpointResource : ITentacleEndpointResource
+    {
+        string ProxyId { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/Endpoints/IPollingTentacleEndpointResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/IPollingTentacleEndpointResource.cs
@@ -1,0 +1,6 @@
+namespace Octopus.Client.Model.Endpoints
+{
+    public interface IPollingTentacleEndpointResource : ITentacleEndpointResource
+    {
+    }
+}

--- a/source/Octopus.Server.Client/Model/Endpoints/ITentacleEndpointResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/ITentacleEndpointResource.cs
@@ -1,0 +1,13 @@
+namespace Octopus.Client.Model.Endpoints
+{
+    public interface ITentacleEndpointResource
+    {
+        string Thumbprint { get; set; }
+
+        string Uri { get; set; }
+
+        TentacleDetailsResource TentacleVersionDetails { get; set; }
+
+        string CertificateSignatureAlgorithm { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/Endpoints/ListeningTentacleEndpointResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/ListeningTentacleEndpointResource.cs
@@ -1,18 +1,10 @@
-using System;
 using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class ListeningTentacleEndpointResource : TentacleEndpointResource
+    public class ListeningTentacleEndpointResource : TentacleEndpointResource, IListeningTentacleEndpointResource
     {
-        public override CommunicationStyle CommunicationStyle
-        {
-            get { return CommunicationStyle.TentaclePassive; }
-        }
-
-        [Trim]
-        [Writeable]
-        public string Uri { get; set; }
+        public override CommunicationStyle CommunicationStyle => CommunicationStyle.TentaclePassive;
 
         [Writeable]
         public string ProxyId { get; set; }

--- a/source/Octopus.Server.Client/Model/Endpoints/PollingTentacleEndpointResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/PollingTentacleEndpointResource.cs
@@ -1,17 +1,7 @@
-using System;
-using Octopus.Client.Extensibility.Attributes;
-
 namespace Octopus.Client.Model.Endpoints
 {
-    public class PollingTentacleEndpointResource : TentacleEndpointResource
+    public class PollingTentacleEndpointResource : TentacleEndpointResource, IPollingTentacleEndpointResource
     {
-        public override CommunicationStyle CommunicationStyle
-        {
-            get { return CommunicationStyle.TentacleActive; }
-        }
-
-        [Trim]
-        [Writeable]
-        public string Uri { get; set; }
+        public override CommunicationStyle CommunicationStyle => CommunicationStyle.TentacleActive;
     }
 }

--- a/source/Octopus.Server.Client/Model/Endpoints/TentacleEndpointResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/TentacleEndpointResource.cs
@@ -1,15 +1,19 @@
-using System;
 using System.ComponentModel.DataAnnotations;
 using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public abstract class TentacleEndpointResource : EndpointResource
+    public abstract class TentacleEndpointResource : EndpointResource, ITentacleEndpointResource
     {
         [Required(ErrorMessage = "Please provide a thumbprint for this machine.")]
         [Trim]
         [Writeable]
         public string Thumbprint { get; set; }
+
+        [Required(ErrorMessage = "Please provide a URI for this machine.")]
+        [Trim]
+        [Writeable]
+        public string Uri { get; set; }
 
         [Writeable]
         public TentacleDetailsResource TentacleVersionDetails { get; set; }


### PR DESCRIPTION
This is one of the first steps toward adding the new Kubernetes Agent Target. #project-k8s-agent

To make things a bit neater I've moved a the `Uri` property to the base class and I've added interfaces to match the interfaces defined in Octopus Server.