### PR TITLE
Revert "Add TinyTypes to first stage ILMerge in build (#790)"

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -135,8 +135,7 @@ class Build : NukeBuild
             var stage1Assemblies = inputFolder.GlobFiles(
                     "Octopus.Server.Client.dll",
                     "Octopus.Server.MessageContracts.Base.dll",
-                    "Octopus.Server.MessageContracts.Base.HttpRoutes.dll",
-                    "Octopus.TinyTypes.dll"
+                    "Octopus.Server.MessageContracts.Base.HttpRoutes.dll"
                 )
                 .Select(x => x.ToString())
                 .OrderBy(x => x)

--- a/source/Octopus.Client.E2ETests/InlinedDependenciesFixture.cs
+++ b/source/Octopus.Client.E2ETests/InlinedDependenciesFixture.cs
@@ -46,7 +46,7 @@ namespace Octopus.Client.E2ETests
         [Test]
         [TestCase("Newtonsoft.Json", "Newtonsoft.Json.JsonConvert", Visibility.Internal)]
         [TestCase("Octodiff", "Octodiff.Core.DeltaBuilder", Visibility.Internal)]
-        [TestCase("Octopus.TinyTypes", "Octopus.TinyTypes.TinyType`1", Visibility.Public)]
+        [TestCase("Octopus.TinyTypes", "Octopus.TinyTypes.TinyType`1", Visibility.Internal)]
         [TestCase("Octopus.TinyTypes.Json", "Octopus.TinyTypes.Json.TinyTypeJsonConverter", Visibility.Internal)]
         [TestCase("Octopus.TinyTypes.TypeConverters", "Octopus.TinyTypes.TypeConverters.TinyTypeConverter`1", Visibility.Internal)]
         [TestCase("Octopus.Server.MessageContracts.Base", "Octopus.Server.MessageContracts.Base.ICommand`2", Visibility.Public)]


### PR DESCRIPTION
This reverts commit 6bd94d545a87d97ef42e725fe7b2ef4edeb11a61.

I've found that this seems to break things so I'm reverting it.

I get an error when I try to register tentacle using a TinyType:
```
Exception logging unhandled exception: 
System.TypeInitializationException: The type initializer for 'Octopus.Diagnostics.ExceptionExtensionMethods' threw an exception.
 ---> System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types.
Could not load file or assembly 'Octopus.TinyTypes, Version=2.2.1008.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.

Could not load file or assembly 'Octopus.TinyTypes, Version=2.2.1008.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.

   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeAssembly.get_DefinedTypes()
   at Octopus.Diagnostics.ExceptionExtensionMethods.<>c.<.cctor>b__1_1(Assembly a)
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at Octopus.Diagnostics.ExceptionExtensionMethods..cctor()
```