### PR TITLE
Add GitHub credential type for Git persistence settings

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3235,6 +3235,13 @@ Octopus.Client.Model
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Username { get; set; }
   }
+  class GitHubProjectGitCredentialResource
+    Octopus.Client.Model.ProjectGitCredentialResource
+  {
+    .ctor()
+    String Id { get; set; }
+    Octopus.Client.Model.ProjectGitCredentialType Type { get; }
+  }
   class GitPersistenceSettingsConversionStateResource
   {
     .ctor()
@@ -4400,6 +4407,7 @@ Octopus.Client.Model
       Anonymous = 0
       UsernamePassword = 1
       Reference = 2
+      GitHub = 3
   }
   class ProjectGroupResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3252,6 +3252,13 @@ Octopus.Client.Model
     Octopus.Client.Model.SensitiveValue Password { get; set; }
     String Username { get; set; }
   }
+  class GitHubProjectGitCredentialResource
+    Octopus.Client.Model.ProjectGitCredentialResource
+  {
+    .ctor()
+    String Id { get; set; }
+    Octopus.Client.Model.ProjectGitCredentialType Type { get; }
+  }
   class GitPersistenceSettingsConversionStateResource
   {
     .ctor()
@@ -4420,6 +4427,7 @@ Octopus.Client.Model
       Anonymous = 0
       UsernamePassword = 1
       Reference = 2
+      GitHub = 3
   }
   class ProjectGroupResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Server.Client/Model/ProjectGitCredentialResource.cs
+++ b/source/Octopus.Server.Client/Model/ProjectGitCredentialResource.cs
@@ -6,7 +6,8 @@ namespace Octopus.Client.Model
     {
         Anonymous,
         UsernamePassword,
-        Reference
+        Reference,
+        GitHub
     }
 
     public abstract class ProjectGitCredentialResource
@@ -32,6 +33,14 @@ namespace Octopus.Client.Model
     public class ReferenceProjectGitCredentialResource : ProjectGitCredentialResource
     {
         public override ProjectGitCredentialType Type { get; } = ProjectGitCredentialType.Reference;
+
+        [Writeable]
+        public string Id { get; set; }
+    }
+    
+    public class GitHubProjectGitCredentialResource : ProjectGitCredentialResource
+    {
+        public override ProjectGitCredentialType Type { get; } = ProjectGitCredentialType.GitHub;
 
         [Writeable]
         public string Id { get; set; }

--- a/source/Octopus.Server.Client/Serialization/GitSettingsConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/GitSettingsConverter.cs
@@ -12,6 +12,7 @@ namespace Octopus.Client.Serialization
                 {ProjectGitCredentialType.Anonymous, typeof(AnonymousProjectGitCredentialResource)},
                 {ProjectGitCredentialType.UsernamePassword, typeof(UsernamePasswordProjectGitCredentialResource)},
                 {ProjectGitCredentialType.Reference, typeof(ReferenceProjectGitCredentialResource)},
+                {ProjectGitCredentialType.GitHub, typeof(GitHubProjectGitCredentialResource)},
             };
 
         static readonly Type defaultType = typeof(AnonymousProjectGitCredentialResource);


### PR DESCRIPTION
Allows the use of the upcoming GitHub app connections as Config as Code credentials