### PR TITLE
Ensure k8s reregistration is correctly

### DIFF
--- a/source/Octopus.Client.Tests/Operations/RegisterKubernetesClusterOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterKubernetesClusterOperationFixture.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
+using Octopus.Client.Exceptions;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
@@ -22,6 +24,7 @@ namespace Octopus.Client.Tests.Operations
         ResourceCollection<EnvironmentResource> environments;
         ResourceCollection<MachineResource> machines;
         ResourceCollection<MachinePolicyResource> machinePolicies;
+        private ResourceCollection<ProxyResource> proxies;
 
         [SetUp]
         public void SetUp()
@@ -32,6 +35,7 @@ namespace Octopus.Client.Tests.Operations
             operation = new RegisterKubernetesClusterOperation(clientFactory);
             serverEndpoint = new OctopusServerEndpoint("http://octopus", "ABC123");
 
+            proxies = new ResourceCollection<ProxyResource>(new ProxyResource[0], LinkCollection.Self("/foo"));
             environments = new ResourceCollection<EnvironmentResource>(new EnvironmentResource[0], LinkCollection.Self("/foo"));
             machines = new ResourceCollection<MachineResource>(new MachineResource[0], LinkCollection.Self("/foo"));
             machinePolicies = new ResourceCollection<MachinePolicyResource>(new MachinePolicyResource[0], LinkCollection.Self("/foo"));
@@ -45,6 +49,7 @@ namespace Octopus.Client.Tests.Operations
                     .Add("MachinePolicies", "/api/machinepolicies")
                     .Add("CurrentUser", "/api/users/me")
                     .Add("SpaceHome", "/api/spaces")
+                    .Add("Proxies", "/api/proxies")
             };
 
             client.Get<RootResource>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(rootDocument);
@@ -57,6 +62,8 @@ namespace Octopus.Client.Tests.Operations
                 .Do(ci => ci.Arg<Func<ResourceCollection<MachineResource>, bool>>()(machines));
             client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachinePolicyResource>, bool>>(), Arg.Any<CancellationToken>()))
                 .Do(ci => ci.Arg<Func<ResourceCollection<MachinePolicyResource>, bool>>()(machinePolicies));
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<ProxyResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<ProxyResource>, bool>>()(proxies));
         }
 
         [Test]
@@ -100,6 +107,148 @@ namespace Octopus.Client.Tests.Operations
             await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
 
             machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new PollingTentacleEndpointConfigurationResource("ABCDEF", "poll://ckyhfyfkcbmzjl8sfgch/")));
+        }
+
+        [Test]
+        public async Task ShouldOnlyUpdateEndpointConnectionConfigurationOnExistingMachine()
+        {
+            var updatedMachines = new List<MachineResource>();
+            await client.Update("/machines/whatever/1", Arg.Do<MachineResource>(m => updatedMachines.Add(m)), Arg.Any<object>(), Arg.Any<CancellationToken>());
+
+            environments.Items.Add(new EnvironmentResource {Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines")});
+            environments.Items.Add(new EnvironmentResource {Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines")});
+
+            machines.Items.Add(new MachineResource
+            {
+                Id = "machines/84", EnvironmentIds = new ReferenceCollection(new[] { "environments-1" }), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1"),
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("123456", "myMachine.test.com") { ProxyId = "proxy-2" })
+            });
+
+            proxies.Items.Add(new ProxyResource { Id = "proxy-1", Name = "MyNewProxy", Links = LinkCollection.Self("/api/proxies/proxy-1") });
+
+            operation.MachineName = "Mymachine";
+            operation.TentaclePort = 10930;
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentacleHostname = "my-new-machine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] {"Production"};
+            operation.ProxyName = "MyNewProxy";
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            var thing = updatedMachines.Should().ContainSingle().Which;
+
+            thing.Should().BeEquivalentTo(new MachineResource
+            {
+                Id = "machines/84",
+                Name = "Mymachine",
+                EnvironmentIds = new ReferenceCollection("environments-1"),
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://my-new-machine.test.com:10930/") {ProxyId = "proxy-1"}),
+                Links = LinkCollection.Self("/machines/whatever/1")
+            }, cfg => cfg.RespectingRuntimeTypes());
+        }
+
+        [Test]
+        public async Task ShouldUpdateExistingMachineWhenForceIsEnabled()
+        {
+            environments.Items.Add(new EnvironmentResource {Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines")});
+            environments.Items.Add(new EnvironmentResource {Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines")});
+
+            machines.Items.Add(new MachineResource {Id = "machines/84", EnvironmentIds = new ReferenceCollection(new[] {"environments-1"}), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1")});
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] {"Production"};
+            operation.AllowOverwrite = true;
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            await client.Received().Update("/machines/whatever/1", Arg.Is<MachineResource>(m =>
+                m.Id == "machines/84"
+                && m.Name == "Mymachine"
+                && m.EnvironmentIds.First() == "environments-2"),
+                Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ShouldCreateWhenCantDeserializeMachines()
+        {
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachineResource>, bool>>()))
+                .Throw(new OctopusDeserializationException(1, "Can not deserialize"));
+
+            environments.Items.Add(new EnvironmentResource { Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines") });
+            environments.Items.Add(new EnvironmentResource { Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines") });
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] { "Production" };
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            await client.Received().Create("/api/machines", Arg.Is<MachineResource>(m =>
+                m.Name == "Mymachine"
+                && ((KubernetesTentacleEndpointResource)m.Endpoint).TentacleEndpointConfiguration.Uri == "https://mymachine.test.com:10930/"
+                && m.EnvironmentIds.First() == "environments-2"),
+                Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ShouldNotOverwriteMachinePolicyToNull()
+        {
+            environments.Items.Add(new EnvironmentResource { Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines") });
+            environments.Items.Add(new EnvironmentResource { Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines") });
+
+            machines.Items.Add(new MachineResource { Id = "machines/84", MachinePolicyId = "MachinePolicies-1", EnvironmentIds = new ReferenceCollection(new[] { "environments-1" }), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1") });
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] { "Production" };
+            operation.AllowOverwrite = true;
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            await client.Received().Update("/machines/whatever/1", Arg.Is<MachineResource>(m =>
+                m.Id == "machines/84"
+                && m.Name == "Mymachine"
+                && m.EnvironmentIds.First() == "environments-2"
+                && m.MachinePolicyId == "MachinePolicies-1"),
+                Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ShouldOverwriteMachinePolicyWhenPassed()
+        {
+            environments.Items.Add(new EnvironmentResource { Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines") });
+            environments.Items.Add(new EnvironmentResource { Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines") });
+
+            machines.Items.Add(new MachineResource { Id = "machines/84", MachinePolicyId = "MachinePolicies-1", EnvironmentIds = new ReferenceCollection(new[] { "environments-1" }), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1") });
+            machinePolicies.Items.Add(new MachinePolicyResource {Id = "MachinePolicies-2", Name = "Machine Policy 2"});
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] { "Production" };
+            operation.AllowOverwrite = true;
+            operation.MachinePolicy = "Machine Policy 2";
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            await client.Received().Update("/machines/whatever/1", Arg.Is<MachineResource>(m =>
+                m.Id == "machines/84"
+                && m.Name == "Mymachine"
+                && m.EnvironmentIds.First() == "environments-2"
+                && m.MachinePolicyId == "MachinePolicies-2"),
+                Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Client.Tests/Operations/RegisterKubernetesClusterOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterKubernetesClusterOperationFixture.cs
@@ -138,14 +138,14 @@ namespace Octopus.Client.Tests.Operations
 
             var thing = updatedMachines.Should().ContainSingle().Which;
 
-            thing.Should().BeEquivalentTo(new MachineResource
+            thing.Should().BeEquivalentTo(new
             {
                 Id = "machines/84",
                 Name = "Mymachine",
                 EnvironmentIds = new ReferenceCollection("environments-1"),
                 Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://my-new-machine.test.com:10930/") {ProxyId = "proxy-1"}),
                 Links = LinkCollection.Self("/machines/whatever/1")
-            }, cfg => cfg.RespectingRuntimeTypes());
+            });
         }
 
         [Test]

--- a/source/Octopus.Server.Client/Operations/RegisterKubernetesClusterOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterKubernetesClusterOperation.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
 
@@ -11,6 +12,11 @@ public class RegisterKubernetesClusterOperation : RegisterMachineOperation, IReg
 
     public RegisterKubernetesClusterOperation(IOctopusClientFactory clientFactory) : base(clientFactory)
     {
+    }
+
+    protected override void PrepareMachineForReRegistration(MachineResource machine, string proxyId)
+    {
+        machine.Endpoint = GenerateEndpoint(proxyId);
     }
 
     protected override EndpointResource GenerateEndpoint(string proxyId)

--- a/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
@@ -66,7 +66,7 @@ namespace Octopus.Client.Operations
             var machine = GetMachine(repository);
             var proxy = GetProxy(repository);
 
-            if (machine.Id == null || AllowOverwrite)
+            if (!IsExistingMachine(machine) || AllowOverwrite)
             {
                 var machinePolicy = GetMachinePolicy(repository);
                 ValidateTenantTags(repository);
@@ -81,9 +81,14 @@ namespace Octopus.Client.Operations
             ModifyOrCreateMachine(repository, machine);
         }
 
+        static bool IsExistingMachine(MachineResource machine)
+        {
+            return machine.Id != null;
+        }
+
         static void ModifyOrCreateMachine(IOctopusSpaceRepository repository, MachineResource machine)
         {
-            if (machine.Id != null)
+            if (IsExistingMachine(machine))
                 repository.Machines.Modify(machine);
             else
                 repository.Machines.Create(machine);
@@ -157,7 +162,7 @@ namespace Octopus.Client.Operations
             var machine = await GetMachine(repository).ConfigureAwait(false);
             var proxy = await GetProxy(repository).ConfigureAwait(false);
 
-            if (machine.Id == null || AllowOverwrite)
+            if (!IsExistingMachine(machine) || AllowOverwrite)
             {
                 var machinePolicy = GetMachinePolicy(repository).ConfigureAwait(false);
                 await ValidateTenantTags(repository).ConfigureAwait(false);
@@ -182,7 +187,7 @@ namespace Octopus.Client.Operations
 
         static async Task ModifyOrCreateMachine(IOctopusSpaceAsyncRepository repository, MachineResource machine)
         {
-            if (machine.Id != null)
+            if (IsExistingMachine(machine))
                 await repository.Machines.Modify(machine).ConfigureAwait(false);
             else
                 await repository.Machines.Create(machine).ConfigureAwait(false);


### PR DESCRIPTION
# Background

Part of #project-k8s-agent

The standard behaviour for the `register-with` command (which is for register machines, as opposed to workers) will automatically set the `--force` flag. This means that it will "blat" over the existing target in server with whatever has been configured.

The `register-k8s-cluster` command followed the same formula originally but it needs to be updated as this doesn't work with kubernetes very well. As the Kubernetes Tentacle will be running in a cluster (duh), the pod could be stopped and restarted at anytime. If we use the existing functionality, the container will "blat" over the settings in server every time it restarts for whatever reason.

However there is also a risk that if the originally configuration is lost in k8s (if it's using a volume mount, the drive config could be deleted, if it's using a configmap or secret, that could be deleted too). If this happens, Tentacle would create a new certificate, thumbprint and other information on restart which would break the connection to server unless we re-register the tentacle.

# Result

The new solution is that when the arg `--force` is not provided and there is already an existing target with the same name, it will only update the Endpoint information, not other information which is user configurable (such as environments, tenants, target roles). This safeguards us from anyone fiddling with configmaps and what not while also maintaining user configured settings.

