### PR TITLE
Add GenerateAccessToken into UserRepository

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3205,6 +3205,11 @@ Octopus.Client.Model
     Stream Contents { get; set; }
     String FileName { get; set; }
   }
+  class GeneratedAccessTokenResource
+  {
+    .ctor()
+    String AccessToken { get; set; }
+  }
   class GitBranchResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -9209,6 +9214,7 @@ Octopus.Client.Repositories.Async
     Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
+    Task<GeneratedAccessTokenResource> GenerateAccessToken(Octopus.Client.Model.UserResource, CancellationToken)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
     Task<UserResource> GetCurrent()
     Task<SpaceResource[]> GetSpaces(Octopus.Client.Model.UserResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3222,6 +3222,11 @@ Octopus.Client.Model
     Stream Contents { get; set; }
     String FileName { get; set; }
   }
+  class GeneratedAccessTokenResource
+  {
+    .ctor()
+    String AccessToken { get; set; }
+  }
   class GitBranchResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -9234,6 +9239,7 @@ Octopus.Client.Repositories.Async
     Task<ApiKeyCreatedResource> CreateApiKey(Octopus.Client.Model.UserResource, String, Nullable<DateTimeOffset>)
     Task<UserResource> CreateServiceAccount(String, String)
     Task<UserResource> FindByUsername(String)
+    Task<GeneratedAccessTokenResource> GenerateAccessToken(Octopus.Client.Model.UserResource, CancellationToken)
     Task<List<ApiKeyResource>> GetApiKeys(Octopus.Client.Model.UserResource)
     Task<UserResource> GetCurrent()
     Task<SpaceResource[]> GetSpaces(Octopus.Client.Model.UserResource)

--- a/source/Octopus.Server.Client/Model/GeneratedAccessTokenResource.cs
+++ b/source/Octopus.Server.Client/Model/GeneratedAccessTokenResource.cs
@@ -1,0 +1,6 @@
+namespace Octopus.Client.Model;
+
+public class GeneratedAccessTokenResource
+{
+    public string AccessToken { get; set; }
+}

--- a/source/Octopus.Server.Client/Repositories/Async/UserRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/UserRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -21,6 +22,9 @@ namespace Octopus.Client.Repositories.Async
         Task SignOut();
         Task<UserResource> GetCurrent();
         Task<SpaceResource[]> GetSpaces(UserResource user);
+
+        Task<GeneratedAccessTokenResource> GenerateAccessToken(UserResource user, CancellationToken cancellationToken);
+
         /// <summary>
         /// Creates a new API key for a user.
         /// </summary>
@@ -107,6 +111,12 @@ namespace Octopus.Client.Repositories.Async
         {
             if (user == null) throw new ArgumentNullException("user");
             return Client.Get<SpaceResource[]>(user.Link("Spaces"));
+        }
+
+        public async Task<GeneratedAccessTokenResource> GenerateAccessToken(UserResource user, CancellationToken cancellationToken)
+        {
+            if (user == null) throw new ArgumentNullException(nameof(user));
+            return await Client.Post<object, GeneratedAccessTokenResource>(user.Link("AccessToken"), new object(), cancellationToken);
         }
 
         public Task<ApiKeyCreatedResource> CreateApiKey(UserResource user, string purpose = null, DateTimeOffset? expires = null)


### PR DESCRIPTION
# Background

We need to generate an Access token for the helm chart in the E2E test in server, so I have put this in so we can do it via the Client.

Server change here: https://github.com/OctopusDeploy/OctopusDeploy/pull/24450

[sc-71113]