### PR TITLE
Add Tenant slug support

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3392,6 +3392,13 @@ Octopus.Client.Model
     Boolean Equals(Octopus.Client.Model.EnvironmentResource, Octopus.Client.Model.EnvironmentResource)
     Int32 GetHashCode(Octopus.Client.Model.EnvironmentResource)
   }
+  class IdComparer
+    IEqualityComparer<TenantResource>
+  {
+    .ctor()
+    Boolean Equals(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantResource)
+    Int32 GetHashCode(Octopus.Client.Model.TenantResource)
+  }
   class IdentityClaimResource
   {
     .ctor()
@@ -5672,6 +5679,13 @@ Octopus.Client.Model
     Octopus.Client.Model.TenantResource ClearTags()
     Octopus.Client.Model.TenantResource ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Model.TenantResource WithTag(Octopus.Client.Model.TagResource)
+    class IdComparer
+      IEqualityComparer<TenantResource>
+    {
+      .ctor()
+      Boolean Equals(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantResource)
+      Int32 GetHashCode(Octopus.Client.Model.TenantResource)
+    }
   }
   class TenantsMissingVariablesResource
   {
@@ -8311,12 +8325,13 @@ Octopus.Client.Repositories
     Octopus.Client.Model.TelemetryConfigurationResource ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
   }
   interface ITenantRepository
+    Octopus.Client.Repositories.IFindBySlug<TenantResource>
+    Octopus.Client.Repositories.IPaginate<TenantResource>
     Octopus.Client.Repositories.ICreate<TenantResource>
     Octopus.Client.Repositories.IModify<TenantResource>
     Octopus.Client.Repositories.IGet<TenantResource>
     Octopus.Client.Repositories.IDelete<TenantResource>
     Octopus.Client.Repositories.IFindByName<TenantResource>
-    Octopus.Client.Repositories.IPaginate<TenantResource>
     Octopus.Client.Repositories.IGetAll<TenantResource>
     Octopus.Client.Repositories.IFindByPartialName<TenantResource>
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3409,6 +3409,13 @@ Octopus.Client.Model
     Boolean Equals(Octopus.Client.Model.EnvironmentResource, Octopus.Client.Model.EnvironmentResource)
     Int32 GetHashCode(Octopus.Client.Model.EnvironmentResource)
   }
+  class IdComparer
+    IEqualityComparer<TenantResource>
+  {
+    .ctor()
+    Boolean Equals(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantResource)
+    Int32 GetHashCode(Octopus.Client.Model.TenantResource)
+  }
   class IdentityClaimResource
   {
     .ctor()
@@ -5693,6 +5700,13 @@ Octopus.Client.Model
     Octopus.Client.Model.TenantResource ClearTags()
     Octopus.Client.Model.TenantResource ConnectToProjectAndEnvironments(Octopus.Client.Model.ProjectResource, Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Model.TenantResource WithTag(Octopus.Client.Model.TagResource)
+    class IdComparer
+      IEqualityComparer<TenantResource>
+    {
+      .ctor()
+      Boolean Equals(Octopus.Client.Model.TenantResource, Octopus.Client.Model.TenantResource)
+      Int32 GetHashCode(Octopus.Client.Model.TenantResource)
+    }
   }
   class TenantsMissingVariablesResource
   {
@@ -8336,12 +8350,13 @@ Octopus.Client.Repositories
     Octopus.Client.Model.TelemetryConfigurationResource ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
   }
   interface ITenantRepository
+    Octopus.Client.Repositories.IFindBySlug<TenantResource>
+    Octopus.Client.Repositories.IPaginate<TenantResource>
     Octopus.Client.Repositories.ICreate<TenantResource>
     Octopus.Client.Repositories.IModify<TenantResource>
     Octopus.Client.Repositories.IGet<TenantResource>
     Octopus.Client.Repositories.IDelete<TenantResource>
     Octopus.Client.Repositories.IFindByName<TenantResource>
-    Octopus.Client.Repositories.IPaginate<TenantResource>
     Octopus.Client.Repositories.IGetAll<TenantResource>
     Octopus.Client.Repositories.IFindByPartialName<TenantResource>
   {

--- a/source/Octopus.Server.Client/Model/TenantResource.cs
+++ b/source/Octopus.Server.Client/Model/TenantResource.cs
@@ -73,5 +73,22 @@ namespace Octopus.Client.Model
         public string Slug { get; set; }
 
         public IconResource Icon { get; set; }
+
+        public class IdComparer : IEqualityComparer<TenantResource>
+        {
+            public bool Equals(TenantResource x, TenantResource y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (ReferenceEquals(x, null)) return false;
+                if (ReferenceEquals(y, null)) return false;
+                if (x.GetType() != y.GetType()) return false;
+                return x.Id == y.Id;
+            }
+
+            public int GetHashCode(TenantResource obj)
+            {
+                return (obj.Id != null ? obj.Id.GetHashCode() : 0);
+            }
+        }
     }
 }

--- a/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterMachineOperation.cs
@@ -110,13 +110,16 @@ namespace Octopus.Client.Operations
             var tenantsByName = repository.Tenants.FindByNames(Tenants);
             var missing = Tenants.Except(tenantsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase).ToArray();
 
+            var tenantsBySlug = repository.Tenants.FindBySlugs(missing);
+            missing = missing.Except(tenantsBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase).ToArray();
+
             var tenantsById = repository.Tenants.Get(missing);
             missing = missing.Except(tenantsById.Select(e => e.Id), StringComparer.OrdinalIgnoreCase).ToArray();
 
             if (missing.Any())
                 throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("tenant", missing));
 
-            return tenantsById.Concat(tenantsByName).ToList();
+            return tenantsById.Concat(tenantsBySlug).Concat(tenantsByName).Distinct(new TenantResource.IdComparer()).ToList();
         }
 
         void ValidateTenantTags(IOctopusSpaceRepository repository)

--- a/source/Octopus.Server.Client/Repositories/TenantRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/TenantRepository.cs
@@ -6,7 +6,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
 {
-    public interface ITenantRepository : ICreate<TenantResource>, IModify<TenantResource>, IGet<TenantResource>, IDelete<TenantResource>, IFindByName<TenantResource>, IGetAll<TenantResource>, IFindByPartialName<TenantResource>
+    public interface ITenantRepository : IFindBySlug<TenantResource>, ICreate<TenantResource>, IModify<TenantResource>, IGet<TenantResource>, IDelete<TenantResource>, IFindByName<TenantResource>, IGetAll<TenantResource>, IFindByPartialName<TenantResource>
     {
         MultiTenancyStatusResource Status();
         void SetLogo(TenantResource tenant, string fileName, Stream contents);


### PR DESCRIPTION
Adding tenant slug support so that we can add tenant support to the Kubernetes agent helm chart

[sc-80799]