### PR TITLE
Update fluent assertions version and fix breaking changes

### DIFF
--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -30,7 +30,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
-        <PackageReference Include="FluentAssertions" Version="4.15.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Octopus.Client.Tests/HttpRequestRouting/GivenAGetPayload.cs
+++ b/source/Octopus.Client.Tests/HttpRequestRouting/GivenAGetPayload.cs
@@ -31,7 +31,7 @@ namespace Octopus.Client.Tests.HttpRequestRouting
 
             Action action = () => httpRouteExtractor.ExtractHttpRoute(command);
 
-            action.ShouldThrow<PayloadRoutingException>();
+            action.Should().Throw<PayloadRoutingException>();
         }
 
         public static IEnumerable<TestCaseData> ValidTestCases()

--- a/source/Octopus.Client.Tests/HttpRequestRouting/GivenAPostPayload.cs
+++ b/source/Octopus.Client.Tests/HttpRequestRouting/GivenAPostPayload.cs
@@ -31,7 +31,7 @@ namespace Octopus.Client.Tests.HttpRequestRouting
 
             Action action = () => httpRouteExtractor.ExtractHttpRoute(command);
 
-            action.ShouldThrow<PayloadRoutingException>();
+            action.Should().Throw<PayloadRoutingException>();
         }
 
         public static IEnumerable<TestCaseData> ValidTestCases()

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/ErrorHandlingTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/ErrorHandlingTests.cs
@@ -21,10 +21,10 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
         }
 
         [Test]
-        public void ShouldHandleValidationError()
+        public async Task ShouldHandleValidationError()
         {
             Func<Task> post = async () => { await AsyncClient.Post("~/").ConfigureAwait(false); };
-            post.ShouldThrow<OctopusValidationException>()
+            (await post.Should().ThrowAsync<OctopusValidationException>())
                 .And
                 .DetailsAs<string[]>().Single().Should().Be("Details");
         }

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/HttpMethodTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/HttpMethodTests.cs
@@ -50,29 +50,29 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
         }
 
         [Test]
-        public void PostingAObjectWorks()
+        public async Task PostingAObjectWorks()
         {
             _lastMethod = null;
             Func<Task> post = () => AsyncClient.Post("~/", new TestDto { Value = "Foo" });
-            post.ShouldNotThrow();
+            await post.Should().NotThrowAsync();
             _lastMethod.Should().Be("Post");
         }
 
         [Test]
-        public void PuttingAObjectWorks()
+        public async Task PuttingAObjectWorks()
         {
             _lastMethod = null;
             Func<Task> put = () => AsyncClient.Put("~/", new TestDto { Value = "Foo" });
-            put.ShouldNotThrow();
+            await put.Should().NotThrowAsync();
             _lastMethod.Should().Be("Put");
         }
 
         [Test]
-        public void DeleteReachesTheServer()
+        public async Task DeleteReachesTheServer()
         {
             _lastMethod = null;
             Func<Task> delete = () => AsyncClient.Delete("~/");
-            delete.ShouldNotThrow();
+            await delete.Should().NotThrowAsync();
             _lastMethod.Should().Be("Delete");
         }
 

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/StatusTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/StatusTests.cs
@@ -27,52 +27,52 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
         }
 
         [Test]
-        public void Status400()
+        public async Task Status400()
         {
             Func<Task> get = () => AsyncClient.Get<object>("~/400");
-            get.ShouldThrow<OctopusValidationException>();
+            await get.Should().ThrowAsync<OctopusValidationException>();
         }
 
         [Test]
-        public void Status401()
+        public async Task Status401()
         {
             Func<Task> get = () => AsyncClient.Get<object>("~/401");
-            get.ShouldThrow<OctopusSecurityException>();
+            await get.Should().ThrowAsync<OctopusSecurityException>();
         }
 
         [Test]
-        public void Status403()
+        public async Task Status403()
         {
             Func<Task> get = () => AsyncClient.Get<object>("~/403");
-            get.ShouldThrow<OctopusSecurityException>();
+            await get.Should().ThrowAsync<OctopusSecurityException>();
         }
 
         [Test]
-        public void Status404()
+        public async Task Status404()
         {
             Func<Task> get = () => AsyncClient.Get<object>("~/404");
-            get.ShouldThrow<OctopusResourceNotFoundException>();
+            await get.Should().ThrowAsync<OctopusResourceNotFoundException>();
         }
 
         [Test]
-        public void Status405()
+        public async Task Status405()
         {
             Func<Task> get = () => AsyncClient.Get<object>("~/405");
-            get.ShouldThrow<OctopusMethodNotAllowedFoundException>();
+            await get.Should().ThrowAsync<OctopusMethodNotAllowedFoundException>();
         }
 
         [Test]
-        public void Status409()
+        public async Task Status409()
         {
             Func<Task> get = () => AsyncClient.Get<object>("~/409");
-            get.ShouldThrow<OctopusValidationException>();
+            await get.Should().ThrowAsync<OctopusValidationException>();
         }
 
         [Test]
-        public void Status500()
+        public async Task Status500()
         {
             Func<Task> get = () => AsyncClient.Get<object>("~/500");
-            get.ShouldThrow<OctopusServerException>();
+            await get.Should().ThrowAsync<OctopusServerException>();
         }
     }
 }

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/StreamTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/StreamTests.cs
@@ -28,13 +28,13 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
         }
 
         [Test]
-        public void PostStream()
+        public async Task PostStream()
         {
             using (var ms = new MemoryStream(SharedBytes))
             {
                 _recieved = false;
                 Func<Task> post = () => AsyncClient.Post("~/", ms);
-                post.ShouldNotThrow();
+                await post.Should().NotThrowAsync();
                 _recieved.Should().BeTrue();
             }
         }

--- a/source/Octopus.Client.Tests/Integration/OctopusClient/TimeoutTests.cs
+++ b/source/Octopus.Client.Tests/Integration/OctopusClient/TimeoutTests.cs
@@ -27,7 +27,7 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
         }
 
         [Test]
-        public void ConfiguredTimeoutWorks()
+        public async Task ConfiguredTimeoutWorks()
         {
             var sw = Stopwatch.StartNew();
             Func<Task> get = () => AsyncClient.Get<string>("~/");
@@ -37,16 +37,16 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             // Functionally the timeout works fine, but doing extra work just to get the right kind of exception isn't worth
             // it for .NET framework
 #if NETFRAMEWORK
-            get.ShouldThrow<OperationCanceledException>();
+            await get.Should().ThrowAsync<OperationCanceledException>();
 #else
-            get.ShouldThrow<TimeoutException>();
+            await get.Should().ThrowAsync<TimeoutException>();
 #endif
             
             sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
         }
 
         [Test]
-        public void CancellationThrowsOperationCanceledException()
+        public async Task CancellationThrowsOperationCanceledException()
         {
             var sw = Stopwatch.StartNew();
             var cancellationTokenSource = new CancellationTokenSource();
@@ -55,7 +55,7 @@ namespace Octopus.Client.Tests.Integration.OctopusClient
             cancellationTokenSource.Cancel();
 
             Func<Task> get = () => getTask;
-            get.ShouldThrow<OperationCanceledException>();
+            await get.Should().ThrowAsync<OperationCanceledException>();
 
             sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
         }

--- a/source/Octopus.Client.Tests/Integration/Repository/UnauthorisedTest.cs
+++ b/source/Octopus.Client.Tests/Integration/Repository/UnauthorisedTest.cs
@@ -25,11 +25,11 @@ namespace Octopus.Client.Tests.Integration.Repository
         }
 
         [Test]
-        public void IfTheServerReturnsAnUnauthorisedResultASecurityExceptionShouldBeThrown()
+        public async Task IfTheServerReturnsAnUnauthorisedResultASecurityExceptionShouldBeThrown()
         {
             var repo = new OctopusAsyncRepository(AsyncClient);
             Func<Task> getUser = () => repo.Users.Get("users-1");
-            getUser.ShouldThrow<OctopusSecurityException>().WithMessage(ErrorMessage);
+            await getUser.Should().ThrowAsync<OctopusSecurityException>().WithMessage(ErrorMessage);
         }
     }
 }

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Assent" Version="1.9.3" />
     <PackageReference Include="Autofac" Version="4.6.0" />
-    <PackageReference Include="FluentAssertions" Version="4.15.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Nancy" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="Serilog" Version="2.3.0" />

--- a/source/Octopus.Client.Tests/Operations/RegisterKubernetesClusterOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterKubernetesClusterOperationFixture.cs
@@ -77,7 +77,7 @@ namespace Octopus.Client.Tests.Operations
 
             await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
 
-            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.ShouldBeEquivalentTo(new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://mymachine.test.com:10930/")));
+            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://mymachine.test.com:10930/")));
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace Octopus.Client.Tests.Operations
 
             await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
 
-            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.ShouldBeEquivalentTo(new KubernetesTentacleEndpointResource(new PollingTentacleEndpointConfigurationResource("ABCDEF", "poll://ckyhfyfkcbmzjl8sfgch/")));
+            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new PollingTentacleEndpointConfigurationResource("ABCDEF", "poll://ckyhfyfkcbmzjl8sfgch/")));
         }
     }
 }

--- a/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
@@ -65,17 +65,17 @@ namespace Octopus.Client.Tests.Operations
         {
             operation.EnvironmentNames = new[] {"Atlantis"};
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.ShouldThrow<ArgumentException>().WithMessage("Could not find the environment named Atlantis on the Octopus Server. Ensure the environment exists and you have permission to access it.");
+            exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environment named Atlantis on the Octopus Server. Ensure the environment exists and you have permission to access it.");
         }
 
         [Test]
-        public void ShouldThrowIfAnyEnvironmentNotFound()
+        public async Task ShouldThrowIfAnyEnvironmentNotFound()
         {
             environments.Items.Add(new EnvironmentResource { Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines") });
 
             operation.EnvironmentNames = new[] {"Production", "Atlantis", "Hyperborea"};
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.ShouldThrow<ArgumentException>().WithMessage("Could not find the environments named: Atlantis, Hyperborea on the Octopus Server. Ensure the environments exist and you have permission to access them.");
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environments named: Atlantis, Hyperborea on the Octopus Server. Ensure the environments exist and you have permission to access them.");
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace Octopus.Client.Tests.Operations
         }
 
         [Test]
-        public void ShouldNotUpdateExistingMachine()
+        public async Task ShouldNotUpdateExistingMachine()
         {
             environments.Items.Add(new EnvironmentResource {Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines")});
             environments.Items.Add(new EnvironmentResource {Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines")});
@@ -117,7 +117,7 @@ namespace Octopus.Client.Tests.Operations
             operation.EnvironmentNames = new[] {"Production"};
 
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.ShouldThrow<ArgumentException>();
+            await exec.Should().ThrowAsync<ArgumentException>();
         }
 
         [Test]

--- a/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/BasicRepositoryFixture.cs
@@ -64,7 +64,7 @@ namespace Octopus.Client.Tests.Repositories.Async
             Action activityUnderTest= () => repoForSpaceScopedResource.Create(resource).Wait();
 
             activityUnderTest
-                .ShouldThrow<ResourceSpaceDoesNotMatchRepositorySpaceException>()
+                .Should().Throw<ResourceSpaceDoesNotMatchRepositorySpaceException>()
                 .WithMessage("The resource has a different space specified than the one specified by the repository. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
         }
         
@@ -105,7 +105,7 @@ namespace Octopus.Client.Tests.Repositories.Async
             var resource = CreateMixedResourceForSpace(otherSpace.Id);
             Action activityUnderTest = () => repoForMixedScopedResource.Modify(resource).Wait();
             activityUnderTest
-                .ShouldThrow<ResourceSpaceDoesNotMatchRepositorySpaceException>()
+                .Should().Throw<ResourceSpaceDoesNotMatchRepositorySpaceException>()
                 .WithMessage("The resource has a different space specified than the one specified by the repository. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
         }
         

--- a/source/Octopus.Client.Tests/Repositories/Async/TaskRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/Async/TaskRepositoryTests.cs
@@ -99,7 +99,7 @@ namespace Octopus.Client.Tests.Repositories.Async
             };
 
             var sw = Stopwatch.StartNew();
-            exec.ShouldThrow<TimeoutException>();
+            exec.Should().Throw<TimeoutException>();
             sw.Stop();
 
             sw.Elapsed.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(3), "Should run until the cancel time");

--- a/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
+++ b/source/Octopus.Client.Tests/Repositories/BasicRepositoryFixture.cs
@@ -53,7 +53,7 @@ namespace Octopus.Client.Tests.Repositories
             Action activityUnderTest= () => repoForSpaceScopedResource.Create(resource);
 
             activityUnderTest
-                .ShouldThrow<ResourceSpaceDoesNotMatchRepositorySpaceException>()
+                .Should().Throw<ResourceSpaceDoesNotMatchRepositorySpaceException>()
                 .WithMessage("The resource has a different space specified than the one specified by the repository. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
         }
         
@@ -94,7 +94,7 @@ namespace Octopus.Client.Tests.Repositories
             var resource = CreateMixedResourceForSpace(otherSpace.Id);
             Action activityUnderTest = () => repoForMixedScopedResource.Modify(resource);
             activityUnderTest
-                .ShouldThrow<ResourceSpaceDoesNotMatchRepositorySpaceException>()
+                .Should().Throw<ResourceSpaceDoesNotMatchRepositorySpaceException>()
                 .WithMessage("The resource has a different space specified than the one specified by the repository. Either change the SpaceId on the resource to Spaces-1, or use a repository that is scoped to Spaces-2.");
         }
         
@@ -147,7 +147,7 @@ namespace Octopus.Client.Tests.Repositories
                 {Links = new LinkCollection() {{"Spaces", "api/spaces"}}});
             var resource = CreateSpaceResourceForSpace(null);
             Action actionUnderTest = () => repoForSpaceScopedResource.Create(resource);
-            actionUnderTest.ShouldThrow<DefaultSpaceNotFoundException>();
+            actionUnderTest.Should().Throw<DefaultSpaceNotFoundException>();
         }
 
         [Test]

--- a/source/Octopus.Client.Tests/Repositories/ProjectBetaRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/ProjectBetaRepositoryTests.cs
@@ -49,7 +49,7 @@ namespace Octopus.Client.Tests.Repositories
         }
 
         [Test]
-        public void MigrateVariablesToGit_GitProjectWithVariablesAlreadyInGit_ThrowsError()
+        public async Task MigrateVariablesToGit_GitProjectWithVariablesAlreadyInGit_ThrowsError()
         {
             // Arrange
             var project = new ProjectResource
@@ -64,17 +64,17 @@ namespace Octopus.Client.Tests.Repositories
             };
 
             // Act + Assert
-            repository.Projects.Beta().Awaiting(p => p.MigrateVariablesToGit(project, "branchy-branch", "Test commit message")).ShouldThrow<NotSupportedException>().WithMessage("*already been migrated*");
+            await repository.Projects.Beta().Awaiting(p => p.MigrateVariablesToGit(project, "branchy-branch", "Test commit message")).Should().ThrowAsync<NotSupportedException>().WithMessage("*already been migrated*");
         }
 
         [Test]
-        public void MigrateVariablesToGit_DoesNotHaveMigrateLink_ThrowsError()
+        public async Task MigrateVariablesToGit_DoesNotHaveMigrateLink_ThrowsError()
         {
             // Arrange
             var project = new ProjectResource();
 
             // Act + Assert
-            repository.Projects.Beta().Awaiting(p => p.MigrateVariablesToGit(project, "branchy-branch", "Test commit message")).ShouldThrow<NotSupportedException>().WithMessage("*not available*");
+            await repository.Projects.Beta().Awaiting(p => p.MigrateVariablesToGit(project, "branchy-branch", "Test commit message")).Should().ThrowAsync<NotSupportedException>().WithMessage("*not available*");
         }
     }
 }

--- a/source/Octopus.Client.Tests/Repositories/VariableSetBetaRepositoryTests.cs
+++ b/source/Octopus.Client.Tests/Repositories/VariableSetBetaRepositoryTests.cs
@@ -40,7 +40,7 @@ namespace Octopus.Client.Tests.Repositories
 
             // Assert
             getUrlUsed.Should().Be(variableLink);
-            getParamsUsed.ShouldBeEquivalentTo(new {gitRef = "branchy"});
+            getParamsUsed.Should().BeEquivalentTo(new {gitRef = "branchy"});
         }
 
 

--- a/source/Octopus.Client.Tests/Serialization/CrossPlatformDateTimeZoneJsonConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/CrossPlatformDateTimeZoneJsonConverterFixture.cs
@@ -39,7 +39,7 @@ namespace Octopus.Client.Tests.Serialization
 
             date
                 .Should()
-                .BeCloseTo(expected, 1000); // Within one second
+                .BeCloseTo(expected, TimeSpan.FromSeconds(1)); // Within one second
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace Octopus.Client.Tests.Serialization
 
             date
                 .Should()
-                .BeCloseTo(expected, 1000); // Within one second
+                .BeCloseTo(expected, TimeSpan.FromSeconds(1)); // Within one second
         }
 
         [Test]

--- a/source/Octopus.Client.Tests/Serialization/CrossPlatformDateTimeZoneJsonConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/CrossPlatformDateTimeZoneJsonConverterFixture.cs
@@ -39,7 +39,7 @@ namespace Octopus.Client.Tests.Serialization
 
             date
                 .Should()
-                .BeCloseTo(expected, TimeSpan.FromSeconds(1)); // Within one second
+                .BeCloseTo(expected, TimeSpan.FromSeconds(1));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace Octopus.Client.Tests.Serialization
 
             date
                 .Should()
-                .BeCloseTo(expected, TimeSpan.FromSeconds(1)); // Within one second
+                .BeCloseTo(expected, TimeSpan.FromSeconds(1));
         }
 
         [Test]

--- a/source/Octopus.Client.Tests/Serialization/PermissiveInstantJsonConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/PermissiveInstantJsonConverterFixture.cs
@@ -87,7 +87,7 @@ namespace Octopus.Client.Tests.Serialization
         {
             Action action = () => JsonConvert.DeserializeObject<Instant>(@"""Something Else""", serializerSettings);
 
-            action.ShouldThrow<FormatException>()
+            action.Should().Throw<FormatException>()
                 .WithMessage("*was not recognized as a valid DateTime*");
         }
     }

--- a/source/Octopus.Client.Tests/Spaces/MixedScopeSpaceContextExtensionTests.cs
+++ b/source/Octopus.Client.Tests/Spaces/MixedScopeSpaceContextExtensionTests.cs
@@ -20,7 +20,7 @@ namespace Octopus.Client.Tests.Spaces
             repository.LoadRootDocument().Returns(GetRootResource());
             ITeamsRepository teamRepo = new TeamsRepository(repository);
             Action switchContext = () => teamRepo.UsingContext(SpaceContext.AllSpaces());
-            switchContext.ShouldThrow<SpaceContextSwitchException>();
+            switchContext.Should().Throw<SpaceContextSwitchException>();
         }
 
         [Test]

--- a/source/Octopus.Client.Tests/UrlTemplateTests.cs
+++ b/source/Octopus.Client.Tests/UrlTemplateTests.cs
@@ -22,7 +22,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // assert
-            url.ShouldBeEquivalentTo(urlTemplate);
+            url.Should().BeEquivalentTo(urlTemplate);
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/users/login?returnUrl=123");
+            url.Should().BeEquivalentTo(@"/api/users/login?returnUrl=123");
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/users/login");
+            url.Should().BeEquivalentTo(@"/api/users/login");
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/projecttriggers/1");
+            url.Should().BeEquivalentTo(@"/api/projecttriggers/1");
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/channels/rule-test?versionRange=1.2");
+            url.Should().BeEquivalentTo(@"/api/channels/rule-test?versionRange=1.2");
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/channels/rule-test?version=2.0.0&versionRange=1.2&preReleaseTag=tag");
+            url.Should().BeEquivalentTo(@"/api/channels/rule-test?version=2.0.0&versionRange=1.2&preReleaseTag=tag");
         }
 
         [Test]
@@ -107,7 +107,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/subscriptions?skip=10");
+            url.Should().BeEquivalentTo(@"/api/subscriptions?skip=10");
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/subscriptions/6?skip=10");
+            url.Should().BeEquivalentTo(@"/api/subscriptions/6?skip=10");
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/subscriptions/6");
+            url.Should().BeEquivalentTo(@"/api/subscriptions/6");
         }
 
         [Test]
@@ -151,7 +151,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/projects?name=KPP.Bastj%C3%A4nster");
+            url.Should().BeEquivalentTo(@"/api/projects?name=KPP.Bastj%C3%A4nster");
         }
 
         [Test]
@@ -165,7 +165,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/tenants?name=Team%20%F0%9F%98%84");
+            url.Should().BeEquivalentTo(@"/api/tenants?name=Team%20%F0%9F%98%84");
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace Octopus.Client.Tests
             var url = urlTemplateResolver.Resolve();
 
             // Assert
-            url.ShouldBeEquivalentTo(@"/api/projects?name=Me%26You");
+            url.Should().BeEquivalentTo(@"/api/projects?name=Me%26You");
         }
     }
 }


### PR DESCRIPTION
I'm adding some tests and I've noticed that FluentAssertions is quite behind. I want to use new features so I'm giving updating it a crack. Only changing tests to fix breaking changes in FluentAssertions as we're updating over a few major versions.

I'm thinking if the build goes green we should be good to go 👍 