### PR TITLE
Change priority field on deployment from a bool to an enum with three states.

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2823,7 +2823,7 @@ Octopus.Client.Model
     Dictionary<String, String> FormValues { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
-    Boolean Priority { get; set; }
+    Octopus.Client.Model.PriorityMode Priority { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
@@ -4448,6 +4448,12 @@ Octopus.Client.Model
     Octopus.Client.Model.PhaseResource WithOptionalDeploymentTargets(Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Model.PhaseResource WithReleaseRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
     Octopus.Client.Model.PhaseResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
+  }
+  PriorityMode
+  {
+      LifecycleDefault = 0
+      On = 1
+      Off = 2
   }
   abstract class ProcessExternalFeedTriggers
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2840,7 +2840,7 @@ Octopus.Client.Model
     Dictionary<String, String> FormValues { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
-    Boolean Priority { get; set; }
+    Octopus.Client.Model.PriorityMode Priority { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
@@ -4468,6 +4468,12 @@ Octopus.Client.Model
     Octopus.Client.Model.PhaseResource WithOptionalDeploymentTargets(Octopus.Client.Model.EnvironmentResource[])
     Octopus.Client.Model.PhaseResource WithReleaseRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
     Octopus.Client.Model.PhaseResource WithTentacleRetentionPolicy(Octopus.Client.Model.RetentionPeriod)
+  }
+  PriorityMode
+  {
+      LifecycleDefault = 0
+      On = 1
+      Off = 2
   }
   abstract class ProcessExternalFeedTriggers
   {

--- a/source/Octopus.Server.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentResource.cs
@@ -66,10 +66,10 @@ namespace Octopus.Client.Model
         public bool UseGuidedFailure { get; set; }
 
         /// <summary>
-        /// If set to true, the deployment will be created with priority.
+        /// If priority mode is on, the deployment will be created with priority.
         /// </summary>
         [WriteableOnCreate]
-        public bool Priority { get; set; }
+        public PriorityMode Priority { get; set; }
 
         [WriteableOnCreate]
         public string Comments { get; set; }

--- a/source/Octopus.Server.Client/Model/PriorityMode.cs
+++ b/source/Octopus.Server.Client/Model/PriorityMode.cs
@@ -1,0 +1,8 @@
+namespace Octopus.Client.Model;
+
+public enum PriorityMode
+{
+    LifecycleDefault,
+    On,
+    Off
+}


### PR DESCRIPTION
Updates the priority field on a deployment resource from a boolean to an enum with three states: LifecycleDefault, On and Off, to ensure a priority of a deployment can inherit from a lifecycle if one isn't overriden from a deployment.