### PR TITLE
Change ProcessExternalFeedTriggers task name

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2221,6 +2221,10 @@ Octopus.Client.Model
     {
       static System.String Name
     }
+    abstract class ProcessExternalFeedTriggers
+    {
+      static System.String Name
+    }
     abstract class Retention
     {
       static System.String Name
@@ -4400,6 +4404,10 @@ Octopus.Client.Model
     Octopus.Client.Model.PhaseResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
   }
   abstract class PollFeedsForTriggers
+  {
+    static System.String Name
+  }
+  abstract class ProcessExternalFeedTriggers
   {
     static System.String Name
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2238,6 +2238,10 @@ Octopus.Client.Model
     {
       static System.String Name
     }
+    abstract class ProcessExternalFeedTriggers
+    {
+      static System.String Name
+    }
     abstract class Retention
     {
       static System.String Name
@@ -4420,6 +4424,10 @@ Octopus.Client.Model
     Octopus.Client.Model.PhaseResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
   }
   abstract class PollFeedsForTriggers
+  {
+    static System.String Name
+  }
+  abstract class ProcessExternalFeedTriggers
   {
     static System.String Name
   }

--- a/source/Octopus.Server.Client/Model/BuiltInTasks.cs
+++ b/source/Octopus.Server.Client/Model/BuiltInTasks.cs
@@ -6,7 +6,7 @@ namespace Octopus.Client.Model
     {
         public static string[] TasksThatCanBeQueuedByUsers()
         {
-            // Everything except "Deploy", "Delete" and "PollFeedsForTriggers"
+            // Everything except "Deploy", "Delete" and "ProcessExternalFeedTriggers"
             return new[]
             {
                 Backup.Name, Health.Name, Retention.Name, Upgrade.Name, TestEmail.Name, AdHocScript.Name, UpdateCalamari.Name, TestAzureAccount.Name, SystemIntegrityCheck.Name, SyncCommunityActionTemplates.Name,
@@ -192,9 +192,15 @@ namespace Octopus.Client.Model
             public const string Name = "SyncCommunityActionTemplates";
         }
         
+        // Replaced by ProcessExternalFeedTriggers, will be removed shortly
         public static class PollFeedsForTriggers
         {
             public const string Name = "PollFeedsForTriggers";
+        }
+        
+        public static class ProcessExternalFeedTriggers
+        {
+            public const string Name = "ProcessExternalFeedTriggers";
         }
     }
 }


### PR DESCRIPTION
We'd like to rename a task from `PollFeedsForTriggers` to `ProcessExternalFeedTriggers`. I'll do this in two parts in `OctopusClients` to avoid any chance of a breaking change.

[sc-76099]