### PR TITLE
FeedRepository to allow fetching of mulitple versions

### DIFF
--- a/source/Octopus.Server.Client/Repositories/Async/FeedRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/FeedRepository.cs
@@ -11,6 +11,8 @@ namespace Octopus.Client.Repositories.Async
         [Obsolete("Please use the overload with cancellation token instead.", false)]
         Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds);
         Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds, CancellationToken cancellationToken);
+        
+        Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds, bool includeAllVersions, CancellationToken cancellationToken);
     }
 
     class FeedRepository : BasicRepository<FeedResource>, IFeedRepository
@@ -27,6 +29,13 @@ namespace Octopus.Client.Repositories.Async
         public Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds, CancellationToken cancellationToken)
         {
             return Client.Get<List<PackageResource>>(feed.Link("VersionsTemplate"), new { packageIds = packageIds }, cancellationToken);
+        }
+        
+        public Task<List<PackageResource>> GetVersions(FeedResource feed, string[] packageIds, bool IncludeMultipleVersions, CancellationToken cancellationToken)
+        {
+            return Client.Get<List<PackageResource>>(feed.Link("VersionsTemplate"), 
+                new { packageIds = packageIds, includeAllVersions = IncludeMultipleVersions },
+                cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Currently the FeedRepository only fetches a single version  -this change adds a function which populates the includeMultipleVersions such that more than 1 is returned.