### PR TITLE
Add helper methods for getting and setting tenant variables

### DIFF
--- a/source/Octopus.Client.Tests/Model/TenantVariableResourceFixture.cs
+++ b/source/Octopus.Client.Tests/Model/TenantVariableResourceFixture.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Tests.Model
+{
+    public class TenantVariableResourceFixture
+    {
+        [Test]
+        public void SettingProjectVariable_Works()
+        {
+            var project = new ProjectResource("Projects-1", "TestProject", "test-project");
+            var environment = new EnvironmentResource { Id = "Environments-1" };
+            var templateId = Guid.NewGuid().ToString();
+            var resource = new TenantVariableResourceBuilder()
+                .WithProjectEnvironment(project, environment)
+                .WithProjectTemplate(project, action => action
+                    .WithId(templateId)
+                    .WithName("ProjectVariable1"))
+                .Build();
+
+            resource.SetProjectVariableValue(project, environment, "ProjectVariable1", "SomeValue");
+
+            resource.ProjectVariables["Projects-1"].Variables["Environments-1"]
+                .Should()
+                .ContainKey(templateId)
+                .WhoseValue.Should().BeEquivalentTo(new PropertyValueResource("SomeValue"));
+        }
+
+        [Test]
+        public void SettingLibraryVariable_Works()
+        {
+            var libraryVariableSet = new LibraryVariableSetResource { Id = "LibraryVariableSets-1" };
+
+            var templateId = Guid.NewGuid().ToString();
+            const string templateName = "LibraryVariable1";
+
+            var resource = new TenantVariableResourceBuilder()
+                .WithLibraryTemplate(libraryVariableSet, action => action
+                    .WithId(templateId)
+                    .WithName(templateName))
+                .Build();
+
+            resource.SetLibraryVariableValue(libraryVariableSet, templateName, "SomeValue");
+
+            resource.LibraryVariables[libraryVariableSet.Id].Variables
+                .Should()
+                .ContainKey(templateId)
+                .WhoseValue.Should().BeEquivalentTo(new PropertyValueResource("SomeValue"));
+        }
+    }
+
+    public class TenantVariableResourceBuilder
+    {
+        private Dictionary<string, TenantVariableResource.Project> projects = new Dictionary<string, TenantVariableResource.Project>();
+        private Dictionary<string, TenantVariableResource.Library> library = new Dictionary<string, TenantVariableResource.Library>();
+
+        public TenantVariableResourceBuilder WithProjectEnvironment(ProjectResource projectResource, EnvironmentResource environmentResource)
+        {
+            if (!projects.TryGetValue(projectResource.Id, out var projectVariables))
+            {
+                projectVariables = projects[projectResource.Id] = new TenantVariableResource.Project(projectResource.Id);
+            }
+
+            projectVariables.Variables[environmentResource.Id] = new Dictionary<string, PropertyValueResource>();
+            return this;
+        }
+
+        public TenantVariableResourceBuilder WithProjectTemplate(ProjectResource projectResource, Action<ActionTemplateParameterResourceBuilder> buildAction)
+        {
+            if (!projects.TryGetValue(projectResource.Id, out var projectVariables))
+            {
+                projectVariables = projects[projectResource.Id] = new TenantVariableResource.Project(projectResource.Id);
+            }
+
+            var builder = new ActionTemplateParameterResourceBuilder();
+            buildAction(builder);
+            var resource = builder.Build();
+            projectVariables.Templates.Add(resource);
+
+            return this;
+        }
+
+        public TenantVariableResourceBuilder WithLibraryTemplate(LibraryVariableSetResource libraryVariableSetResource, Action<ActionTemplateParameterResourceBuilder> buildAction)
+        {
+            if (!library.TryGetValue(libraryVariableSetResource.Id, out var libraryVariables))
+            {
+                libraryVariables = library[libraryVariableSetResource.Id] = new TenantVariableResource.Library(libraryVariableSetResource.Id);
+            }
+
+            var builder = new ActionTemplateParameterResourceBuilder();
+            buildAction(builder);
+            var resource = builder.Build();
+            libraryVariables.Templates.Add(resource);
+
+            return this;
+        }
+
+        public TenantVariableResource Build()
+        {
+            var resource = new TenantVariableResource
+            {
+                ProjectVariables = projects,
+                LibraryVariables = library
+            };
+
+            return resource;
+        }
+    }
+
+    public class ActionTemplateParameterResourceBuilder
+    {
+        private string id;
+        private string name;
+        private string label;
+        private string helpText;
+        private Dictionary<string, string> displaySettings = new Dictionary<string, string>();
+
+        public ActionTemplateParameterResourceBuilder WithId(string id)
+        {
+            this.id = id;
+            return this;
+        }
+
+        public ActionTemplateParameterResourceBuilder WithName(string name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public ActionTemplateParameterResourceBuilder WithLabel(string label)
+        {
+            this.label = label;
+            return this;
+        }
+
+        public ActionTemplateParameterResourceBuilder WithHelpText(string helpText)
+        {
+            this.helpText = helpText;
+            return this;
+        }
+
+        public ActionTemplateParameterResourceBuilder WithControlType(string controlType)
+        {
+            displaySettings[ControlType.ControlTypeKey] = controlType;
+            return this;
+        }
+
+        public ActionTemplateParameterResource Build()
+        {
+            return new ActionTemplateParameterResource
+            {
+                Id = id ?? Guid.NewGuid().ToString(),
+                Name = name ?? Guid.NewGuid().ToString(),
+                Label = label ?? Guid.NewGuid().ToString(),
+                HelpText = helpText,
+                DisplaySettings = displaySettings
+            };
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/Model/TenantVariableResourceFixture.cs
+++ b/source/Octopus.Client.Tests/Model/TenantVariableResourceFixture.cs
@@ -9,6 +9,26 @@ namespace Octopus.Client.Tests.Model
     public class TenantVariableResourceFixture
     {
         [Test]
+        public void GettingProjectVariable_Works()
+        {
+            var project = new ProjectResource("Projects-1", "TestProject", "test-project");
+            var environment = new EnvironmentResource { Id = "Environments-1" };
+            var templateId = Guid.NewGuid().ToString();
+            var resource = new TenantVariableResourceBuilder()
+                .WithProjectEnvironment(project, environment)
+                .WithProjectTemplate(project, action => action
+                    .WithId(templateId)
+                    .WithName("ProjectVariable1"))
+                .Build();
+
+            resource.ProjectVariables[project.Id].Variables[environment.Id][templateId] = "SomeValue";
+
+            resource.GetProjectVariableValue(project, environment, "ProjectVariable1")
+                .Should()
+                .BeEquivalentTo(new PropertyValueResource("SomeValue"));
+        }
+
+        [Test]
         public void SettingProjectVariable_Works()
         {
             var project = new ProjectResource("Projects-1", "TestProject", "test-project");
@@ -23,10 +43,31 @@ namespace Octopus.Client.Tests.Model
 
             resource.SetProjectVariableValue(project, environment, "ProjectVariable1", "SomeValue");
 
-            resource.ProjectVariables["Projects-1"].Variables["Environments-1"]
+            resource.ProjectVariables[project.Id].Variables[environment.Id]
                 .Should()
                 .ContainKey(templateId)
                 .WhoseValue.Should().BeEquivalentTo(new PropertyValueResource("SomeValue"));
+        }
+
+        [Test]
+        public void GettingLibraryVariable_Works()
+        {
+            var libraryVariableSet = new LibraryVariableSetResource { Id = "LibraryVariableSets-1" };
+
+            var templateId = Guid.NewGuid().ToString();
+            const string templateName = "LibraryVariable1";
+
+            var resource = new TenantVariableResourceBuilder()
+                .WithLibraryTemplate(libraryVariableSet, action => action
+                    .WithId(templateId)
+                    .WithName(templateName))
+                .Build();
+
+            resource.LibraryVariables[libraryVariableSet.Id].Variables[templateId] = "SomeValue";
+
+            resource.GetLibraryVariableValue(libraryVariableSet, templateName)
+                .Should()
+                .BeEquivalentTo(new PropertyValueResource("SomeValue"));
         }
 
         [Test]

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3517,6 +3517,7 @@ Octopus.Client.Model
     Octopus.Client.Extensibility.LinkCollection Links { get; set; }
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, PropertyValueResource> Variables { get; set; }
+    Octopus.Client.Model.PropertyValueResource GetVariableValue(String)
     void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
   }
   class LibraryVariableSetProjectUsage
@@ -4443,6 +4444,7 @@ Octopus.Client.Model
     String ProjectName { get; set; }
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
+    Octopus.Client.Model.PropertyValueResource GetVariableValue(Octopus.Client.Model.EnvironmentResource, String)
     void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
   }
   class ProjectedTeamReferenceDataItem
@@ -5662,6 +5664,8 @@ Octopus.Client.Model
     String SpaceId { get; set; }
     String TenantId { get; set; }
     String TenantName { get; set; }
+    Octopus.Client.Model.PropertyValueResource GetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String)
+    Octopus.Client.Model.PropertyValueResource GetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String)
     void SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
     void SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
     class Library
@@ -5672,6 +5676,7 @@ Octopus.Client.Model
       Octopus.Client.Extensibility.LinkCollection Links { get; set; }
       List<ActionTemplateParameterResource> Templates { get; set; }
       Dictionary<String, PropertyValueResource> Variables { get; set; }
+      Octopus.Client.Model.PropertyValueResource GetVariableValue(String)
       void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
     }
     class Project
@@ -5682,6 +5687,7 @@ Octopus.Client.Model
       String ProjectName { get; set; }
       List<ActionTemplateParameterResource> Templates { get; set; }
       Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
+      Octopus.Client.Model.PropertyValueResource GetVariableValue(Octopus.Client.Model.EnvironmentResource, String)
       void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
     }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1001,6 +1001,8 @@ Octopus.Client.Editors
     Octopus.Client.Editors.TenantVariablesEditor Customize(Action<TenantVariableResource>)
     Octopus.Client.Editors.TenantVariablesEditor Load()
     Octopus.Client.Editors.TenantVariablesEditor Save()
+    Octopus.Client.Editors.TenantVariablesEditor SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
+    Octopus.Client.Editors.TenantVariablesEditor SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
   }
   class UsernamePasswordAccountEditor
     Octopus.Client.Editors.IResourceEditor<UsernamePasswordAccountResource, UsernamePasswordAccountEditor>
@@ -1359,6 +1361,8 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.TenantVariablesEditor Customize(Action<TenantVariableResource>)
     Task<TenantVariablesEditor> Load()
     Task<TenantVariablesEditor> Save()
+    Octopus.Client.Editors.Async.TenantVariablesEditor SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
+    Octopus.Client.Editors.Async.TenantVariablesEditor SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
   }
   class UsernamePasswordAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<UsernamePasswordAccountResource, UsernamePasswordAccountEditor>
@@ -3513,6 +3517,7 @@ Octopus.Client.Model
     Octopus.Client.Extensibility.LinkCollection Links { get; set; }
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, PropertyValueResource> Variables { get; set; }
+    void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
   }
   class LibraryVariableSetProjectUsage
   {
@@ -4438,6 +4443,7 @@ Octopus.Client.Model
     String ProjectName { get; set; }
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
+    void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
   }
   class ProjectedTeamReferenceDataItem
     Octopus.Client.Model.ReferenceDataItem
@@ -5656,6 +5662,8 @@ Octopus.Client.Model
     String SpaceId { get; set; }
     String TenantId { get; set; }
     String TenantName { get; set; }
+    void SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
+    void SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
     class Library
     {
       .ctor(String)
@@ -5664,6 +5672,7 @@ Octopus.Client.Model
       Octopus.Client.Extensibility.LinkCollection Links { get; set; }
       List<ActionTemplateParameterResource> Templates { get; set; }
       Dictionary<String, PropertyValueResource> Variables { get; set; }
+      void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
     }
     class Project
     {
@@ -5673,6 +5682,7 @@ Octopus.Client.Model
       String ProjectName { get; set; }
       List<ActionTemplateParameterResource> Templates { get; set; }
       Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
+      void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
     }
   }
   TentacleUpdateBehavior

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3519,6 +3519,7 @@ Octopus.Client.Model
     Dictionary<String, PropertyValueResource> Variables { get; set; }
     Octopus.Client.Model.PropertyValueResource GetVariableValue(String)
     void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
+    Boolean TryGetVariableValue(String, Octopus.Client.Model.PropertyValueResource&)
   }
   class LibraryVariableSetProjectUsage
   {
@@ -4446,6 +4447,7 @@ Octopus.Client.Model
     Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
     Octopus.Client.Model.PropertyValueResource GetVariableValue(Octopus.Client.Model.EnvironmentResource, String)
     void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
+    Boolean TryGetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource&)
   }
   class ProjectedTeamReferenceDataItem
     Octopus.Client.Model.ReferenceDataItem
@@ -5668,6 +5670,8 @@ Octopus.Client.Model
     Octopus.Client.Model.PropertyValueResource GetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String)
     void SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
     void SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
+    Boolean TryGetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource&)
+    Boolean TryGetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource&)
     class Library
     {
       .ctor(String)
@@ -5678,6 +5682,7 @@ Octopus.Client.Model
       Dictionary<String, PropertyValueResource> Variables { get; set; }
       Octopus.Client.Model.PropertyValueResource GetVariableValue(String)
       void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
+      Boolean TryGetVariableValue(String, Octopus.Client.Model.PropertyValueResource&)
     }
     class Project
     {
@@ -5689,6 +5694,7 @@ Octopus.Client.Model
       Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
       Octopus.Client.Model.PropertyValueResource GetVariableValue(Octopus.Client.Model.EnvironmentResource, String)
       void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
+      Boolean TryGetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource&)
     }
   }
   TentacleUpdateBehavior

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1002,6 +1002,8 @@ Octopus.Client.Editors
     Octopus.Client.Editors.TenantVariablesEditor Customize(Action<TenantVariableResource>)
     Octopus.Client.Editors.TenantVariablesEditor Load()
     Octopus.Client.Editors.TenantVariablesEditor Save()
+    Octopus.Client.Editors.TenantVariablesEditor SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
+    Octopus.Client.Editors.TenantVariablesEditor SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
   }
   class UsernamePasswordAccountEditor
     Octopus.Client.Editors.IResourceEditor<UsernamePasswordAccountResource, UsernamePasswordAccountEditor>
@@ -1360,6 +1362,8 @@ Octopus.Client.Editors.Async
     Octopus.Client.Editors.Async.TenantVariablesEditor Customize(Action<TenantVariableResource>)
     Task<TenantVariablesEditor> Load()
     Task<TenantVariablesEditor> Save()
+    Octopus.Client.Editors.Async.TenantVariablesEditor SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
+    Octopus.Client.Editors.Async.TenantVariablesEditor SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
   }
   class UsernamePasswordAccountEditor
     Octopus.Client.Editors.Async.IResourceEditor<UsernamePasswordAccountResource, UsernamePasswordAccountEditor>
@@ -3530,6 +3534,7 @@ Octopus.Client.Model
     Octopus.Client.Extensibility.LinkCollection Links { get; set; }
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, PropertyValueResource> Variables { get; set; }
+    void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
   }
   class LibraryVariableSetProjectUsage
   {
@@ -4458,6 +4463,7 @@ Octopus.Client.Model
     String ProjectName { get; set; }
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
+    void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
   }
   class ProjectedTeamReferenceDataItem
     Octopus.Client.Model.ReferenceDataItem
@@ -5677,6 +5683,8 @@ Octopus.Client.Model
     String SpaceId { get; set; }
     String TenantId { get; set; }
     String TenantName { get; set; }
+    void SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
+    void SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
     class Library
     {
       .ctor(String)
@@ -5685,6 +5693,7 @@ Octopus.Client.Model
       Octopus.Client.Extensibility.LinkCollection Links { get; set; }
       List<ActionTemplateParameterResource> Templates { get; set; }
       Dictionary<String, PropertyValueResource> Variables { get; set; }
+      void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
     }
     class Project
     {
@@ -5694,6 +5703,7 @@ Octopus.Client.Model
       String ProjectName { get; set; }
       List<ActionTemplateParameterResource> Templates { get; set; }
       Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
+      void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
     }
   }
   TentacleUpdateBehavior

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3536,6 +3536,7 @@ Octopus.Client.Model
     Dictionary<String, PropertyValueResource> Variables { get; set; }
     Octopus.Client.Model.PropertyValueResource GetVariableValue(String)
     void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
+    Boolean TryGetVariableValue(String, Octopus.Client.Model.PropertyValueResource&)
   }
   class LibraryVariableSetProjectUsage
   {
@@ -4466,6 +4467,7 @@ Octopus.Client.Model
     Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
     Octopus.Client.Model.PropertyValueResource GetVariableValue(Octopus.Client.Model.EnvironmentResource, String)
     void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
+    Boolean TryGetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource&)
   }
   class ProjectedTeamReferenceDataItem
     Octopus.Client.Model.ReferenceDataItem
@@ -5689,6 +5691,8 @@ Octopus.Client.Model
     Octopus.Client.Model.PropertyValueResource GetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String)
     void SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
     void SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
+    Boolean TryGetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource&)
+    Boolean TryGetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource&)
     class Library
     {
       .ctor(String)
@@ -5699,6 +5703,7 @@ Octopus.Client.Model
       Dictionary<String, PropertyValueResource> Variables { get; set; }
       Octopus.Client.Model.PropertyValueResource GetVariableValue(String)
       void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
+      Boolean TryGetVariableValue(String, Octopus.Client.Model.PropertyValueResource&)
     }
     class Project
     {
@@ -5710,6 +5715,7 @@ Octopus.Client.Model
       Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
       Octopus.Client.Model.PropertyValueResource GetVariableValue(Octopus.Client.Model.EnvironmentResource, String)
       void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
+      Boolean TryGetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource&)
     }
   }
   TentacleUpdateBehavior

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3534,6 +3534,7 @@ Octopus.Client.Model
     Octopus.Client.Extensibility.LinkCollection Links { get; set; }
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, PropertyValueResource> Variables { get; set; }
+    Octopus.Client.Model.PropertyValueResource GetVariableValue(String)
     void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
   }
   class LibraryVariableSetProjectUsage
@@ -4463,6 +4464,7 @@ Octopus.Client.Model
     String ProjectName { get; set; }
     List<ActionTemplateParameterResource> Templates { get; set; }
     Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
+    Octopus.Client.Model.PropertyValueResource GetVariableValue(Octopus.Client.Model.EnvironmentResource, String)
     void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
   }
   class ProjectedTeamReferenceDataItem
@@ -5683,6 +5685,8 @@ Octopus.Client.Model
     String SpaceId { get; set; }
     String TenantId { get; set; }
     String TenantName { get; set; }
+    Octopus.Client.Model.PropertyValueResource GetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String)
+    Octopus.Client.Model.PropertyValueResource GetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String)
     void SetLibraryVariableValue(Octopus.Client.Model.LibraryVariableSetResource, String, Octopus.Client.Model.PropertyValueResource)
     void SetProjectVariableValue(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
     class Library
@@ -5693,6 +5697,7 @@ Octopus.Client.Model
       Octopus.Client.Extensibility.LinkCollection Links { get; set; }
       List<ActionTemplateParameterResource> Templates { get; set; }
       Dictionary<String, PropertyValueResource> Variables { get; set; }
+      Octopus.Client.Model.PropertyValueResource GetVariableValue(String)
       void SetVariableValue(String, Octopus.Client.Model.PropertyValueResource)
     }
     class Project
@@ -5703,6 +5708,7 @@ Octopus.Client.Model
       String ProjectName { get; set; }
       List<ActionTemplateParameterResource> Templates { get; set; }
       Dictionary<String, Dictionary<String, PropertyValueResource>> Variables { get; set; }
+      Octopus.Client.Model.PropertyValueResource GetVariableValue(Octopus.Client.Model.EnvironmentResource, String)
       void SetVariableValue(Octopus.Client.Model.EnvironmentResource, String, Octopus.Client.Model.PropertyValueResource)
     }
   }

--- a/source/Octopus.Server.Client/Editors/Async/TenantVariablesEditor.cs
+++ b/source/Octopus.Server.Client/Editors/Async/TenantVariablesEditor.cs
@@ -35,5 +35,24 @@ namespace Octopus.Client.Editors.Async
             Instance = await repository.ModifyVariables(tenant, Instance).ConfigureAwait(false);
             return this;
         }
+
+        public TenantVariablesEditor SetProjectVariableValue(
+            ProjectResource projectResource,
+            EnvironmentResource environmentResource,
+            string templateName,
+            PropertyValueResource value)
+        {
+            Instance.SetProjectVariableValue(projectResource, environmentResource, templateName, value);
+            return this;
+        }
+
+        public TenantVariablesEditor SetLibraryVariableValue(
+            LibraryVariableSetResource libraryVariableSetResource,
+            string templateName,
+            PropertyValueResource value)
+        {
+            Instance.SetLibraryVariableValue(libraryVariableSetResource, templateName, value);
+            return this;
+        }
     }
 }

--- a/source/Octopus.Server.Client/Editors/TenantVariablesEditor.cs
+++ b/source/Octopus.Server.Client/Editors/TenantVariablesEditor.cs
@@ -34,5 +34,24 @@ namespace Octopus.Client.Editors
             Instance = repository.ModifyVariables(tenant, Instance);
             return this;
         }
+
+        public TenantVariablesEditor SetProjectVariableValue(
+            ProjectResource projectResource,
+            EnvironmentResource environmentResource,
+            string templateName,
+            PropertyValueResource value)
+        {
+            Instance.SetProjectVariableValue(projectResource, environmentResource, templateName, value);
+            return this;
+        }
+
+        public TenantVariablesEditor SetLibraryVariableValue(
+            LibraryVariableSetResource libraryVariableSetResource,
+            string templateName,
+            PropertyValueResource value)
+        {
+            Instance.SetLibraryVariableValue(libraryVariableSetResource, templateName, value);
+            return this;
+        }
     }
 }

--- a/source/Octopus.Server.Client/Model/TenantVariableResource.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariableResource.cs
@@ -118,8 +118,7 @@ namespace Octopus.Client.Model
                     return false;
                 }
 
-                value = environmentVariables[templateId];
-                return true;
+                return environmentVariables.TryGetValue(templateId, out value);
             }
 
             public PropertyValueResource GetVariableValue(EnvironmentResource environment, string templateName)
@@ -180,8 +179,7 @@ namespace Octopus.Client.Model
                     return false;
                 }
 
-                value = Variables[templateId];
-                return true;
+                return Variables.TryGetValue(templateId, out value);
             }
 
             public PropertyValueResource GetVariableValue(string templateName)


### PR DESCRIPTION
# Background

Getting and setting tenant variable values using the client is difficult due to how they're accessed from the `TenantVariableResource`. It requires navigating 2 or 3 nested layers of dictionaries, with no indication of which keys are to be used at each level - you just have to know.

Also, the template being used is specified by its ID, which is not meaningful to end-users, rather than it's name. A lookup has to be manually performed each time to translate the name to the ID.

# Results

Added convenience methods to the `TenantVariablesResource` and `TenantVariableEditor` classes to simplify getting and setting values for tenant variables.

Example of usage in https://github.com/OctopusDeploy/OctopusDeploy/pull/24166