### PR TITLE
Fix AgentCommunicationMode property name

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6574,7 +6574,7 @@ Octopus.Client.Model.Endpoints
     Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource
   {
     .ctor(String, String)
-    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationModeResource { get; }
+    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationMode { get; }
     String ProxyId { get; set; }
   }
   class ListeningTentacleEndpointResource
@@ -6618,7 +6618,7 @@ Octopus.Client.Model.Endpoints
     Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource
   {
     .ctor(String, String)
-    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationModeResource { get; }
+    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationMode { get; }
   }
   class PollingTentacleEndpointResource
     Octopus.Client.Extensibility.IResource
@@ -6694,7 +6694,7 @@ Octopus.Client.Model.Endpoints
     Octopus.Client.Model.Endpoints.ITentacleEndpointResource
   {
     String CertificateSignatureAlgorithm { get; set; }
-    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationModeResource { get; }
+    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationMode { get; }
     Octopus.Client.Model.Endpoints.TentacleDetailsResource TentacleVersionDetails { get; set; }
     String Thumbprint { get; set; }
     String Uri { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6598,7 +6598,7 @@ Octopus.Client.Model.Endpoints
     Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource
   {
     .ctor(String, String)
-    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationModeResource { get; }
+    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationMode { get; }
     String ProxyId { get; set; }
   }
   class ListeningTentacleEndpointResource
@@ -6642,7 +6642,7 @@ Octopus.Client.Model.Endpoints
     Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource
   {
     .ctor(String, String)
-    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationModeResource { get; }
+    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationMode { get; }
   }
   class PollingTentacleEndpointResource
     Octopus.Client.Extensibility.IResource
@@ -6718,7 +6718,7 @@ Octopus.Client.Model.Endpoints
     Octopus.Client.Model.Endpoints.ITentacleEndpointResource
   {
     String CertificateSignatureAlgorithm { get; set; }
-    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationModeResource { get; }
+    Octopus.Client.Model.Endpoints.AgentCommunicationModeResource CommunicationMode { get; }
     Octopus.Client.Model.Endpoints.TentacleDetailsResource TentacleVersionDetails { get; set; }
     String Thumbprint { get; set; }
     String Uri { get; set; }

--- a/source/Octopus.Server.Client/Model/Endpoints/ListeningTentacleEndpointConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/ListeningTentacleEndpointConfigurationResource.cs
@@ -12,7 +12,7 @@ namespace Octopus.Client.Model.Endpoints
         {
         }
 
-        public override AgentCommunicationModeResource CommunicationModeResource => AgentCommunicationModeResource.Listening;
+        public override AgentCommunicationModeResource CommunicationMode => AgentCommunicationModeResource.Listening;
 
         [Writeable]
         public string ProxyId { get; set; }

--- a/source/Octopus.Server.Client/Model/Endpoints/PollingTentacleEndpointConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/PollingTentacleEndpointConfigurationResource.cs
@@ -2,7 +2,7 @@ namespace Octopus.Client.Model.Endpoints
 {
     public class PollingTentacleEndpointConfigurationResource : TentacleEndpointConfigurationResource, IPollingTentacleEndpointResource
     {
-        public override AgentCommunicationModeResource CommunicationModeResource => AgentCommunicationModeResource.Polling;
+        public override AgentCommunicationModeResource CommunicationMode => AgentCommunicationModeResource.Polling;
 
         protected PollingTentacleEndpointConfigurationResource()
         {

--- a/source/Octopus.Server.Client/Model/Endpoints/TentacleEndpointConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/TentacleEndpointConfigurationResource.cs
@@ -16,7 +16,7 @@ namespace Octopus.Client.Model.Endpoints
         }
 
 
-        public abstract AgentCommunicationModeResource CommunicationModeResource { get; }
+        public abstract AgentCommunicationModeResource CommunicationMode { get; }
 
         [Required(ErrorMessage = "Please provide a thumbprint for this machine.")]
         [Trim]

--- a/source/Octopus.Server.Client/Serialization/TentacleConfigurationConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/TentacleConfigurationConverter.cs
@@ -14,5 +14,5 @@ public class TentacleConfigurationConverter: InheritedClassConverter<TentacleEnd
         };
 
     protected override IDictionary<AgentCommunicationModeResource, Type> DerivedTypeMappings => EndpointTypes;
-    protected override string TypeDesignatingPropertyName => nameof(TentacleEndpointConfigurationResource.CommunicationModeResource);
+    protected override string TypeDesignatingPropertyName => nameof(TentacleEndpointConfigurationResource.CommunicationMode);
 }


### PR DESCRIPTION
I accidentally renamed this property when I was using Rider's refactor.

Just naming back to what I wanted it to be.