### PR TITLE
Stop the build from doing a restore

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -108,7 +108,8 @@ class Build : NukeBuild
         DotNetBuild(_ => _
             .SetProjectFile(SourceDir)
             .SetConfiguration(Configuration)
-            .SetVersion(FullSemVer));
+            .SetVersion(FullSemVer)
+            .EnableNoRestore());
     });
 
     Target Merge => _ => _


### PR DESCRIPTION
Stop the build from doing a restore as the Restore target runs first and is required.