### PR TITLE
Add resources for external feed release creation

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7032,7 +7032,9 @@ Octopus.Client.Model.Triggers
   class FeedFilterReferenceResource
   {
     .ctor()
-    String DeploymentProcessStepSlug { get; set; }
+    String DeploymentActionSlug { get; set; }
+    String DeploymentStepSlug { get; set; }
+    String FeedIdOrName { get; set; }
     String PackageId { get; set; }
   }
   class FeedFilterResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7020,6 +7020,29 @@ Octopus.Client.Model.Triggers
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     Boolean ShouldRedeployWhenMachineHasBeenDeployedTo { get; set; }
   }
+  class CreateReleaseActionResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Triggers.TriggerActionResource
+  {
+    .ctor()
+    Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
+    String ChannelId { get; set; }
+  }
+  class FeedFilterReferenceResource
+  {
+    .ctor()
+    String DeploymentProcessStepSlug { get; set; }
+  }
+  class FeedFilterResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Triggers.TriggerFilterResource
+  {
+    .ctor()
+    List<FeedFilterReferenceResource> FeedFilterReferences { get; set; }
+    Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
+  }
   class MachineFilterResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -7066,6 +7089,7 @@ Octopus.Client.Model.Triggers
       DeployLatestRelease = 1
       DeployNewRelease = 2
       RunRunbook = 3
+      CreateRelease = 4
   }
   abstract class TriggerFilterResource
     Octopus.Client.Extensibility.IResource
@@ -7083,6 +7107,7 @@ Octopus.Client.Model.Triggers
       CronExpressionSchedule = 4
       DailySchedule = 5
       DaysPerWeekSchedule = 6
+      FeedFilter = 7
   }
 }
 Octopus.Client.Model.Triggers.ScheduledTriggers

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7029,22 +7029,14 @@ Octopus.Client.Model.Triggers
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     String ChannelId { get; set; }
   }
-  class FeedFilterReferenceResource
-  {
-    .ctor()
-    String DeploymentActionSlug { get; set; }
-    String DeploymentStepSlug { get; set; }
-    String FeedIdOrName { get; set; }
-    String PackageId { get; set; }
-  }
   class FeedFilterResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.Triggers.TriggerFilterResource
   {
     .ctor()
-    List<FeedFilterReferenceResource> FeedFilterReferences { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
+    List<TriggerPackageReferenceResource> Packages { get; set; }
   }
   class MachineFilterResource
     Octopus.Client.Extensibility.IResource
@@ -7111,6 +7103,12 @@ Octopus.Client.Model.Triggers
       DailySchedule = 5
       DaysPerWeekSchedule = 6
       FeedFilter = 7
+  }
+  class TriggerPackageReferenceResource
+  {
+    .ctor()
+    String DeploymentActionSlug { get; set; }
+    String PackageReferenceName { get; set; }
   }
 }
 Octopus.Client.Model.Triggers.ScheduledTriggers

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7033,6 +7033,7 @@ Octopus.Client.Model.Triggers
   {
     .ctor()
     String DeploymentProcessStepSlug { get; set; }
+    String PackageId { get; set; }
   }
   class FeedFilterResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7053,20 +7053,14 @@ Octopus.Client.Model.Triggers
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     String ChannelId { get; set; }
   }
-  class TriggerPackageReferenceResource
-  {
-    .ctor()
-    String DeploymentActionSlug { get; set; }
-    String PackageReferenceName { get; set; }
-  }
   class FeedFilterResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.Triggers.TriggerFilterResource
   {
     .ctor()
-    List<TriggerPackageReferenceResource> Packages { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
+    List<TriggerPackageReferenceResource> Packages { get; set; }
   }
   class MachineFilterResource
     Octopus.Client.Extensibility.IResource
@@ -7133,6 +7127,12 @@ Octopus.Client.Model.Triggers
       DailySchedule = 5
       DaysPerWeekSchedule = 6
       FeedFilter = 7
+  }
+  class TriggerPackageReferenceResource
+  {
+    .ctor()
+    String DeploymentActionSlug { get; set; }
+    String PackageReferenceName { get; set; }
   }
 }
 Octopus.Client.Model.Triggers.ScheduledTriggers

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7056,7 +7056,9 @@ Octopus.Client.Model.Triggers
   class FeedFilterReferenceResource
   {
     .ctor()
-    String DeploymentProcessStepSlug { get; set; }
+    String DeploymentActionSlug { get; set; }
+    String DeploymentStepSlug { get; set; }
+    String FeedIdOrName { get; set; }
     String PackageId { get; set; }
   }
   class FeedFilterResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7053,6 +7053,21 @@ Octopus.Client.Model.Triggers
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     String ChannelId { get; set; }
   }
+  class FeedFilterReferenceResource
+  {
+    .ctor()
+    String DeploymentProcessStepSlug { get; set; }
+    String PackageId { get; set; }
+  }
+  class FeedFilterResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Triggers.TriggerFilterResource
+  {
+    .ctor()
+    List<FeedFilterReferenceResource> FeedFilterReferences { get; set; }
+    Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
+  }
   class MachineFilterResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -7099,6 +7114,7 @@ Octopus.Client.Model.Triggers
       DeployLatestRelease = 1
       DeployNewRelease = 2
       RunRunbook = 3
+      CreateRelease = 4
   }
   abstract class TriggerFilterResource
     Octopus.Client.Extensibility.IResource
@@ -7116,6 +7132,7 @@ Octopus.Client.Model.Triggers
       CronExpressionSchedule = 4
       DailySchedule = 5
       DaysPerWeekSchedule = 6
+      FeedFilter = 7
   }
 }
 Octopus.Client.Model.Triggers.ScheduledTriggers

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7044,6 +7044,15 @@ Octopus.Client.Model.Triggers
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     Boolean ShouldRedeployWhenMachineHasBeenDeployedTo { get; set; }
   }
+  class CreateReleaseActionResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.Triggers.TriggerActionResource
+  {
+    .ctor()
+    Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
+    String ChannelId { get; set; }
+  }
   class MachineFilterResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7053,13 +7053,11 @@ Octopus.Client.Model.Triggers
     Octopus.Client.Model.Triggers.TriggerActionType ActionType { get; }
     String ChannelId { get; set; }
   }
-  class FeedFilterReferenceResource
+  class TriggerPackageReferenceResource
   {
     .ctor()
     String DeploymentActionSlug { get; set; }
-    String DeploymentStepSlug { get; set; }
-    String FeedIdOrName { get; set; }
-    String PackageId { get; set; }
+    String PackageReferenceName { get; set; }
   }
   class FeedFilterResource
     Octopus.Client.Extensibility.IResource
@@ -7067,7 +7065,7 @@ Octopus.Client.Model.Triggers
     Octopus.Client.Model.Triggers.TriggerFilterResource
   {
     .ctor()
-    List<FeedFilterReferenceResource> FeedFilterReferences { get; set; }
+    List<TriggerPackageReferenceResource> Packages { get; set; }
     Octopus.Client.Model.Triggers.TriggerFilterType FilterType { get; }
   }
   class MachineFilterResource

--- a/source/Octopus.Server.Client/Model/Triggers/CreateReleaseActionResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/CreateReleaseActionResource.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.Triggers;
+
+public class CreateReleaseActionResource : TriggerActionResource
+{
+    public override TriggerActionType ActionType => TriggerActionType.CreateRelease;
+
+    [Writeable]
+    public string ChannelId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Triggers/FeedFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/FeedFilterResource.cs
@@ -8,20 +8,14 @@ public class FeedFilterResource : TriggerFilterResource
     public override TriggerFilterType FilterType => TriggerFilterType.FeedFilter;
 
     [Writeable]
-    public List<FeedFilterReferenceResource> FeedFilterReferences { get; set; } = new();
+    public List<TriggerPackageReferenceResource> Packages { get; set; } = new();
 }
 
-public class FeedFilterReferenceResource
+public class TriggerPackageReferenceResource
 {
     [Writeable]
-    public string DeploymentStepSlug { get; set; }
-    
-    [Writeable]
     public string DeploymentActionSlug { get; set; }
-    
+
     [Writeable]
-    public string FeedIdOrName { get; set; }
-    
-    [Writeable]
-    public string PackageId { get; set; }
+    public string PackageReferenceName { get; set; }
 }

--- a/source/Octopus.Server.Client/Model/Triggers/FeedFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/FeedFilterResource.cs
@@ -14,7 +14,13 @@ public class FeedFilterResource : TriggerFilterResource
 public class FeedFilterReferenceResource
 {
     [Writeable]
-    public string DeploymentProcessStepSlug { get; set; }
+    public string DeploymentStepSlug { get; set; }
+    
+    [Writeable]
+    public string DeploymentActionSlug { get; set; }
+    
+    [Writeable]
+    public string FeedIdOrName { get; set; }
     
     [Writeable]
     public string PackageId { get; set; }

--- a/source/Octopus.Server.Client/Model/Triggers/FeedFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/FeedFilterResource.cs
@@ -15,4 +15,7 @@ public class FeedFilterReferenceResource
 {
     [Writeable]
     public string DeploymentProcessStepSlug { get; set; }
+    
+    [Writeable]
+    public string PackageId { get; set; }
 }

--- a/source/Octopus.Server.Client/Model/Triggers/FeedFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/FeedFilterResource.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.Triggers;
+
+public class FeedFilterResource : TriggerFilterResource
+{
+    public override TriggerFilterType FilterType => TriggerFilterType.FeedFilter;
+
+    [Writeable]
+    public List<FeedFilterReferenceResource> FeedFilterReferences { get; set; } = new();
+}
+
+public class FeedFilterReferenceResource
+{
+    [Writeable]
+    public string DeploymentProcessStepSlug { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Triggers/TriggerActionResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/TriggerActionResource.cs
@@ -5,7 +5,8 @@
         AutoDeploy,
         DeployLatestRelease,
         DeployNewRelease,
-        RunRunbook
+        RunRunbook,
+        CreateRelease
     }
 
     public abstract class TriggerActionResource : Resource

--- a/source/Octopus.Server.Client/Model/Triggers/TriggerFilterResource.cs
+++ b/source/Octopus.Server.Client/Model/Triggers/TriggerFilterResource.cs
@@ -11,7 +11,8 @@ namespace Octopus.Client.Model.Triggers
         DaysPerMonthSchedule,
         CronExpressionSchedule,
         DailySchedule,
-        DaysPerWeekSchedule
+        DaysPerWeekSchedule,
+        FeedFilter
     }
 
     public abstract class TriggerFilterResource : Resource

--- a/source/Octopus.Server.Client/Serialization/TriggerActionConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/TriggerActionConverter.cs
@@ -13,7 +13,8 @@ namespace Octopus.Client.Serialization
                 {TriggerActionType.AutoDeploy, typeof(AutoDeployActionResource)},
                 {TriggerActionType.DeployLatestRelease, typeof(DeployLatestReleaseActionResource)},
                 {TriggerActionType.DeployNewRelease, typeof(DeployNewReleaseActionResource)},
-                {TriggerActionType.RunRunbook, typeof(RunRunbookActionResource)}
+                {TriggerActionType.RunRunbook, typeof(RunRunbookActionResource)},
+                {TriggerActionType.CreateRelease, typeof(CreateReleaseActionResource)}
             };
 
         protected override IDictionary<TriggerActionType, Type> DerivedTypeMappings => ActionTypes;

--- a/source/Octopus.Server.Client/Serialization/TriggerFilterConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/TriggerFilterConverter.cs
@@ -16,7 +16,8 @@ namespace Octopus.Client.Serialization
               { TriggerFilterType.ContinuousDailySchedule, typeof (ContinuousDailyScheduledTriggerFilterResource)},
               { TriggerFilterType.DaysPerMonthSchedule, typeof (DaysPerMonthScheduledTriggerFilterResource)},
               { TriggerFilterType.DaysPerWeekSchedule, typeof (DaysPerWeekScheduledTriggerFilterResource)},
-              { TriggerFilterType.CronExpressionSchedule, typeof (CronScheduledTriggerFilterResource)}
+              { TriggerFilterType.CronExpressionSchedule, typeof (CronScheduledTriggerFilterResource)},
+              { TriggerFilterType.FeedFilter, typeof (FeedFilterResource)}
           };
 
         protected override IDictionary<TriggerFilterType, Type> DerivedTypeMappings => FilterTypes;


### PR DESCRIPTION
Adds resources required for the new project trigger that creates a new release when new packages are pushed to external feeds.

[sc-68515]