### PR TITLE
It's a response.. but not a IResponse

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6449,7 +6449,6 @@ Octopus.Client.Model.DeploymentFreezes
     Int32 Take { get; set; }
   }
   class GetDeploymentFreezesResponse
-    Octopus.Server.MessageContracts.Base.IResponse
   {
     .ctor()
     Int32 Count { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6473,7 +6473,6 @@ Octopus.Client.Model.DeploymentFreezes
     Int32 Take { get; set; }
   }
   class GetDeploymentFreezesResponse
-    Octopus.Server.MessageContracts.Base.IResponse
   {
     .ctor()
     Int32 Count { get; set; }

--- a/source/Octopus.Server.Client/Model/DeploymentFreezes/GetDeploymentFreezesResponse.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentFreezes/GetDeploymentFreezesResponse.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Octopus.Server.MessageContracts.Base;
 
 namespace Octopus.Client.Model.DeploymentFreezes;
 
-public class GetDeploymentFreezesResponse : IResponse
+public class GetDeploymentFreezesResponse
 {
     [Required] public IReadOnlyCollection<DeploymentFreezeResource> DeploymentFreezes { get; set; }
 


### PR DESCRIPTION
We don't publish any recent message contracts, so opting not to make this as IResponse. Otherwise we would use the message contract response.