### PR TITLE
Add SkipInitialHealthCheck flag to MachineBasedResource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3748,6 +3748,7 @@ Octopus.Client.Model
     String OperatingSystem { get; set; }
     String ShellName { get; set; }
     String ShellVersion { get; set; }
+    Boolean SkipInitialHealthCheck { get; set; }
     String Slug { get; set; }
     Octopus.Client.Model.MachineModelStatus Status { get; set; }
     String StatusSummary { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3765,6 +3765,7 @@ Octopus.Client.Model
     String OperatingSystem { get; set; }
     String ShellName { get; set; }
     String ShellVersion { get; set; }
+    Boolean SkipInitialHealthCheck { get; set; }
     String Slug { get; set; }
     Octopus.Client.Model.MachineModelStatus Status { get; set; }
     String StatusSummary { get; set; }

--- a/source/Octopus.Server.Client/Model/MachineBasedResource.cs
+++ b/source/Octopus.Server.Client/Model/MachineBasedResource.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Octopus.Client.Extensibility;
+﻿using Octopus.Client.Extensibility;
 using Octopus.Client.Extensibility.Attributes;
 using Octopus.Client.Model.Endpoints;
 
@@ -51,5 +50,8 @@ namespace Octopus.Client.Model
         public string Architecture { get; set; }
         
         public string Slug { get; set; }
+
+        [Writeable]
+        public bool SkipInitialHealthCheck { get; set; }
     }
 }


### PR DESCRIPTION
# Background

There are a few tests in Server which use Octopus.Server.Client to create machines but they don't want background processes like HealthChecks to run. Adding this property allows us to skip the initial health check when adding a machine to make testing easier, more stable and decrease the load on the server running in the test.

# Results

In the Client all we have to do is add the additional property. The server PR (https://github.com/OctopusDeploy/OctopusDeploy/pull/24785) will handle this flag and ensure an initial health check isn't executed if the flag is true.