### PR TITLE
GHA: Update setup-dotnet, use correct powershell date syntax

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,19 +40,18 @@ jobs:
           fetch-depth: 0 # all
 
       - name: Setup .NET 6.0
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
-      # Adjustment is done prior to Nuke build as OCTOVERSION information is included in the result package.
       - name: Append OCTOVERSION_CurrentBranch with -nightly (for scheduled)
         if: github.event_name == 'schedule'
-        run: echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly-$(date +'%Y%m%d%H%M%S')" >> $env:GITHUB_ENV
+        run: echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly-$(Get-Date -Format 'yyyyMMddHHmmss')" >> $env:GITHUB_ENV
 
       # Note: Because this step runs on Windows, this will also run all of the tests on Windows
       - name: Nuke Build 🏗
@@ -144,7 +143,7 @@ jobs:
 
       - name: Tag release (when not pre-release) 🏷️
         id: github-tag
-        if: ${{ github.event_name != 'schedule' && !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}
+        if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -163,12 +162,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup .NET 6.0
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
@@ -193,12 +192,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup .NET 6.0
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -246,7 +246,7 @@ jobs:
       - name: Login to Octopus Deploy 🐙
         uses: OctopusDeploy/login@v1
         with: 
-          server: https://deploy.octopus.app
+          server: ${{ secrets.OCTOPUS_URL }}
           service_account_id: 8b5a7f0f-c2c9-48de-a0f6-74d83669accf
 
       - name: Push to Octopus 🐙


### PR DESCRIPTION
Note: Unlike all the other repos, I didn't need to update the permissions to allow git tag creation on this workflow.

Because of the cross-platform builds this does, the "push stuff to octopus" happens at the end in it's own job, which _only_ does those things. The git tagging happens in an earlier job which doesn't use OIDC and thus specifies nothing for permissions; The default permissions allow git tagging so we had no problem.

You can see a manual GHA run here:
https://github.com/OctopusDeploy/OctopusClients/actions/runs/7813217991