### PR TITLE
Rename TentacleEndpointConfigurationResource to make it clear it's only for KubernetesTentacles

### DIFF
--- a/source/Octopus.Client.Tests/Operations/RegisterKubernetesClusterOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterKubernetesClusterOperationFixture.cs
@@ -84,7 +84,7 @@ namespace Octopus.Client.Tests.Operations
 
             await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
 
-            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://mymachine.test.com:10930/")));
+            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new ListeningKubernetesTentacleEndpointConfigurationResource("ABCDEF", "https://mymachine.test.com:10930/")));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace Octopus.Client.Tests.Operations
 
             await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
 
-            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new PollingTentacleEndpointConfigurationResource("ABCDEF", "poll://ckyhfyfkcbmzjl8sfgch/")));
+            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new PollingKubernetesTentacleEndpointConfigurationResource("ABCDEF", "poll://ckyhfyfkcbmzjl8sfgch/")));
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace Octopus.Client.Tests.Operations
             machines.Items.Add(new MachineResource
             {
                 Id = "machines/84", EnvironmentIds = new ReferenceCollection(new[] { "environments-1" }), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1"),
-                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("123456", "myMachine.test.com") { ProxyId = "proxy-2" })
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningKubernetesTentacleEndpointConfigurationResource("123456", "myMachine.test.com") { ProxyId = "proxy-2" })
             });
 
             proxies.Items.Add(new ProxyResource { Id = "proxy-1", Name = "MyNewProxy", Links = LinkCollection.Self("/api/proxies/proxy-1") });
@@ -143,7 +143,7 @@ namespace Octopus.Client.Tests.Operations
                 Id = "machines/84",
                 Name = "Mymachine",
                 EnvironmentIds = new ReferenceCollection("environments-1"),
-                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://my-new-machine.test.com:10930/") {ProxyId = "proxy-1"}),
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningKubernetesTentacleEndpointConfigurationResource("ABCDEF", "https://my-new-machine.test.com:10930/") {ProxyId = "proxy-1"}),
                 Links = LinkCollection.Self("/machines/whatever/1")
             });
         }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6720,20 +6720,29 @@ Octopus.Client.Model.Endpoints
     String AccountId { get; set; }
     String AuthenticationType { get; }
   }
+  abstract class KubernetesTentacleEndpointConfigurationResource
+    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
+  {
+    String CertificateSignatureAlgorithm { get; set; }
+    Octopus.Client.Model.Endpoints.TentacleCommunicationModeResource CommunicationMode { get; }
+    Octopus.Client.Model.Endpoints.TentacleDetailsResource TentacleVersionDetails { get; set; }
+    String Thumbprint { get; set; }
+    String Uri { get; set; }
+  }
   class KubernetesTentacleEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.Endpoints.EndpointResource
   {
-    .ctor(Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource)
+    .ctor(Octopus.Client.Model.Endpoints.KubernetesTentacleEndpointConfigurationResource)
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
     String DefaultNamespace { get; set; }
-    Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource TentacleEndpointConfiguration { get; set; }
+    Octopus.Client.Model.Endpoints.KubernetesTentacleEndpointConfigurationResource TentacleEndpointConfiguration { get; set; }
   }
-  class ListeningTentacleEndpointConfigurationResource
+  class ListeningKubernetesTentacleEndpointConfigurationResource
     Octopus.Client.Model.Endpoints.ITentacleEndpointResource
     Octopus.Client.Model.Endpoints.IListeningTentacleEndpointResource
-    Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource
+    Octopus.Client.Model.Endpoints.KubernetesTentacleEndpointConfigurationResource
   {
     .ctor(String, String)
     Octopus.Client.Model.Endpoints.TentacleCommunicationModeResource CommunicationMode { get; }
@@ -6774,10 +6783,10 @@ Octopus.Client.Model.Endpoints
     String OctopusWorkingDirectory { get; set; }
     Octopus.Client.Model.SensitiveValue SensitiveVariablesEncryptionPassword { get; set; }
   }
-  class PollingTentacleEndpointConfigurationResource
+  class PollingKubernetesTentacleEndpointConfigurationResource
     Octopus.Client.Model.Endpoints.ITentacleEndpointResource
     Octopus.Client.Model.Endpoints.IPollingTentacleEndpointResource
-    Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource
+    Octopus.Client.Model.Endpoints.KubernetesTentacleEndpointConfigurationResource
   {
     .ctor(String, String)
     Octopus.Client.Model.Endpoints.TentacleCommunicationModeResource CommunicationMode { get; }
@@ -6859,15 +6868,6 @@ Octopus.Client.Model.Endpoints
     Boolean UpgradeRequired { get; set; }
     Boolean UpgradeSuggested { get; set; }
     String Version { get; set; }
-  }
-  abstract class TentacleEndpointConfigurationResource
-    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
-  {
-    String CertificateSignatureAlgorithm { get; set; }
-    Octopus.Client.Model.Endpoints.TentacleCommunicationModeResource CommunicationMode { get; }
-    Octopus.Client.Model.Endpoints.TentacleDetailsResource TentacleVersionDetails { get; set; }
-    String Thumbprint { get; set; }
-    String Uri { get; set; }
   }
   abstract class TentacleEndpointResource
     Octopus.Client.Extensibility.IResource
@@ -9314,7 +9314,7 @@ Octopus.Client.Serialization
     static String Serialize(Object)
   }
   class TentacleConfigurationConverter
-    Octopus.Client.Serialization.InheritedClassConverter<TentacleEndpointConfigurationResource, TentacleCommunicationModeResource>
+    Octopus.Client.Serialization.InheritedClassConverter<KubernetesTentacleEndpointConfigurationResource, TentacleCommunicationModeResource>
   {
     .ctor()
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6744,20 +6744,29 @@ Octopus.Client.Model.Endpoints
     String AccountId { get; set; }
     String AuthenticationType { get; }
   }
+  abstract class KubernetesTentacleEndpointConfigurationResource
+    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
+  {
+    String CertificateSignatureAlgorithm { get; set; }
+    Octopus.Client.Model.Endpoints.TentacleCommunicationModeResource CommunicationMode { get; }
+    Octopus.Client.Model.Endpoints.TentacleDetailsResource TentacleVersionDetails { get; set; }
+    String Thumbprint { get; set; }
+    String Uri { get; set; }
+  }
   class KubernetesTentacleEndpointResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.Endpoints.EndpointResource
   {
-    .ctor(Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource)
+    .ctor(Octopus.Client.Model.Endpoints.KubernetesTentacleEndpointConfigurationResource)
     Octopus.Client.Model.CommunicationStyle CommunicationStyle { get; }
     String DefaultNamespace { get; set; }
-    Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource TentacleEndpointConfiguration { get; set; }
+    Octopus.Client.Model.Endpoints.KubernetesTentacleEndpointConfigurationResource TentacleEndpointConfiguration { get; set; }
   }
-  class ListeningTentacleEndpointConfigurationResource
+  class ListeningKubernetesTentacleEndpointConfigurationResource
     Octopus.Client.Model.Endpoints.ITentacleEndpointResource
     Octopus.Client.Model.Endpoints.IListeningTentacleEndpointResource
-    Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource
+    Octopus.Client.Model.Endpoints.KubernetesTentacleEndpointConfigurationResource
   {
     .ctor(String, String)
     Octopus.Client.Model.Endpoints.TentacleCommunicationModeResource CommunicationMode { get; }
@@ -6798,10 +6807,10 @@ Octopus.Client.Model.Endpoints
     String OctopusWorkingDirectory { get; set; }
     Octopus.Client.Model.SensitiveValue SensitiveVariablesEncryptionPassword { get; set; }
   }
-  class PollingTentacleEndpointConfigurationResource
+  class PollingKubernetesTentacleEndpointConfigurationResource
     Octopus.Client.Model.Endpoints.ITentacleEndpointResource
     Octopus.Client.Model.Endpoints.IPollingTentacleEndpointResource
-    Octopus.Client.Model.Endpoints.TentacleEndpointConfigurationResource
+    Octopus.Client.Model.Endpoints.KubernetesTentacleEndpointConfigurationResource
   {
     .ctor(String, String)
     Octopus.Client.Model.Endpoints.TentacleCommunicationModeResource CommunicationMode { get; }
@@ -6883,15 +6892,6 @@ Octopus.Client.Model.Endpoints
     Boolean UpgradeRequired { get; set; }
     Boolean UpgradeSuggested { get; set; }
     String Version { get; set; }
-  }
-  abstract class TentacleEndpointConfigurationResource
-    Octopus.Client.Model.Endpoints.ITentacleEndpointResource
-  {
-    String CertificateSignatureAlgorithm { get; set; }
-    Octopus.Client.Model.Endpoints.TentacleCommunicationModeResource CommunicationMode { get; }
-    Octopus.Client.Model.Endpoints.TentacleDetailsResource TentacleVersionDetails { get; set; }
-    String Thumbprint { get; set; }
-    String Uri { get; set; }
   }
   abstract class TentacleEndpointResource
     Octopus.Client.Extensibility.IResource
@@ -9340,7 +9340,7 @@ Octopus.Client.Serialization
     static String Serialize(Object)
   }
   class TentacleConfigurationConverter
-    Octopus.Client.Serialization.InheritedClassConverter<TentacleEndpointConfigurationResource, TentacleCommunicationModeResource>
+    Octopus.Client.Serialization.InheritedClassConverter<KubernetesTentacleEndpointConfigurationResource, TentacleCommunicationModeResource>
   {
     .ctor()
   }

--- a/source/Octopus.Client.Tests/Serialization/TentacleConfigurationConverterFixture.cs
+++ b/source/Octopus.Client.Tests/Serialization/TentacleConfigurationConverterFixture.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
 using Octopus.Client.Serialization;
 
@@ -21,7 +20,7 @@ namespace Octopus.Client.Tests.Serialization
                 ProxyId = "The ProxyId"
             };
 
-            var result = Execute<ListeningTentacleEndpointConfigurationResource>(input);
+            var result = Execute<ListeningKubernetesTentacleEndpointConfigurationResource>(input);
 
             result.CommunicationMode.Should().Be(TentacleCommunicationModeResource.Listening);
             result.Uri.Should().Be(input.Uri);
@@ -39,7 +38,7 @@ namespace Octopus.Client.Tests.Serialization
                 Thumbprint = "The thumbprint",
             };
 
-            var result = Execute<PollingTentacleEndpointConfigurationResource>(input);
+            var result = Execute<PollingKubernetesTentacleEndpointConfigurationResource>(input);
 
             result.CommunicationMode.Should().Be(TentacleCommunicationModeResource.Polling);
             result.Uri.Should().Be(input.Uri);
@@ -52,7 +51,7 @@ namespace Octopus.Client.Tests.Serialization
             var json = JsonConvert.SerializeObject(input);
             
             var settings = JsonSerialization.GetDefaultSerializerSettings();
-            return JsonConvert.DeserializeObject<TentacleEndpointConfigurationResource>(json, settings)
+            return JsonConvert.DeserializeObject<KubernetesTentacleEndpointConfigurationResource>(json, settings)
                 .Should().BeOfType<T>().Subject;
         }
     }

--- a/source/Octopus.Server.Client/Model/Endpoints/KubernetesTentacleEndpointConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/KubernetesTentacleEndpointConfigurationResource.cs
@@ -3,13 +3,13 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public abstract class TentacleEndpointConfigurationResource : ITentacleEndpointResource
+    public abstract class KubernetesTentacleEndpointConfigurationResource : ITentacleEndpointResource
     {
-        protected TentacleEndpointConfigurationResource()
+        protected KubernetesTentacleEndpointConfigurationResource()
         {
         }
 
-        protected TentacleEndpointConfigurationResource(string thumbprint, string uri)
+        protected KubernetesTentacleEndpointConfigurationResource(string thumbprint, string uri)
         {
             Thumbprint = thumbprint;
             Uri = uri;

--- a/source/Octopus.Server.Client/Model/Endpoints/KubernetesTentacleEndpointResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/KubernetesTentacleEndpointResource.cs
@@ -8,12 +8,12 @@ public class KubernetesTentacleEndpointResource : EndpointResource
     {
     }
 
-    public KubernetesTentacleEndpointResource(TentacleEndpointConfigurationResource tentacleEndpointConfiguration)
+    public KubernetesTentacleEndpointResource(KubernetesTentacleEndpointConfigurationResource tentacleEndpointConfiguration)
     {
         TentacleEndpointConfiguration = tentacleEndpointConfiguration;
     }
 
-    public TentacleEndpointConfigurationResource TentacleEndpointConfiguration { get; set; }
+    public KubernetesTentacleEndpointConfigurationResource TentacleEndpointConfiguration { get; set; }
 
     public string DefaultNamespace { get; set; }
 }

--- a/source/Octopus.Server.Client/Model/Endpoints/ListeningTentacleEndpointConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/ListeningTentacleEndpointConfigurationResource.cs
@@ -2,13 +2,13 @@ using Octopus.Client.Extensibility.Attributes;
 
 namespace Octopus.Client.Model.Endpoints
 {
-    public class ListeningTentacleEndpointConfigurationResource : TentacleEndpointConfigurationResource, IListeningTentacleEndpointResource
+    public class ListeningKubernetesTentacleEndpointConfigurationResource : KubernetesTentacleEndpointConfigurationResource, IListeningTentacleEndpointResource
     {
-        protected ListeningTentacleEndpointConfigurationResource()
+        protected ListeningKubernetesTentacleEndpointConfigurationResource()
         {
         }
 
-        public ListeningTentacleEndpointConfigurationResource(string thumbprint, string uri) : base(thumbprint, uri)
+        public ListeningKubernetesTentacleEndpointConfigurationResource(string thumbprint, string uri) : base(thumbprint, uri)
         {
         }
 

--- a/source/Octopus.Server.Client/Model/Endpoints/PollingTentacleEndpointConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/Endpoints/PollingTentacleEndpointConfigurationResource.cs
@@ -1,14 +1,14 @@
 namespace Octopus.Client.Model.Endpoints
 {
-    public class PollingTentacleEndpointConfigurationResource : TentacleEndpointConfigurationResource, IPollingTentacleEndpointResource
+    public class PollingKubernetesTentacleEndpointConfigurationResource : KubernetesTentacleEndpointConfigurationResource, IPollingTentacleEndpointResource
     {
         public override TentacleCommunicationModeResource CommunicationMode => TentacleCommunicationModeResource.Polling;
 
-        protected PollingTentacleEndpointConfigurationResource()
+        protected PollingKubernetesTentacleEndpointConfigurationResource()
         {
         }
 
-        public PollingTentacleEndpointConfigurationResource(string thumbprint, string uri) : base(thumbprint, uri)
+        public PollingKubernetesTentacleEndpointConfigurationResource(string thumbprint, string uri) : base(thumbprint, uri)
         {
         }
     }

--- a/source/Octopus.Server.Client/Operations/RegisterKubernetesClusterOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterKubernetesClusterOperation.cs
@@ -26,9 +26,9 @@ public class RegisterKubernetesClusterOperation : RegisterMachineOperation, IReg
         var endpoint = CommunicationStyle switch
         {
             CommunicationStyle.TentaclePassive => new KubernetesTentacleEndpointResource(
-                new ListeningTentacleEndpointConfigurationResource(TentacleThumbprint, GetListeningUri()) { ProxyId = proxyId }),
+                new ListeningKubernetesTentacleEndpointConfigurationResource(TentacleThumbprint, GetListeningUri()) { ProxyId = proxyId }),
             CommunicationStyle.TentacleActive => new KubernetesTentacleEndpointResource(
-                new PollingTentacleEndpointConfigurationResource(TentacleThumbprint, SubscriptionId.ToString())),
+                new PollingKubernetesTentacleEndpointConfigurationResource(TentacleThumbprint, SubscriptionId.ToString())),
             _ => throw new ArgumentOutOfRangeException(nameof(CommunicationStyle), CommunicationStyle, $"Must be either {CommunicationStyle.TentacleActive} or {CommunicationStyle.TentaclePassive} for this operation")
         };
 

--- a/source/Octopus.Server.Client/Serialization/TentacleConfigurationConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/TentacleConfigurationConverter.cs
@@ -4,15 +4,15 @@ using Octopus.Client.Model.Endpoints;
 
 namespace Octopus.Client.Serialization;
 
-public class TentacleConfigurationConverter: InheritedClassConverter<TentacleEndpointConfigurationResource, TentacleCommunicationModeResource>
+public class TentacleConfigurationConverter: InheritedClassConverter<KubernetesTentacleEndpointConfigurationResource, TentacleCommunicationModeResource>
 {
     static readonly IDictionary<TentacleCommunicationModeResource, Type> EndpointTypes =
         new Dictionary<TentacleCommunicationModeResource, Type>
         {
-            {TentacleCommunicationModeResource.Listening, typeof (ListeningTentacleEndpointConfigurationResource)},
-            {TentacleCommunicationModeResource.Polling, typeof(PollingTentacleEndpointConfigurationResource)}
+            {TentacleCommunicationModeResource.Listening, typeof (ListeningKubernetesTentacleEndpointConfigurationResource)},
+            {TentacleCommunicationModeResource.Polling, typeof(PollingKubernetesTentacleEndpointConfigurationResource)}
         };
 
     protected override IDictionary<TentacleCommunicationModeResource, Type> DerivedTypeMappings => EndpointTypes;
-    protected override string TypeDesignatingPropertyName => nameof(TentacleEndpointConfigurationResource.CommunicationMode);
+    protected override string TypeDesignatingPropertyName => nameof(KubernetesTentacleEndpointConfigurationResource.CommunicationMode);
 }


### PR DESCRIPTION
*TentacleEndpointConfigurationResource -> *KubernetesTentacleEndpointConfigurationResource

I want to make it clear these classes are for KubernetesTentacles only. I'll make a similar change in server after this merges.