### PR TITLE
Remove PollFeedsForTriggers task

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2217,10 +2217,6 @@ Octopus.Client.Model
     {
       static System.String Name
     }
-    abstract class PollFeedsForTriggers
-    {
-      static System.String Name
-    }
     abstract class ProcessExternalFeedTriggers
     {
       static System.String Name
@@ -4402,10 +4398,6 @@ Octopus.Client.Model
     Octopus.Client.Model.PhaseResource WithOptionalDeploymentTargets(Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Model.PhaseResource WithReleaseRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
     Octopus.Client.Model.PhaseResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
-  }
-  abstract class PollFeedsForTriggers
-  {
-    static System.String Name
   }
   abstract class ProcessExternalFeedTriggers
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2234,10 +2234,6 @@ Octopus.Client.Model
     {
       static System.String Name
     }
-    abstract class PollFeedsForTriggers
-    {
-      static System.String Name
-    }
     abstract class ProcessExternalFeedTriggers
     {
       static System.String Name
@@ -4422,10 +4418,6 @@ Octopus.Client.Model
     Octopus.Client.Model.PhaseResource WithOptionalDeploymentTargets(Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Model.PhaseResource WithReleaseRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
     Octopus.Client.Model.PhaseResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
-  }
-  abstract class PollFeedsForTriggers
-  {
-    static System.String Name
   }
   abstract class ProcessExternalFeedTriggers
   {

--- a/source/Octopus.Server.Client/Model/BuiltInTasks.cs
+++ b/source/Octopus.Server.Client/Model/BuiltInTasks.cs
@@ -192,12 +192,6 @@ namespace Octopus.Client.Model
             public const string Name = "SyncCommunityActionTemplates";
         }
         
-        // Replaced by ProcessExternalFeedTriggers, will be removed shortly
-        public static class PollFeedsForTriggers
-        {
-            public const string Name = "PollFeedsForTriggers";
-        }
-        
         public static class ProcessExternalFeedTriggers
         {
             public const string Name = "ProcessExternalFeedTriggers";


### PR DESCRIPTION
Follow up to #839

Removes the now-unused `PollFeedsForTriggers` task

[sc-76099]