### PR TITLE
Isaac/artifactory generic feeds

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1955,6 +1955,21 @@ Octopus.Client.Model
   {
     static System.String AccountId
   }
+  class ArtifactoryGenericFeedResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Model.FeedResource
+  {
+    .ctor()
+    Octopus.Client.Model.FeedType FeedType { get; }
+    String FeedUri { get; set; }
+    String LayoutRegex { get; set; }
+    Octopus.Client.Model.SensitiveValue Password { get; set; }
+    String Repository { get; set; }
+  }
   class ArtifactResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -3148,6 +3163,7 @@ Octopus.Client.Model
       S3 = 10
       AzureContainerRegistry = 11
       GoogleContainerRegistry = 12
+      ArtifactoryGeneric = 13
   }
   class FileUpload
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1969,6 +1969,7 @@ Octopus.Client.Model
     String LayoutRegex { get; set; }
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Repository { get; set; }
+    String Username { get; set; }
   }
   class ArtifactResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1972,6 +1972,21 @@ Octopus.Client.Model
   {
     static System.String AccountId
   }
+  class ArtifactoryGenericFeedResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Model.FeedResource
+  {
+    .ctor()
+    Octopus.Client.Model.FeedType FeedType { get; }
+    String FeedUri { get; set; }
+    String LayoutRegex { get; set; }
+    Octopus.Client.Model.SensitiveValue Password { get; set; }
+    String Repository { get; set; }
+  }
   class ArtifactResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -3165,6 +3180,7 @@ Octopus.Client.Model
       S3 = 10
       AzureContainerRegistry = 11
       GoogleContainerRegistry = 12
+      ArtifactoryGeneric = 13
   }
   class FileUpload
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1986,6 +1986,7 @@ Octopus.Client.Model
     String LayoutRegex { get; set; }
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Repository { get; set; }
+    String Username { get; set; }
   }
   class ArtifactResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/Serialization/FeedResourceConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/FeedResourceConverterFixture.cs
@@ -80,6 +80,29 @@ namespace Octopus.Client.Tests.Serialization
             Assert.IsAssignableFrom(typeof(GitHubFeedResource), result);
             Assert.AreEqual(input.DownloadAttempts, result.DownloadAttempts);
         }
+        
+        
+        [Test]
+        public void ArtifactoryGenericFeedTypesDeserialize()
+        {
+            var input = new
+            {
+                Name = "Blah",
+                FeedType = FeedType.ArtifactoryGeneric,
+                DownloadAttempts = 91,
+                FeedUri = "https://hello",
+                Repository = "repo",
+                LayoutRegex = "<SomeRegex>"
+            };
+
+            var result = Execute<ArtifactoryGenericFeedResource>(input);
+
+            Assert.AreEqual(FeedType.ArtifactoryGeneric, result.FeedType);
+            Assert.IsAssignableFrom(typeof(ArtifactoryGenericFeedResource), result);
+            Assert.AreEqual(input.FeedUri, result.FeedUri);
+            Assert.AreEqual(input.Repository, result.Repository);
+            Assert.AreEqual(input.LayoutRegex, result.LayoutRegex);
+        }
 
         [Test]
         public void NuGetFeedTypesDeserialize()

--- a/source/Octopus.Server.Client/Model/ArtifactoryGenericFeedResource.cs
+++ b/source/Octopus.Server.Client/Model/ArtifactoryGenericFeedResource.cs
@@ -1,0 +1,24 @@
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model
+{
+    public class ArtifactoryGenericFeedResource : FeedResource
+    {
+        public override FeedType FeedType => FeedType.ArtifactoryGeneric;
+
+        [Writeable]
+        public string FeedUri { get; set; }
+
+        [Trim]
+        [Writeable]
+        public string LayoutRegex { get; set; }
+        
+        [Trim]
+        [Writeable]
+        public string Repository { get; set; }
+
+        [Trim]
+        [Writeable]
+        public SensitiveValue Password { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/ArtifactoryGenericFeedResource.cs
+++ b/source/Octopus.Server.Client/Model/ArtifactoryGenericFeedResource.cs
@@ -20,5 +20,9 @@ namespace Octopus.Client.Model
         [Trim]
         [Writeable]
         public SensitiveValue Password { get; set; }
+
+        [Trim]
+        [Writeable]
+        public string Username { get; set; }
     }
 }

--- a/source/Octopus.Server.Client/Model/FeedType.cs
+++ b/source/Octopus.Server.Client/Model/FeedType.cs
@@ -14,6 +14,7 @@
         AwsElasticContainerRegistry,
         S3,
         AzureContainerRegistry,
-        GoogleContainerRegistry
+        GoogleContainerRegistry,
+        ArtifactoryGeneric
     }
 }

--- a/source/Octopus.Server.Client/Serialization/FeedConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/FeedConverter.cs
@@ -21,6 +21,7 @@ namespace Octopus.Client.Serialization
                 {FeedType.S3, typeof(S3FeedResource)},
                 {FeedType.AzureContainerRegistry, typeof(AzureContainerRegistryFeedResource)},
                 {FeedType.GoogleContainerRegistry, typeof(GoogleContainerRegistryFeedResource)},
+                {FeedType.ArtifactoryGeneric, typeof(ArtifactoryGenericFeedResource)},
             };
 
         static readonly Type defaultType = typeof(NuGetFeedResource);


### PR DESCRIPTION
Adds support for Artifactory Generic feeds to match the Server resource in https://github.com/OctopusDeploy/OctopusDeploy/compare/master...isaac/art-feed-versions-path#diff-fdcd241ef4272129c1fe1f27d620f202d9ea45d541530b71692482bb245710d2R7 

![image](https://github.com/OctopusDeploy/OctopusClients/assets/101079287/d7c6537c-11ec-4a86-b309-0a16d44b9927)
