### PR TITLE
Fix Kubernetes Agent resource serialization

### DIFF
--- a/source/Octopus.Client.Tests/Serialization/EndpointConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/EndpointConverterFixture.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NUnit.Framework;
+using Octopus.Client.Model;
+using Octopus.Client.Model.Endpoints;
+using Octopus.Client.Serialization;
+
+namespace Octopus.Client.Tests.Serialization
+{
+    [TestFixture]
+    public class EndpointConverterFixture
+    {
+        [Test]
+        public void AzureWebApp()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.AzureWebApp),
+                WebAppName = "The thumbprint"
+            };
+
+            var result = Execute<AzureWebAppEndpointResource>(input);
+
+            result.WebAppName.Should().Be(input.WebAppName);
+        }
+
+        [Test]
+        public void CloudRegion()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.None),
+                DefaultWorkerPoolId = "The pool"
+            };
+
+            var result = Execute<CloudRegionEndpointResource>(input);
+
+            result.DefaultWorkerPoolId.Should().Be(input.DefaultWorkerPoolId);
+        }
+        
+        [Test]
+        public void AzureCloudService()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.AzureCloudService),
+                AccountId = "The account"
+            };
+
+            var result = Execute<CloudServiceEndpointResource>(input);
+
+            result.AccountId.Should().Be(input.AccountId);
+        }
+        
+        [Test]
+        public void KubernetesApi()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.Kubernetes),
+                ClusterUrl = "The URL"
+            };
+
+            var result = Execute<KubernetesEndpointResource>(input);
+
+            result.ClusterUrl.Should().Be(input.ClusterUrl);
+        }
+
+        [Test]
+        public void KUbernetesTentacle()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.KubernetesTentacle),
+                TentacleEndpointConfiguration = new
+                {
+                    CommunicationMode = nameof(TentacleCommunicationModeResource.Listening),
+                    Thumbprint = "The thumbprint",
+                    Uri = "Some Uri"
+                }
+            };
+
+            var result = Execute<KubernetesTentacleEndpointResource>(input);
+
+            result.CommunicationStyle.Should().Be(CommunicationStyle.KubernetesTentacle);
+            result.TentacleEndpointConfiguration.CommunicationMode.Should().Be(TentacleCommunicationModeResource.Listening);
+        }
+
+        [Test]
+        public void OfflineDrop()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.OfflineDrop),
+                Destination = new
+                {
+                    DestinationType = "FileSystem",
+                    DropFolderPath = "The path"
+                }
+            };
+
+            var result = Execute<OfflineDropEndpointResource>(input);
+
+            result.Destination.DestinationType.Should().Be(OfflineDropDestinationType.FileSystem);
+            result.Destination.DropFolderPath.Should().Be(input.Destination.DropFolderPath);
+        }
+
+        [Test]
+        public void AzureServiceFabric()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.AzureServiceFabricCluster),
+                SecurityMode = "SecureClientCertificate"
+            };
+
+            var result = Execute<ServiceFabricEndpointResource>(input);
+
+            result.SecurityMode.Should().Be(AzureServiceFabricSecurityMode.SecureClientCertificate);
+        }
+
+        [Test]
+        public void Ssh()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.Ssh),
+                AccountId = "The account"
+            };
+
+            var result = Execute<SshEndpointResource>(input);
+
+            result.AccountId.Should().Be(input.AccountId);
+        }
+
+        [Test]
+        public void StepPackage()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.StepPackage),
+                StepPackageVersion = "The version"
+            };
+
+            var result = Execute<StepPackageEndpointResource>(input);
+
+            result.StepPackageVersion.Should().Be(input.StepPackageVersion);
+        }
+
+        [Test]
+        public void ListeningTentacle()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.TentaclePassive),
+                ProxyId = "The proxy",
+                Thumbprint = "The thumb"
+            };
+
+            var result = Execute<ListeningTentacleEndpointResource>(input);
+
+            result.Thumbprint.Should().Be(input.Thumbprint);
+            result.ProxyId.Should().Be(input.ProxyId);
+        }
+
+        [Test]
+        public void PollingTentacle()
+        {
+            var input = new
+            {
+                CommunicationStyle = nameof(CommunicationStyle.TentacleActive),
+                Thumbprint = "The thumb"
+            };
+
+            var result = Execute<PollingTentacleEndpointResource>(input);
+
+            result.Thumbprint.Should().Be(input.Thumbprint);
+        }
+        
+        [Test]
+        public void TinyTypeDiscriminator()
+        {
+            var input = new
+            {
+                CommunicationMode = nameof(TentacleCommunicationModeResource.Listening),
+                Thumbprint = "The thumbprint",
+                Uri = "Some Uri"
+            };
+
+            var result = Execute<TentacleEndpointConfigurationResource>(input);
+
+            result.CommunicationMode.Should().Be(TentacleCommunicationModeResource.Listening);
+            result.Thumbprint.Should().Be(input.Thumbprint);
+            result.Uri.Should().Be(input.Uri);
+        }
+
+        private static T Execute<T>(object input)
+        {
+            //Serialize anonymous object to JSON
+            var json = JsonConvert.SerializeObject(input);
+            
+            var settings = JsonSerialization.GetDefaultSerializerSettings();
+            return JsonConvert.DeserializeObject<T>(json, settings);
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/Serialization/EndpointConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/EndpointConverterFixture.cs
@@ -183,23 +183,6 @@ namespace Octopus.Client.Tests.Serialization
             result.Thumbprint.Should().Be(input.Thumbprint);
         }
         
-        [Test]
-        public void TinyTypeDiscriminator()
-        {
-            var input = new
-            {
-                CommunicationMode = nameof(TentacleCommunicationModeResource.Listening),
-                Thumbprint = "The thumbprint",
-                Uri = "Some Uri"
-            };
-
-            var result = Execute<TentacleEndpointConfigurationResource>(input);
-
-            result.CommunicationMode.Should().Be(TentacleCommunicationModeResource.Listening);
-            result.Thumbprint.Should().Be(input.Thumbprint);
-            result.Uri.Should().Be(input.Uri);
-        }
-
         private static T Execute<T>(object input)
         {
             //Serialize anonymous object to JSON

--- a/source/Octopus.Client.Tests/Serialization/EndpointConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/EndpointConverterFixture.cs
@@ -189,7 +189,8 @@ namespace Octopus.Client.Tests.Serialization
             var json = JsonConvert.SerializeObject(input);
             
             var settings = JsonSerialization.GetDefaultSerializerSettings();
-            return JsonConvert.DeserializeObject<T>(json, settings);
+            return JsonConvert.DeserializeObject<EndpointResource>(json, settings)
+                .Should().BeOfType<T>().Subject;
         }
     }
 }

--- a/source/Octopus.Client.Tests/Serialization/InheritedClassConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/InheritedClassConverterFixture.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Octopus.Client.Serialization;
+using Octopus.TinyTypes;
+
+namespace Octopus.Client.Tests.Serialization
+{
+    [TestFixture]
+    public class InheritedClassConverterFixture
+    {
+        [Test]
+        public void StringDiscriminator()
+        {
+            var input = new
+            {
+                Discriminator = StringDiscriminatorClass1.DiscriminatorName
+            };
+
+            var result = Execute<StringDiscriminatorBaseClass>(input, new StringDiscriminatorClassConverter());
+
+            result.Should().BeOfType<StringDiscriminatorClass1>();
+        }
+
+        [Test]
+        public void EnumDiscriminator()
+        {
+            var input = new
+            {
+                Discriminator = nameof(DiscriminatorEnum.Class1)
+            };
+
+            var result = Execute<EnumDiscriminatorBaseClass>(input, new EnumDiscriminatorClassConverter());
+
+            result.Should().BeOfType<EnumDiscriminatorClass1>();
+        }
+
+        [Test]
+        public void TinyTypeDiscriminator()
+        {
+            var input = new
+            {
+                Discriminator = DiscriminatorTinyType.Class1Name.Value
+            };
+
+            var result = Execute<TinyTypeDiscriminatorBaseClass>(input, new TinyTypeDiscriminatorClassConverter());
+
+            result.Should().BeOfType<TinyTypeDiscriminatorClass1>();
+        }
+        
+        private static T Execute<T>(object input, JsonConverter customJsonConverter)
+        {
+            //Serialize anonymous object to JSON
+            var json = JsonConvert.SerializeObject(input);
+            
+            var settings = JsonSerialization.GetDefaultSerializerSettings();
+            settings.Converters.Add(customJsonConverter);
+            return JsonConvert.DeserializeObject<T>(json, settings);
+        }
+
+        abstract class StringDiscriminatorBaseClass
+        {
+            public abstract string Discriminator { get; }
+        }
+
+        class StringDiscriminatorClass1 : StringDiscriminatorBaseClass
+        {
+            public const string DiscriminatorName = "Class1";
+            public override string Discriminator => DiscriminatorName;
+        }
+        
+        class StringDiscriminatorClassConverter : InheritedClassConverter<StringDiscriminatorBaseClass, string>
+        {
+            static readonly IDictionary<string, Type> TypeMappings =
+                new Dictionary<string, Type>
+                {
+                    {StringDiscriminatorClass1.DiscriminatorName, typeof(StringDiscriminatorClass1)}
+                };
+
+            protected override IDictionary<string, Type> DerivedTypeMappings => TypeMappings;
+            protected override string TypeDesignatingPropertyName => "Discriminator";
+        }
+
+        enum DiscriminatorEnum
+        {
+            Something,
+            Class1
+        }
+
+        abstract class EnumDiscriminatorBaseClass
+        {
+            public abstract DiscriminatorEnum Discriminator { get; }
+        }
+
+        class EnumDiscriminatorClass1 : EnumDiscriminatorBaseClass
+        {
+            public const DiscriminatorEnum DiscriminatorName = DiscriminatorEnum.Class1;
+            public override DiscriminatorEnum Discriminator => DiscriminatorName;
+        }
+        
+        class EnumDiscriminatorClassConverter : InheritedClassConverter<EnumDiscriminatorBaseClass, DiscriminatorEnum>
+        {
+            static readonly IDictionary<DiscriminatorEnum, Type> TypeMappings =
+                new Dictionary<DiscriminatorEnum, Type>
+                {
+                    {DiscriminatorEnum.Class1, typeof(EnumDiscriminatorClass1)}
+                };
+
+            protected override IDictionary<DiscriminatorEnum, Type> DerivedTypeMappings => TypeMappings;
+            protected override string TypeDesignatingPropertyName => "Discriminator";
+        }
+        
+        class DiscriminatorTinyType : CaseInsensitiveStringTinyType
+        {
+            public static readonly DiscriminatorTinyType Class1Name = new DiscriminatorTinyType("Class1");
+            public DiscriminatorTinyType(string value) : base(value)
+            {
+            }
+        }
+
+        abstract class TinyTypeDiscriminatorBaseClass
+        {
+            public abstract DiscriminatorTinyType Discriminator { get; }
+        }
+
+        class TinyTypeDiscriminatorClass1 : TinyTypeDiscriminatorBaseClass
+        {
+            public static readonly DiscriminatorTinyType DiscriminatorName = DiscriminatorTinyType.Class1Name;
+            public override DiscriminatorTinyType Discriminator => DiscriminatorName;
+        }
+        
+        class TinyTypeDiscriminatorClassConverter : InheritedClassConverter<TinyTypeDiscriminatorBaseClass, DiscriminatorTinyType>
+        {
+            static readonly IDictionary<DiscriminatorTinyType, Type> TypeMappings =
+                new Dictionary<DiscriminatorTinyType, Type>
+                {
+                    {DiscriminatorTinyType.Class1Name, typeof(TinyTypeDiscriminatorClass1)}
+                };
+
+            protected override IDictionary<DiscriminatorTinyType, Type> DerivedTypeMappings => TypeMappings;
+            protected override string TypeDesignatingPropertyName => "Discriminator";
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/Serialization/TentacleConfigurationConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/TentacleConfigurationConverterFixture.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Octopus.Client.Model;
+using Octopus.Client.Model.Endpoints;
+using Octopus.Client.Serialization;
+
+namespace Octopus.Client.Tests.Serialization
+{
+    [TestFixture]
+    public class TentacleConfigurationConverterFixture
+    {
+        [Test]
+        public void ListeningTentacle()
+        {
+            var input = new
+            {
+                CommunicationMode = nameof(TentacleCommunicationModeResource.Listening),
+                Uri = "The Uri",
+                Thumbprint = "The thumbprint",
+                ProxyId = "The ProxyId"
+            };
+
+            var result = Execute<ListeningTentacleEndpointConfigurationResource>(input);
+
+            result.CommunicationMode.Should().Be(TentacleCommunicationModeResource.Listening);
+            result.Uri.Should().Be(input.Uri);
+            result.Thumbprint.Should().Be(input.Thumbprint);
+            result.ProxyId.Should().Be(input.ProxyId);
+        }
+
+        [Test]
+        public void PollingTentacle()
+        {
+            var input = new
+            {
+                CommunicationMode = nameof(TentacleCommunicationModeResource.Polling),
+                Uri = "The Uri",
+                Thumbprint = "The thumbprint",
+            };
+
+            var result = Execute<PollingTentacleEndpointConfigurationResource>(input);
+
+            result.CommunicationMode.Should().Be(TentacleCommunicationModeResource.Polling);
+            result.Uri.Should().Be(input.Uri);
+            result.Thumbprint.Should().Be(input.Thumbprint);
+        }
+        
+        private static T Execute<T>(object input)
+        {
+            //Serialize anonymous object to JSON
+            var json = JsonConvert.SerializeObject(input);
+            
+            var settings = JsonSerialization.GetDefaultSerializerSettings();
+            return JsonConvert.DeserializeObject<T>(json, settings);
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/Serialization/TentacleConfigurationConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/TentacleConfigurationConverterFixture.cs
@@ -52,7 +52,8 @@ namespace Octopus.Client.Tests.Serialization
             var json = JsonConvert.SerializeObject(input);
             
             var settings = JsonSerialization.GetDefaultSerializerSettings();
-            return JsonConvert.DeserializeObject<T>(json, settings);
+            return JsonConvert.DeserializeObject<TentacleEndpointConfigurationResource>(json, settings)
+                .Should().BeOfType<T>().Subject;
         }
     }
 }

--- a/source/Octopus.Server.Client/Serialization/EndpointConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/EndpointConverter.cs
@@ -23,7 +23,7 @@ namespace Octopus.Client.Serialization
                 {CommunicationStyle.Kubernetes, typeof (KubernetesEndpointResource)},
                 {CommunicationStyle.AzureServiceFabricCluster, typeof(ServiceFabricEndpointResource)},
                 {CommunicationStyle.StepPackage, typeof(StepPackageEndpointResource)},
-                {CommunicationStyle.KubernetesTentacle, typeof(KubernetesEndpointResource)}
+                {CommunicationStyle.KubernetesTentacle, typeof(KubernetesTentacleEndpointResource)}
           };
 
         protected override IDictionary<CommunicationStyle, Type> DerivedTypeMappings => EndpointTypes;

--- a/source/Octopus.Server.Client/Serialization/InheritedClassConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/InheritedClassConverter.cs
@@ -5,11 +5,12 @@ using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Octopus.Client.Model;
+using Octopus.TinyTypes;
 using Octopus.TinyTypes.TypeConverters;
 
 namespace Octopus.Client.Serialization
 {
-    public abstract class InheritedClassConverter<TBaseResource, TEnumType> : JsonConverter
+    public abstract class InheritedClassConverter<TBaseResource, TDiscriminator> : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -46,24 +47,8 @@ namespace Octopus.Client.Serialization
             }
             else
             {
-
                 var derivedType = designatingProperty.ToObject<string>();
-                TEnumType discriminatingType;
-                if (typeof(TEnumType).IsEnum)
-                {
-                    discriminatingType = (TEnumType)Enum.Parse(typeof(TEnumType), derivedType);
-                }
-                else
-                {
-                    discriminatingType = (TEnumType)new TinyTypeConverter<TEnumType>().ConvertFrom(derivedType);
-                }
-                
-                if (!DerivedTypeMappings.ContainsKey(discriminatingType))
-                {
-                    throw new Exception($"Unable to determine type to deserialize. {TypeDesignatingPropertyName} `{discriminatingType}` does not map to a known type");
-                }
-
-                type = DerivedTypeMappings[discriminatingType];
+                type = GetTypeFromDiscriminator(derivedType);
             }
 
             var ctor = type.GetTypeInfo().GetConstructors(BindingFlags.Public | BindingFlags.Instance).Single();
@@ -83,12 +68,44 @@ namespace Octopus.Client.Serialization
             return instance;
         }
 
+        private Type GetTypeFromDiscriminator(string derivedType)
+        {
+            var discriminatingType = GetDiscriminatingTypeFromStringValue(derivedType);
+
+            if (!DerivedTypeMappings.ContainsKey(discriminatingType))
+            {
+                throw new Exception($"Unable to determine type to deserialize. {TypeDesignatingPropertyName} `{discriminatingType}` does not map to a known type");
+            }
+
+            return DerivedTypeMappings[discriminatingType];
+        }
+
+        private static TDiscriminator GetDiscriminatingTypeFromStringValue(string derivedType)
+        {
+            if (typeof(TDiscriminator).IsEnum)
+            {
+                return (TDiscriminator)Enum.Parse(typeof(TDiscriminator), derivedType);
+            }
+
+            if (typeof(TDiscriminator).IsTinyType())
+            {
+                return (TDiscriminator)new TinyTypeConverter<TDiscriminator>().ConvertFrom(derivedType);
+            }
+
+            if (typeof(TDiscriminator) == typeof(string))
+            {
+                return (TDiscriminator)(object)derivedType;
+            }
+            
+            throw new Exception("Discriminator type not supported: " + typeof(TDiscriminator));
+        }
+
         public override bool CanConvert(Type objectType)
         {
             return typeof(TBaseResource).GetTypeInfo().IsAssignableFrom(objectType);
         }
 
-        protected abstract IDictionary<TEnumType, Type> DerivedTypeMappings { get; }
+        protected abstract IDictionary<TDiscriminator, Type> DerivedTypeMappings { get; }
 
         protected abstract string TypeDesignatingPropertyName { get; }
     }


### PR DESCRIPTION
[sc-71239]

The Kubernetes Agent resource couldn't actually be deserialized due to:
- No support for tiny types as the discriminator
- Incorrect resource type declaration