### PR TITLE
Add ability to register machine to environments using slug or id

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",
@@ -15,7 +15,7 @@
         },
         "AzureKeyVaultAppSecret": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "AzureKeyVaultCertificateName": {
           "type": "string"
@@ -44,6 +44,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",
@@ -101,7 +102,6 @@
               "CopyToLocalPackages",
               "CopyUnsignedNugetToLocalPackages",
               "Default",
-              "LocalTest",
               "Merge",
               "PackSignedMergedClientNuget",
               "PackSignedNormalClientNuget",
@@ -124,7 +124,6 @@
               "CopyToLocalPackages",
               "CopyUnsignedNugetToLocalPackages",
               "Default",
-              "LocalTest",
               "Merge",
               "PackSignedMergedClientNuget",
               "PackSignedNormalClientNuget",

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3017,6 +3017,13 @@ Octopus.Client.Model
     Int32 SortOrder { get; set; }
     String SpaceId { get; set; }
     Boolean UseGuidedFailure { get; set; }
+    class IdComparer
+      IEqualityComparer<EnvironmentResource>
+    {
+      .ctor()
+      Boolean Equals(Octopus.Client.Model.EnvironmentResource, Octopus.Client.Model.EnvironmentResource)
+      Int32 GetHashCode(Octopus.Client.Model.EnvironmentResource)
+    }
   }
   class EnvironmentsSummaryResource
     Octopus.Client.Model.SummaryResourcesCombined
@@ -3372,6 +3379,13 @@ Octopus.Client.Model
     .ctor(String, String)
     String Color { get; set; }
     String Id { get; set; }
+  }
+  class IdComparer
+    IEqualityComparer<EnvironmentResource>
+  {
+    .ctor()
+    Boolean Equals(Octopus.Client.Model.EnvironmentResource, Octopus.Client.Model.EnvironmentResource)
+    Int32 GetHashCode(Octopus.Client.Model.EnvironmentResource)
   }
   class IdentityClaimResource
   {
@@ -7569,6 +7583,7 @@ Octopus.Client.Operations
     Octopus.Client.Operations.IRegisterMachineOperationBase
   {
     String[] EnvironmentNames { get; set; }
+    String[] Environments { get; set; }
     String[] Roles { get; set; }
     Octopus.Client.Model.TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
     String[] Tenants { get; set; }
@@ -7615,6 +7630,7 @@ Octopus.Client.Operations
     .ctor()
     .ctor(Octopus.Client.IOctopusClientFactory)
     String[] EnvironmentNames { get; set; }
+    String[] Environments { get; set; }
     String[] Roles { get; set; }
     Octopus.Client.Model.TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
     String[] Tenants { get; set; }
@@ -7871,8 +7887,9 @@ Octopus.Client.Repositories
     Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.DeploymentSettingsResource, String)
   }
   interface IEnvironmentRepository
-    Octopus.Client.Repositories.IFindByName<EnvironmentResource>
+    Octopus.Client.Repositories.IFindBySlug<EnvironmentResource>
     Octopus.Client.Repositories.IPaginate<EnvironmentResource>
+    Octopus.Client.Repositories.IFindByName<EnvironmentResource>
     Octopus.Client.Repositories.IGet<EnvironmentResource>
     Octopus.Client.Repositories.ICreate<EnvironmentResource>
     Octopus.Client.Repositories.IModify<EnvironmentResource>
@@ -7922,6 +7939,12 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<TResource>
   {
     List<TResource> FindByPartialName(String, String, Object)
+  }
+  interface IFindBySlug`1
+    Octopus.Client.Repositories.IPaginate<TResource>
+  {
+    Octopus.Client.Repositories.TResource FindBySlug(String, String, Object)
+    List<TResource> FindBySlugs(IEnumerable<String>, String, Object)
   }
   interface IGetAll`1
   {
@@ -8629,8 +8652,9 @@ Octopus.Client.Repositories.Async
     Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.DeploymentSettingsResource, String, CancellationToken)
   }
   interface IEnvironmentRepository
-    Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>
+    Octopus.Client.Repositories.Async.IFindBySlug<EnvironmentResource>
     Octopus.Client.Repositories.Async.IPaginate<EnvironmentResource>
+    Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>
     Octopus.Client.Repositories.Async.IGet<EnvironmentResource>
     Octopus.Client.Repositories.Async.ICreate<EnvironmentResource>
     Octopus.Client.Repositories.Async.IModify<EnvironmentResource>
@@ -8686,6 +8710,14 @@ Octopus.Client.Repositories.Async
   {
     Task<List<TResource>> FindByPartialName(String, CancellationToken)
     Task<List<TResource>> FindByPartialName(String, String, Object, CancellationToken)
+  }
+  interface IFindBySlug`1
+    Octopus.Client.Repositories.Async.IPaginate<TResource>
+  {
+    Task<TResource> FindBySlug(String, CancellationToken)
+    Task<TResource> FindBySlug(String, String, Object, CancellationToken)
+    Task<List<TResource>> FindBySlugs(IEnumerable<String>, CancellationToken)
+    Task<List<TResource>> FindBySlugs(IEnumerable<String>, String, Object, CancellationToken)
   }
   interface IGetAll`1
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3034,6 +3034,13 @@ Octopus.Client.Model
     Int32 SortOrder { get; set; }
     String SpaceId { get; set; }
     Boolean UseGuidedFailure { get; set; }
+    class IdComparer
+      IEqualityComparer<EnvironmentResource>
+    {
+      .ctor()
+      Boolean Equals(Octopus.Client.Model.EnvironmentResource, Octopus.Client.Model.EnvironmentResource)
+      Int32 GetHashCode(Octopus.Client.Model.EnvironmentResource)
+    }
   }
   class EnvironmentsSummaryResource
     Octopus.Client.Model.SummaryResourcesCombined
@@ -3389,6 +3396,13 @@ Octopus.Client.Model
     .ctor(String, String)
     String Color { get; set; }
     String Id { get; set; }
+  }
+  class IdComparer
+    IEqualityComparer<EnvironmentResource>
+  {
+    .ctor()
+    Boolean Equals(Octopus.Client.Model.EnvironmentResource, Octopus.Client.Model.EnvironmentResource)
+    Int32 GetHashCode(Octopus.Client.Model.EnvironmentResource)
   }
   class IdentityClaimResource
   {
@@ -7594,6 +7608,7 @@ Octopus.Client.Operations
     Octopus.Client.Operations.IRegisterMachineOperationBase
   {
     String[] EnvironmentNames { get; set; }
+    String[] Environments { get; set; }
     String[] Roles { get; set; }
     Octopus.Client.Model.TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
     String[] Tenants { get; set; }
@@ -7640,6 +7655,7 @@ Octopus.Client.Operations
     .ctor()
     .ctor(Octopus.Client.IOctopusClientFactory)
     String[] EnvironmentNames { get; set; }
+    String[] Environments { get; set; }
     String[] Roles { get; set; }
     Octopus.Client.Model.TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
     String[] Tenants { get; set; }
@@ -7896,8 +7912,9 @@ Octopus.Client.Repositories
     Octopus.Client.Model.DeploymentSettingsResource Modify(Octopus.Client.Model.DeploymentSettingsResource, String)
   }
   interface IEnvironmentRepository
-    Octopus.Client.Repositories.IFindByName<EnvironmentResource>
+    Octopus.Client.Repositories.IFindBySlug<EnvironmentResource>
     Octopus.Client.Repositories.IPaginate<EnvironmentResource>
+    Octopus.Client.Repositories.IFindByName<EnvironmentResource>
     Octopus.Client.Repositories.IGet<EnvironmentResource>
     Octopus.Client.Repositories.ICreate<EnvironmentResource>
     Octopus.Client.Repositories.IModify<EnvironmentResource>
@@ -7947,6 +7964,12 @@ Octopus.Client.Repositories
     Octopus.Client.Repositories.IPaginate<TResource>
   {
     List<TResource> FindByPartialName(String, String, Object)
+  }
+  interface IFindBySlug`1
+    Octopus.Client.Repositories.IPaginate<TResource>
+  {
+    Octopus.Client.Repositories.TResource FindBySlug(String, String, Object)
+    List<TResource> FindBySlugs(IEnumerable<String>, String, Object)
   }
   interface IGetAll`1
   {
@@ -8654,8 +8677,9 @@ Octopus.Client.Repositories.Async
     Task<DeploymentSettingsResource> Modify(Octopus.Client.Model.DeploymentSettingsResource, String, CancellationToken)
   }
   interface IEnvironmentRepository
-    Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>
+    Octopus.Client.Repositories.Async.IFindBySlug<EnvironmentResource>
     Octopus.Client.Repositories.Async.IPaginate<EnvironmentResource>
+    Octopus.Client.Repositories.Async.IFindByName<EnvironmentResource>
     Octopus.Client.Repositories.Async.IGet<EnvironmentResource>
     Octopus.Client.Repositories.Async.ICreate<EnvironmentResource>
     Octopus.Client.Repositories.Async.IModify<EnvironmentResource>
@@ -8711,6 +8735,14 @@ Octopus.Client.Repositories.Async
   {
     Task<List<TResource>> FindByPartialName(String, CancellationToken)
     Task<List<TResource>> FindByPartialName(String, String, Object, CancellationToken)
+  }
+  interface IFindBySlug`1
+    Octopus.Client.Repositories.Async.IPaginate<TResource>
+  {
+    Task<TResource> FindBySlug(String, CancellationToken)
+    Task<TResource> FindBySlug(String, String, Object, CancellationToken)
+    Task<List<TResource>> FindBySlugs(IEnumerable<String>, CancellationToken)
+    Task<List<TResource>> FindBySlugs(IEnumerable<String>, String, Object, CancellationToken)
   }
   interface IGetAll`1
   {

--- a/source/Octopus.Server.Client/Model/EnvironmentResource.cs
+++ b/source/Octopus.Server.Client/Model/EnvironmentResource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Extensibility.Attributes;
 
@@ -48,5 +49,22 @@ namespace Octopus.Client.Model
         public string SpaceId { get; set; }
         
         public string Slug { get; set; }
+
+        public class IdComparer : IEqualityComparer<EnvironmentResource>
+        {
+            public bool Equals(EnvironmentResource x, EnvironmentResource y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (ReferenceEquals(x, null)) return false;
+                if (ReferenceEquals(y, null)) return false;
+                if (x.GetType() != y.GetType()) return false;
+                return x.Id == y.Id;
+            }
+
+            public int GetHashCode(EnvironmentResource obj)
+            {
+                return (obj.Id != null ? obj.Id.GetHashCode() : 0);
+            }
+        }
     }
 }

--- a/source/Octopus.Server.Client/Operations/IRegisterMachineOperation.cs
+++ b/source/Octopus.Server.Client/Operations/IRegisterMachineOperation.cs
@@ -13,6 +13,11 @@ namespace Octopus.Client.Operations
         /// Gets or sets the environments that this machine should be added to.
         /// </summary>
         string[] EnvironmentNames { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the environments that this machine should be added to.
+        /// </summary>
+        string[] Environments { get; set; }
 
         /// <summary>
         /// Gets or sets the roles that this machine belongs to.

--- a/source/Octopus.Server.Client/Operations/IRegisterMachineOperation.cs
+++ b/source/Octopus.Server.Client/Operations/IRegisterMachineOperation.cs
@@ -13,12 +13,12 @@ namespace Octopus.Client.Operations
         /// Gets or sets the environments that this machine should be added to. These are environment names only.
         /// </summary>
         [Obsolete($"Use the {nameof(Environments)} property as it supports environment names, slugs and Ids.")]
-        public string[] EnvironmentNames { get; set; }
+        string[] EnvironmentNames { get; set; }
 
         /// <summary>
         /// Gets or sets the environments that this machine should be added to. These can be environment names, slugs or Ids
         /// </summary>
-        public string[] Environments { get; set; }
+        string[] Environments { get; set; }
 
         /// <summary>
         /// Gets or sets the roles that this machine belongs to.

--- a/source/Octopus.Server.Client/Operations/IRegisterMachineOperation.cs
+++ b/source/Octopus.Server.Client/Operations/IRegisterMachineOperation.cs
@@ -10,14 +10,15 @@ namespace Octopus.Client.Operations
     public interface IRegisterMachineOperation : IRegisterMachineOperationBase
     {
         /// <summary>
-        /// Gets or sets the environments that this machine should be added to.
+        /// Gets or sets the environments that this machine should be added to. These are environment names only.
         /// </summary>
-        string[] EnvironmentNames { get; set; }
-        
+        [Obsolete($"Use the {nameof(Environments)} property as it supports environment names, slugs and Ids.")]
+        public string[] EnvironmentNames { get; set; }
+
         /// <summary>
-        /// Gets or sets the environments that this machine should be added to.
+        /// Gets or sets the environments that this machine should be added to. These can be environment names, slugs or Ids
         /// </summary>
-        string[] Environments { get; set; }
+        public string[] Environments { get; set; }
 
         /// <summary>
         /// Gets or sets the roles that this machine belongs to.
@@ -39,6 +40,5 @@ namespace Octopus.Client.Operations
         /// Allowed values are Untenanted, TenantedOrUntenanted or Tenanted
         /// </summary>
         TenantedDeploymentMode TenantedDeploymentParticipation { get; set; }
-
     }
 }

--- a/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
@@ -29,13 +29,13 @@ namespace Octopus.Client.Operations
         }
 
         /// <summary>
-        /// Gets or sets the environments that this machine should be added to.
+        /// Gets or sets the environments that this machine should be added to. These are environment names only.
         /// </summary>
-        [Obsolete($"Use the {nameof(Environments)} property")]
+        [Obsolete($"Use the {nameof(Environments)} property as it supports environment names, slugs and Ids.")]
         public string[] EnvironmentNames { get; set; }
 
         /// <summary>
-        /// Gets or sets the environments that this machine should be added to. These can be Environment names, slugs or Ids
+        /// Gets or sets the environments that this machine should be added to. These can be environment names, slugs or Ids
         /// </summary>
         public string[] Environments { get; set; }
 

--- a/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
@@ -25,13 +26,18 @@ namespace Octopus.Client.Operations
         /// <param name="clientFactory">The client factory.</param>
         public RegisterMachineOperation(IOctopusClientFactory clientFactory) : base(clientFactory)
         {
-
         }
 
         /// <summary>
         /// Gets or sets the environments that this machine should be added to.
         /// </summary>
+        [Obsolete($"Use the {nameof(Environments)} property")]
         public string[] EnvironmentNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets the environments that this machine should be added to. These can be Environment names, slugs or Ids
+        /// </summary>
+        public string[] Environments { get; set; }
 
         /// <summary>
         /// Gets or sets the roles that this machine belongs to.
@@ -100,15 +106,15 @@ namespace Octopus.Client.Operations
             {
                 return new List<TenantResource>();
             }
+
             var tenantsByName = repository.Tenants.FindByNames(Tenants);
             var missing = Tenants.Except(tenantsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToArray();
-
 
             var tenantsById = repository.Tenants.Get(missing);
             missing = missing.Except(tenantsById.Select(e => e.Id), StringComparer.OrdinalIgnoreCase).ToArray();
 
             if (missing.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("tenant", missing));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tenant", missing));
 
             return tenantsById.Concat(tenantsByName).ToList();
         }
@@ -119,22 +125,62 @@ namespace Octopus.Client.Operations
                 return;
 
             var tagSets = repository.TagSets.FindAll();
-            var missingTags = TenantTags.Where(tt => !tagSets.Any(ts => ts.Tags.Any(t => t.CanonicalTagName.Equals(tt, StringComparison.OrdinalIgnoreCase)))).ToList();
+            var missingTags = TenantTags.Where(tt =>
+                    !tagSets.Any(ts =>
+                        ts.Tags.Any(t => t.CanonicalTagName.Equals(tt, StringComparison.OrdinalIgnoreCase))))
+                .ToList();
 
             if (missingTags.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("tag", missingTags.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tag",
+                    missingTags.ToArray()));
         }
 
         List<EnvironmentResource> GetEnvironments(IOctopusSpaceRepository repository)
         {
-            var selectedEnvironments = repository.Environments.FindByNames(EnvironmentNames);
+            List<EnvironmentResource> environments = new();
+            if (EnvironmentNames is not null && EnvironmentNames.Any())
+            {
+                var envsByName = repository.Environments.FindByNames(EnvironmentNames);
+                environments.AddRange(envsByName);
 
-            var missing = EnvironmentNames.Except(selectedEnvironments.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToList();
+                //if there are any missing environment names only, then we want to throw an exception and not check the missing names against slugs or ids
+                var missingByNameOnly = EnvironmentNames
+                    .Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToArray();
 
-            if (missing.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("environment", missing.ToArray()));
+                if (missingByNameOnly.Any())
+                    throw new InvalidRegistrationArgumentsException(
+                        CouldNotFindByNameMessage("environment", missingByNameOnly.ToArray()));
+            }
 
-            return selectedEnvironments;
+            if (Environments is not null && Environments.Any())
+            {
+                var envsByName = repository.Environments.FindByNames(EnvironmentNames);
+                environments.AddRange(envsByName);
+
+                //if there are any missing environment names only, then we want to throw an exception and not check the missing names against slugs or ids
+                var missing = Environments.Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                //use the missing names to try and find by slug
+                var environmentsBySlug = repository.Environments.FindBySlugs(missing);
+                environments.AddRange(environmentsBySlug);
+
+                missing = missing.Except(environmentsBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                //any other missing slugs/names could be Id's, so looks again
+                var environmentByIds = repository.Environments.Get(missing);
+                environments.AddRange(environmentByIds);
+
+                missing = missing.Except(environmentByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                if (missing.Any())
+                    throw new InvalidRegistrationArgumentsException(
+                        CouldNotFindByMultipleMessage("environment", missing.ToArray()));
+            }
+
+            return environments.Distinct(new EnvironmentResource.IdComparer()).ToList();
         }
 
         MachineResource GetMachine(IOctopusSpaceRepository repository)
@@ -144,7 +190,8 @@ namespace Octopus.Client.Operations
             {
                 existing = repository.Machines.FindByName(MachineName);
             }
-            catch (OctopusDeserializationException) // eat it, probably caused by resource incompatibility between versions
+            catch
+                (OctopusDeserializationException) // eat it, probably caused by resource incompatibility between versions
             {
             }
 
@@ -214,7 +261,7 @@ namespace Octopus.Client.Operations
             missing = missing.Except(tenantsById.Select(e => e.Id), StringComparer.OrdinalIgnoreCase).ToArray();
 
             if (missing.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("tenant", missing));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tenant", missing));
 
             return tenantsById.Concat(tenantsByName).ToList();
         }
@@ -225,28 +272,63 @@ namespace Octopus.Client.Operations
                 return;
 
             var tagSets = await repository.TagSets.FindAll().ConfigureAwait(false);
-            var missingTags = TenantTags.Where(tt => !tagSets.Any(ts => ts.Tags.Any(t => t.CanonicalTagName.Equals(tt, StringComparison.OrdinalIgnoreCase)))).ToList();
+            var missingTags = TenantTags.Where(tt =>
+                    !tagSets.Any(ts =>
+                        ts.Tags.Any(t => t.CanonicalTagName.Equals(tt, StringComparison.OrdinalIgnoreCase))))
+                .ToList();
 
             if (missingTags.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("tag", missingTags.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tag",
+                    missingTags.ToArray()));
         }
 
         async Task<List<EnvironmentResource>> GetEnvironments(IOctopusSpaceAsyncRepository repository)
         {
-            var selectedEnvironments = new List<EnvironmentResource>();
-            foreach (var environmentName in EnvironmentNames)
+            List<EnvironmentResource> environments = new();
+            if (EnvironmentNames is not null && EnvironmentNames.Any())
             {
-                var environment = await repository.Environments.FindByName(environmentName).ConfigureAwait(false);
-                if (environment != null)
-                    selectedEnvironments.Add(environment);
+                var envsByName = await repository.Environments.FindByNames(EnvironmentNames).ConfigureAwait(false);
+                environments.AddRange(envsByName);
+
+                //if there are any missing environment names only, then we want to throw an exception and not check the missing names against slugs or ids
+                var missingByNameOnly = EnvironmentNames
+                    .Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToArray();
+
+                if (missingByNameOnly.Any())
+                    throw new InvalidRegistrationArgumentsException(
+                        CouldNotFindByNameMessage("environment", missingByNameOnly.ToArray()));
             }
 
-            var missing = EnvironmentNames.Except(selectedEnvironments.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToList();
+            if (Environments is not null && Environments.Any())
+            {
+                var envsByName = await repository.Environments.FindByNames(Environments).ConfigureAwait(false);
+                environments.AddRange(envsByName);
 
-            if (missing.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("environment", missing.ToArray()));
+                //if there are any missing environment names only, then we want to throw an exception and not check the missing names against slugs or ids
+                var missing = Environments.Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
 
-            return selectedEnvironments;
+                //use the missing names to try and find by slug
+                var environmentsBySlug = await repository.Environments.FindBySlugs(missing, CancellationToken.None)
+                    .ConfigureAwait(false);
+                environments.AddRange(environmentsBySlug);
+
+                missing = missing.Except(environmentsBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                //any other missing slugs/names could be Id's, so looks again
+                var environmentByIds = await repository.Environments.Get(missing).ConfigureAwait(false);
+                environments.AddRange(environmentByIds);
+
+                missing = missing.Except(environmentByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                if (missing.Any())
+                    throw new InvalidRegistrationArgumentsException(
+                        CouldNotFindByMultipleMessage("environment", missing.ToArray()));
+            }
+
+            return environments.Distinct(new EnvironmentResource.IdComparer()).ToList();
         }
 
         async Task<MachineResource> GetMachine(IOctopusSpaceAsyncRepository repository)
@@ -256,13 +338,16 @@ namespace Octopus.Client.Operations
             {
                 existing = await repository.Machines.FindByName(MachineName).ConfigureAwait(false);
             }
-            catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
+            catch
+                (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
             {
             }
+
             return existing ?? new MachineResource();
         }
 
-        void ApplyDeploymentTargetChanges(MachineResource machine, IEnumerable<EnvironmentResource> environment, IEnumerable<TenantResource> tenants)
+        void ApplyDeploymentTargetChanges(MachineResource machine, IEnumerable<EnvironmentResource> environment,
+            IEnumerable<TenantResource> tenants)
         {
             machine.EnvironmentIds = new ReferenceCollection(environment.Select(e => e.Id).ToArray());
             machine.TenantIds = new ReferenceCollection(tenants.Select(t => t.Id).ToArray());

--- a/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
@@ -131,8 +131,7 @@ namespace Octopus.Client.Operations
                 .ToList();
 
             if (missingTags.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tag",
-                    missingTags.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tag", missingTags.ToArray()));
         }
 
         List<EnvironmentResource> GetEnvironments(IOctopusSpaceRepository repository)
@@ -145,11 +144,11 @@ namespace Octopus.Client.Operations
 
                 //if there are any missing environment names only, then we want to throw an exception and not check the missing names against slugs or ids
                 var missingByNameOnly = EnvironmentNames
-                    .Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToArray();
+                    .Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
 
                 if (missingByNameOnly.Any())
-                    throw new InvalidRegistrationArgumentsException(
-                        CouldNotFindByNameMessage("environment", missingByNameOnly.ToArray()));
+                    throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("environment", missingByNameOnly.ToArray()));
             }
 
             if (Environments is not null && Environments.Any())
@@ -157,27 +156,28 @@ namespace Octopus.Client.Operations
                 var envsByName = repository.Environments.FindByNames(EnvironmentNames);
                 environments.AddRange(envsByName);
 
-                //if there are any missing environment names only, then we want to throw an exception and not check the missing names against slugs or ids
-                var missing = Environments.Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
+                var missing = Environments
+                    .Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
                     .ToArray();
 
                 //use the missing names to try and find by slug
                 var environmentsBySlug = repository.Environments.FindBySlugs(missing);
                 environments.AddRange(environmentsBySlug);
 
-                missing = missing.Except(environmentsBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
+                missing = missing
+                    .Except(environmentsBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
                     .ToArray();
 
                 //any other missing slugs/names could be Id's, so looks again
                 var environmentByIds = repository.Environments.Get(missing);
                 environments.AddRange(environmentByIds);
 
-                missing = missing.Except(environmentByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
+                missing = missing
+                    .Except(environmentByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
                     .ToArray();
 
                 if (missing.Any())
-                    throw new InvalidRegistrationArgumentsException(
-                        CouldNotFindByMultipleMessage("environment", missing.ToArray()));
+                    throw new InvalidRegistrationArgumentsException(CouldNotFindByMultipleMessage("environment", missing.ToArray()));
             }
 
             return environments.Distinct(new EnvironmentResource.IdComparer()).ToList();
@@ -190,9 +190,9 @@ namespace Octopus.Client.Operations
             {
                 existing = repository.Machines.FindByName(MachineName);
             }
-            catch
-                (OctopusDeserializationException) // eat it, probably caused by resource incompatibility between versions
+            catch (OctopusDeserializationException)
             {
+                // probably caused by resource incompatibility between versions
             }
 
             return existing ?? new MachineResource();
@@ -278,8 +278,7 @@ namespace Octopus.Client.Operations
                 .ToList();
 
             if (missingTags.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tag",
-                    missingTags.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tag", missingTags.ToArray()));
         }
 
         async Task<List<EnvironmentResource>> GetEnvironments(IOctopusSpaceAsyncRepository repository)
@@ -292,11 +291,11 @@ namespace Octopus.Client.Operations
 
                 //if there are any missing environment names only, then we want to throw an exception and not check the missing names against slugs or ids
                 var missingByNameOnly = EnvironmentNames
-                    .Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToArray();
+                    .Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
 
                 if (missingByNameOnly.Any())
-                    throw new InvalidRegistrationArgumentsException(
-                        CouldNotFindByNameMessage("environment", missingByNameOnly.ToArray()));
+                    throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("environment", missingByNameOnly.ToArray()));
             }
 
             if (Environments is not null && Environments.Any())
@@ -304,8 +303,8 @@ namespace Octopus.Client.Operations
                 var envsByName = await repository.Environments.FindByNames(Environments).ConfigureAwait(false);
                 environments.AddRange(envsByName);
 
-                //if there are any missing environment names only, then we want to throw an exception and not check the missing names against slugs or ids
-                var missing = Environments.Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
+                var missing = Environments
+                    .Except(envsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
                     .ToArray();
 
                 //use the missing names to try and find by slug
@@ -313,19 +312,20 @@ namespace Octopus.Client.Operations
                     .ConfigureAwait(false);
                 environments.AddRange(environmentsBySlug);
 
-                missing = missing.Except(environmentsBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
+                missing = missing
+                    .Except(environmentsBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
                     .ToArray();
 
                 //any other missing slugs/names could be Id's, so looks again
                 var environmentByIds = await repository.Environments.Get(missing).ConfigureAwait(false);
                 environments.AddRange(environmentByIds);
 
-                missing = missing.Except(environmentByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
+                missing = missing
+                    .Except(environmentByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
                     .ToArray();
 
                 if (missing.Any())
-                    throw new InvalidRegistrationArgumentsException(
-                        CouldNotFindByMultipleMessage("environment", missing.ToArray()));
+                    throw new InvalidRegistrationArgumentsException(CouldNotFindByMultipleMessage("environment", missing.ToArray()));
             }
 
             return environments.Distinct(new EnvironmentResource.IdComparer()).ToList();
@@ -338,9 +338,9 @@ namespace Octopus.Client.Operations
             {
                 existing = await repository.Machines.FindByName(MachineName).ConfigureAwait(false);
             }
-            catch
-                (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
+            catch (OctopusDeserializationException)
             {
+                // probably caused by resource incompatability between versions
             }
 
             return existing ?? new MachineResource();

--- a/source/Octopus.Server.Client/Operations/RegisterMachineOperationBase.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterMachineOperationBase.cs
@@ -113,7 +113,7 @@ namespace Octopus.Client.Operations
             {
                 machinePolicy = repository.MachinePolicies.FindByName(MachinePolicy);
                 if (machinePolicy == null)
-                    throw new ArgumentException(CouldNotFindMessage("machine policy", MachinePolicy));
+                    throw new ArgumentException(CouldNotFindByNameMessage("machine policy", MachinePolicy));
             }
             return machinePolicy;
         }
@@ -125,7 +125,7 @@ namespace Octopus.Client.Operations
             {
                 proxy = repository.Proxies.FindByName(ProxyName);
                 if (proxy == null)
-                    throw new ArgumentException(CouldNotFindMessage("proxy name", ProxyName));
+                    throw new ArgumentException(CouldNotFindByNameMessage("proxy name", ProxyName));
             }
             return proxy;
         }
@@ -173,7 +173,7 @@ namespace Octopus.Client.Operations
             {
                 machinePolicy = await repository.MachinePolicies.FindByName(MachinePolicy).ConfigureAwait(false);
                 if (machinePolicy == null)
-                    throw new ArgumentException(CouldNotFindMessage("machine policy", MachinePolicy));
+                    throw new ArgumentException(CouldNotFindByNameMessage("machine policy", MachinePolicy));
             }
             return machinePolicy;
         }
@@ -185,7 +185,7 @@ namespace Octopus.Client.Operations
             {
                 proxy = await repository.Proxies.FindByName(ProxyName).ConfigureAwait(false);
                 if (proxy == null)
-                    throw new ArgumentException(CouldNotFindMessage("proxy name", ProxyName));
+                    throw new ArgumentException(CouldNotFindByNameMessage("proxy name", ProxyName));
             }
             return proxy;
         }
@@ -226,11 +226,18 @@ namespace Octopus.Client.Operations
             return new Uri($"https://{TentacleHostname.ToLowerInvariant()}:{TentaclePort.ToString(CultureInfo.InvariantCulture)}/").ToString();
         }
 
-        protected static string CouldNotFindMessage(string modelType, params string[] missing)
+        protected static string CouldNotFindByNameMessage(string modelType, params string[] missing)
         {
             return missing.Length == 1
                 ? $"Could not find the {modelType} named {missing.Single()} on the Octopus Server. Ensure the {modelType} exists and you have permission to access it."
                 : $"Could not find the {modelType}s named: {string.Join(", ", missing)} on the Octopus Server. Ensure the {modelType}s exist and you have permission to access them.";
+        }
+        
+        protected static string CouldNotFindByMultipleMessage(string modelType, params string[] missing)
+        {
+            return missing.Length == 1
+                ? $"Could not find the {modelType} with name, slug or Id {missing.Single()} on the Octopus Server. Ensure the {modelType} exists and you have permission to access it."
+                : $"Could not find the {modelType}s with names, slugs or Ids: {string.Join(", ", missing)} on the Octopus Server. Ensure the {modelType}s exist and you have permission to access them.";
         }
     }
 }

--- a/source/Octopus.Server.Client/Operations/RegisterWorkerOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterWorkerOperation.cs
@@ -65,7 +65,7 @@ namespace Octopus.Client.Operations
             var missing = WorkerPoolNames.Except(selectedPools.Select(p => p.Name), StringComparer.OrdinalIgnoreCase).ToList();
 
             if (missing.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("worker pool", missing.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("worker pool", missing.ToArray()));
 
             return selectedPools;
         }
@@ -116,7 +116,7 @@ namespace Octopus.Client.Operations
             var missing = WorkerPoolNames.Except(selectedPools.Select(p => p.Name), StringComparer.OrdinalIgnoreCase).ToList();
 
             if (missing.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindMessage("worker pool", missing.ToArray()));
+                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("worker pool", missing.ToArray()));
 
             return selectedPools;
         }

--- a/source/Octopus.Server.Client/Repositories/Async/EnvironmentRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/EnvironmentRepository.cs
@@ -6,7 +6,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
-    public interface IEnvironmentRepository : IFindByName<EnvironmentResource>, IGet<EnvironmentResource>, ICreate<EnvironmentResource>, IModify<EnvironmentResource>, IDelete<EnvironmentResource>, IGetAll<EnvironmentResource>
+    public interface IEnvironmentRepository : IFindBySlug<EnvironmentResource>, IFindByName<EnvironmentResource>, IGet<EnvironmentResource>, ICreate<EnvironmentResource>, IModify<EnvironmentResource>, IDelete<EnvironmentResource>, IGetAll<EnvironmentResource>
     {
         Task<List<MachineResource>> GetMachines(EnvironmentResource environment,
             int? skip = 0,

--- a/source/Octopus.Server.Client/Repositories/Async/IFindBySlug.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/IFindBySlug.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Repositories.Async
+{
+    public interface IFindBySlug<TResource> : IPaginate<TResource> where TResource: IHaveSlugResource
+    {
+        Task<TResource> FindBySlug(string slug, CancellationToken cancellationToken);
+        Task<TResource> FindBySlug(string slug, string path, object pathParameters, CancellationToken cancellationToken);
+        
+        Task<List<TResource>> FindBySlugs(IEnumerable<string> slugs, CancellationToken cancellationToken);
+        Task<List<TResource>> FindBySlugs(IEnumerable<string> slugs, string path, object pathParameters, CancellationToken cancellationToken);
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/BasicRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/BasicRepository.cs
@@ -222,6 +222,36 @@ namespace Octopus.Client.Repositories
                 return false;
             }, path, pathParameters);
         }
+        
+        public TResource FindBySlug(string slug, string path = null, object pathParameters = null)
+        {
+            ThrowIfServerVersionIsNotCompatible();
+
+            slug = (slug ?? string.Empty).Trim();
+            // Some endpoints allow a Slug query param which greatly increases efficiency
+            if (pathParameters == null)
+                pathParameters = new {slug = slug};
+
+            return FindOne(r =>
+            {
+                var slugd = r as IHaveSlugResource;
+                if (slugd != null) return string.Equals((slugd.Slug ?? string.Empty).Trim(), slug, StringComparison.OrdinalIgnoreCase);
+                return false;
+            }, path, pathParameters);
+        }
+
+        public List<TResource> FindBySlugs(IEnumerable<string> slugs, string path = null, object pathParameters = null)
+        {
+            ThrowIfServerVersionIsNotCompatible();
+
+            var slugSet = new HashSet<string>((slugs ?? new string[0]).Select(n => (n ?? string.Empty).Trim()), StringComparer.OrdinalIgnoreCase);
+            return FindMany(r =>
+            {
+                var slugd = r as IHaveSlugResource;
+                if (slugd != null) return slugSet.Contains((slugd.Slug ?? string.Empty).Trim());
+                return false;
+            }, path, pathParameters);
+        }
 
         public TResource Get(string idOrHref)
         {

--- a/source/Octopus.Server.Client/Repositories/EnvironmentRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/EnvironmentRepository.cs
@@ -4,7 +4,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
 {
-    public interface IEnvironmentRepository : IFindByName<EnvironmentResource>, IGet<EnvironmentResource>, ICreate<EnvironmentResource>, IModify<EnvironmentResource>, IDelete<EnvironmentResource>, IGetAll<EnvironmentResource>
+    public interface IEnvironmentRepository : IFindBySlug<EnvironmentResource>, IFindByName<EnvironmentResource>, IGet<EnvironmentResource>, ICreate<EnvironmentResource>, IModify<EnvironmentResource>, IDelete<EnvironmentResource>, IGetAll<EnvironmentResource>
     {
         List<MachineResource> GetMachines(EnvironmentResource environment,
             int? skip = 0,

--- a/source/Octopus.Server.Client/Repositories/IFindBySlug.cs
+++ b/source/Octopus.Server.Client/Repositories/IFindBySlug.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Octopus.Client.Model;
+
+namespace Octopus.Client.Repositories
+{
+    public interface IFindBySlug<TResource> : IPaginate<TResource> where TResource: IHaveSlugResource
+    {
+        TResource FindBySlug(string slug, string path = null, object pathParameters = null);
+        List<TResource> FindBySlugs(IEnumerable<string> slugs, string path = null, object pathParameters = null);
+    }
+}


### PR DESCRIPTION
When registering a deployment target/machine, we currently require the environment names specified. This means that you can't supply an environment slug or id and have it correctly register.

To resolve this, I have added a new `Environments` property to `IRegisterMachineOperation` which can take either an environment name, slug or id and will search all options.

`EnvironmentNames` has been marked as obsolete.

We have kept the same logic around detecting missing `EnvironmentNames`. If there is an `EnvironmentNames` value that can't be found by name, we do not try and resolve that name to a slug or id, but throw an exception. We only check the slug and/or id for the new property

Shortcut story: [sc-77588]
Related to: https://github.com/OctopusDeploy/Issues/issues/8760