### PR TITLE
Adds priority field to deployment resource and phases

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2823,6 +2823,7 @@ Octopus.Client.Model
     Dictionary<String, String> FormValues { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
+    Boolean Priority { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
@@ -4422,6 +4423,8 @@ Octopus.Client.Model
     Boolean Blocked { get; set; }
     List<PhaseDeploymentResource> Deployments { get; set; }
     String Id { get; set; }
+    Boolean IsOptionalPhase { get; set; }
+    Boolean IsPriorityPhase { get; set; }
     Int32 MinimumEnvironmentsBeforePromotion { get; set; }
     String Name { get; set; }
     Octopus.Client.Model.ReferenceCollection OptionalDeploymentTargets { get; set; }
@@ -4433,6 +4436,7 @@ Octopus.Client.Model
     Octopus.Client.Model.ReferenceCollection AutomaticDeploymentTargets { get; set; }
     String Id { get; set; }
     Boolean IsOptionalPhase { get; set; }
+    Boolean IsPriorityPhase { get; set; }
     Int32 MinimumEnvironmentsBeforePromotion { get; set; }
     String Name { get; set; }
     Octopus.Client.Model.ReferenceCollection OptionalDeploymentTargets { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2840,6 +2840,7 @@ Octopus.Client.Model
     Dictionary<String, String> FormValues { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
+    Boolean Priority { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
@@ -4442,6 +4443,8 @@ Octopus.Client.Model
     Boolean Blocked { get; set; }
     List<PhaseDeploymentResource> Deployments { get; set; }
     String Id { get; set; }
+    Boolean IsOptionalPhase { get; set; }
+    Boolean IsPriorityPhase { get; set; }
     Int32 MinimumEnvironmentsBeforePromotion { get; set; }
     String Name { get; set; }
     Octopus.Client.Model.ReferenceCollection OptionalDeploymentTargets { get; set; }
@@ -4453,6 +4456,7 @@ Octopus.Client.Model
     Octopus.Client.Model.ReferenceCollection AutomaticDeploymentTargets { get; set; }
     String Id { get; set; }
     Boolean IsOptionalPhase { get; set; }
+    Boolean IsPriorityPhase { get; set; }
     Int32 MinimumEnvironmentsBeforePromotion { get; set; }
     String Name { get; set; }
     Octopus.Client.Model.ReferenceCollection OptionalDeploymentTargets { get; set; }

--- a/source/Octopus.Server.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentResource.cs
@@ -65,6 +65,12 @@ namespace Octopus.Client.Model
         [WriteableOnCreate]
         public bool UseGuidedFailure { get; set; }
 
+        /// <summary>
+        /// If set to true, the deployment will be created with priority.
+        /// </summary>
+        [WriteableOnCreate]
+        public bool Priority { get; set; }
+
         [WriteableOnCreate]
         public string Comments { get; set; }
 

--- a/source/Octopus.Server.Client/Model/PhaseProgressionResource.cs
+++ b/source/Octopus.Server.Client/Model/PhaseProgressionResource.cs
@@ -18,5 +18,7 @@ namespace Octopus.Client.Model
         public ReferenceCollection AutomaticDeploymentTargets { get; set; }
         public ReferenceCollection OptionalDeploymentTargets { get; set; }
         public int MinimumEnvironmentsBeforePromotion { get; set; }
+        public bool IsOptionalPhase { get; set; }
+        public bool IsPriorityPhase { get; set; }
     }
 }

--- a/source/Octopus.Server.Client/Model/PhaseResource.cs
+++ b/source/Octopus.Server.Client/Model/PhaseResource.cs
@@ -19,6 +19,7 @@ namespace Octopus.Client.Model
         public ReferenceCollection OptionalDeploymentTargets { get; set; }
         public int MinimumEnvironmentsBeforePromotion { get; set; }
         public bool IsOptionalPhase { get; set; }
+        public bool IsPriorityPhase { get; set; }
         public RetentionPeriod ReleaseRetentionPolicy { get; set; }
         public RetentionPeriod TentacleRetentionPolicy { get; set; }
 


### PR DESCRIPTION
Adds priority-related fields to deployment resource and phase resources.

Note: `IsOptionalPhase` was missing in the client, which I've also added while adding the priority phase.

[sc-81662]