### PR TITLE
Add client operations to support registering the Kubernetes agent as a worker

### DIFF
--- a/source/Octopus.Client.Tests/Operations/RegisterKubernetesDeploymentTargetOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterKubernetesDeploymentTargetOperationFixture.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Client.Exceptions;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Model.Endpoints;
+using Octopus.Client.Operations;
+
+namespace Octopus.Client.Tests.Operations
+{
+    [TestFixture]
+    public class RegisterKubernetesDeploymentTargetOperationFixture
+    {
+        RegisterKubernetesDeploymentTargetOperation operation;
+        IOctopusClientFactory clientFactory;
+        IOctopusAsyncClient client;
+        OctopusServerEndpoint serverEndpoint;
+        ResourceCollection<EnvironmentResource> environments;
+        ResourceCollection<MachineResource> machines;
+        ResourceCollection<MachinePolicyResource> machinePolicies;
+        private ResourceCollection<ProxyResource> proxies;
+
+        [SetUp]
+        public void SetUp()
+        {
+            clientFactory = Substitute.For<IOctopusClientFactory>();
+            client = Substitute.For<IOctopusAsyncClient>();
+            clientFactory.CreateAsyncClient(Arg.Any<OctopusServerEndpoint>()).Returns(client);
+            operation = new RegisterKubernetesDeploymentTargetOperation(clientFactory);
+            serverEndpoint = new OctopusServerEndpoint("http://octopus", "ABC123");
+
+            proxies = new ResourceCollection<ProxyResource>(new ProxyResource[0], LinkCollection.Self("/foo"));
+            environments = new ResourceCollection<EnvironmentResource>(new EnvironmentResource[0], LinkCollection.Self("/foo"));
+            machines = new ResourceCollection<MachineResource>(new MachineResource[0], LinkCollection.Self("/foo"));
+            machinePolicies = new ResourceCollection<MachinePolicyResource>(new MachinePolicyResource[0], LinkCollection.Self("/foo"));
+            var rootDocument = new RootResource
+            {
+                ApiVersion = "3.0.0",
+                Version = "2099.0.0",
+                Links = LinkCollection.Self("/api")
+                    .Add("Environments", "/api/environments")
+                    .Add("Machines", "/api/machines")
+                    .Add("MachinePolicies", "/api/machinepolicies")
+                    .Add("CurrentUser", "/api/users/me")
+                    .Add("SpaceHome", "/api/spaces")
+                    .Add("Proxies", "/api/proxies")
+            };
+
+            client.Get<RootResource>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(rootDocument);
+            client.Repository.HasLink(Arg.Any<string>()).Returns(ci => rootDocument.HasLink(ci.Arg<string>()));
+            client.Repository.Link(Arg.Any<string>()).Returns(ci => rootDocument.Link(ci.Arg<string>()));
+
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<EnvironmentResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<EnvironmentResource>, bool>>()(environments));
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachineResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<MachineResource>, bool>>()(machines));
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachinePolicyResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<MachinePolicyResource>, bool>>()(machinePolicies));
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<ProxyResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<ProxyResource>, bool>>()(proxies));
+        }
+
+        [Test]
+        public async Task ShouldCreateNewListeningKubernetesTentacle()
+        {
+            var machineResources = new List<MachineResource>();
+            await client.Create("/api/machines", Arg.Do<MachineResource>(m => machineResources.Add(m)), Arg.Any<object>(), Arg.Any<CancellationToken>());
+
+            environments.Items.Add(new EnvironmentResource {Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines")});
+            environments.Items.Add(new EnvironmentResource {Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines")});
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] {"Production"};
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://mymachine.test.com:10930/")));
+        }
+
+        [Test]
+        public async Task ShouldCreateNewPollingKubernetesTentacle()
+        {
+            var machineResources = new List<MachineResource>();
+            await client.Create("/api/machines", Arg.Do<MachineResource>(m => machineResources.Add(m)), Arg.Any<object>(), Arg.Any<CancellationToken>());
+
+            environments.Items.Add(new EnvironmentResource {Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines")});
+            environments.Items.Add(new EnvironmentResource {Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines")});
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentacleActive;
+            operation.EnvironmentNames = new[] {"Production"};
+            operation.SubscriptionId = new Uri("poll://ckyhfyfkcbmzjl8sfgch/");
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            machineResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new PollingTentacleEndpointConfigurationResource("ABCDEF", "poll://ckyhfyfkcbmzjl8sfgch/")));
+        }
+
+        [Test]
+        public async Task ShouldOnlyUpdateEndpointConnectionConfigurationOnExistingMachine()
+        {
+            var updatedMachines = new List<MachineResource>();
+            await client.Update("/machines/whatever/1", Arg.Do<MachineResource>(m => updatedMachines.Add(m)), Arg.Any<object>(), Arg.Any<CancellationToken>());
+
+            environments.Items.Add(new EnvironmentResource {Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines")});
+            environments.Items.Add(new EnvironmentResource {Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines")});
+
+            machines.Items.Add(new MachineResource
+            {
+                Id = "machines/84", EnvironmentIds = new ReferenceCollection(new[] { "environments-1" }), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1"),
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("123456", "myMachine.test.com") { ProxyId = "proxy-2" })
+            });
+
+            proxies.Items.Add(new ProxyResource { Id = "proxy-1", Name = "MyNewProxy", Links = LinkCollection.Self("/api/proxies/proxy-1") });
+
+            operation.MachineName = "Mymachine";
+            operation.TentaclePort = 10930;
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentacleHostname = "my-new-machine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] {"Production"};
+            operation.ProxyName = "MyNewProxy";
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            var thing = updatedMachines.Should().ContainSingle().Which;
+
+            thing.Should().BeEquivalentTo(new
+            {
+                Id = "machines/84",
+                Name = "Mymachine",
+                EnvironmentIds = new ReferenceCollection("environments-1"),
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://my-new-machine.test.com:10930/") {ProxyId = "proxy-1"}),
+                Links = LinkCollection.Self("/machines/whatever/1")
+            });
+        }
+
+        [Test]
+        public async Task ShouldUpdateExistingMachineWhenForceIsEnabled()
+        {
+            environments.Items.Add(new EnvironmentResource {Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines")});
+            environments.Items.Add(new EnvironmentResource {Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines")});
+
+            machines.Items.Add(new MachineResource {Id = "machines/84", EnvironmentIds = new ReferenceCollection(new[] {"environments-1"}), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1")});
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] {"Production"};
+            operation.AllowOverwrite = true;
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            await client.Received().Update("/machines/whatever/1", Arg.Is<MachineResource>(m =>
+                m.Id == "machines/84"
+                && m.Name == "Mymachine"
+                && m.EnvironmentIds.First() == "environments-2"),
+                Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ShouldCreateWhenCantDeserializeMachines()
+        {
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<MachineResource>, bool>>()))
+                .Throw(new OctopusDeserializationException(1, "Can not deserialize"));
+
+            environments.Items.Add(new EnvironmentResource { Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines") });
+            environments.Items.Add(new EnvironmentResource { Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines") });
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] { "Production" };
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            await client.Received().Create("/api/machines", Arg.Is<MachineResource>(m =>
+                m.Name == "Mymachine"
+                && ((KubernetesTentacleEndpointResource)m.Endpoint).TentacleEndpointConfiguration.Uri == "https://mymachine.test.com:10930/"
+                && m.EnvironmentIds.First() == "environments-2"),
+                Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ShouldNotOverwriteMachinePolicyToNull()
+        {
+            environments.Items.Add(new EnvironmentResource { Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines") });
+            environments.Items.Add(new EnvironmentResource { Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines") });
+
+            machines.Items.Add(new MachineResource { Id = "machines/84", MachinePolicyId = "MachinePolicies-1", EnvironmentIds = new ReferenceCollection(new[] { "environments-1" }), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1") });
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] { "Production" };
+            operation.AllowOverwrite = true;
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            await client.Received().Update("/machines/whatever/1", Arg.Is<MachineResource>(m =>
+                m.Id == "machines/84"
+                && m.Name == "Mymachine"
+                && m.EnvironmentIds.First() == "environments-2"
+                && m.MachinePolicyId == "MachinePolicies-1"),
+                Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ShouldOverwriteMachinePolicyWhenPassed()
+        {
+            environments.Items.Add(new EnvironmentResource { Id = "environments-1", Name = "UAT", Links = LinkCollection.Self("/api/environments/environments-1").Add("Machines", "/api/environments/environments-1/machines") });
+            environments.Items.Add(new EnvironmentResource { Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines") });
+
+            machines.Items.Add(new MachineResource { Id = "machines/84", MachinePolicyId = "MachinePolicies-1", EnvironmentIds = new ReferenceCollection(new[] { "environments-1" }), Name = "Mymachine", Links = LinkCollection.Self("/machines/whatever/1") });
+            machinePolicies.Items.Add(new MachinePolicyResource {Id = "MachinePolicies-2", Name = "Machine Policy 2"});
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "Mymachine";
+            operation.TentacleHostname = "Mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.EnvironmentNames = new[] { "Production" };
+            operation.AllowOverwrite = true;
+            operation.MachinePolicy = "Machine Policy 2";
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            await client.Received().Update("/machines/whatever/1", Arg.Is<MachineResource>(m =>
+                m.Id == "machines/84"
+                && m.Name == "Mymachine"
+                && m.EnvironmentIds.First() == "environments-2"
+                && m.MachinePolicyId == "MachinePolicies-2"),
+                Arg.Any<object>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/Operations/RegisterKubernetesWorkerOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterKubernetesWorkerOperationFixture.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
-using Octopus.Client.Exceptions;
 using Octopus.Client.Extensibility;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;

--- a/source/Octopus.Client.Tests/Operations/RegisterKubernetesWorkerOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterKubernetesWorkerOperationFixture.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Client.Exceptions;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Model.Endpoints;
+using Octopus.Client.Operations;
+
+namespace Octopus.Client.Tests.Operations
+{
+    [TestFixture]
+    public class RegisterKubernetesWorkerOperationFixture
+    {
+        RegisterKubernetesWorkerOperation operation;
+        IOctopusClientFactory clientFactory;
+        IOctopusAsyncClient client;
+        OctopusServerEndpoint serverEndpoint;
+        ResourceCollection<WorkerResource> workers;
+        ResourceCollection<WorkerPoolResource> workerPools;
+        private ResourceCollection<ProxyResource> proxies;
+
+        [SetUp]
+        public void SetUp()
+        {
+            clientFactory = Substitute.For<IOctopusClientFactory>();
+            client = Substitute.For<IOctopusAsyncClient>();
+            clientFactory.CreateAsyncClient(Arg.Any<OctopusServerEndpoint>()).Returns(client);
+            operation = new RegisterKubernetesWorkerOperation(clientFactory);
+            serverEndpoint = new OctopusServerEndpoint("http://octopus", "ABC123");
+            
+            workers = new ResourceCollection<WorkerResource>(new WorkerResource[0], LinkCollection.Self("/foo"));
+            workerPools = new ResourceCollection<WorkerPoolResource>(new WorkerPoolResource[0], LinkCollection.Self("/foo"));
+            proxies = new ResourceCollection<ProxyResource>(new ProxyResource[0], LinkCollection.Self("/foo"));
+            var rootDocument = new RootResource
+            {
+                ApiVersion = "3.0.0",
+                Version = "2099.0.0",
+                Links = LinkCollection.Self("/api")
+                    .Add("Workers", "/api/workers")
+                    .Add("WorkerPools", "/api/workerpools")
+                    .Add("CurrentUser", "/api/users/me")
+                    .Add("SpaceHome", "/api/spaces")
+                    .Add("Proxies", "/api/proxies")
+            };
+
+            client.Get<RootResource>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(rootDocument);
+            client.Repository.HasLink(Arg.Any<string>()).Returns(ci => rootDocument.HasLink(ci.Arg<string>()));
+            client.Repository.Link(Arg.Any<string>()).Returns(ci => rootDocument.Link(ci.Arg<string>()));
+
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<WorkerResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<WorkerResource>, bool>>()(workers));
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<WorkerPoolResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<WorkerPoolResource>, bool>>()(workerPools));
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<ProxyResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<ProxyResource>, bool>>()(proxies));
+        }
+
+        [Test]
+        public async Task ShouldCreateNewListeningKubernetesTentacle()
+        {
+            var workerResources = new List<WorkerResource>();
+            await client.Create("/api/workers", Arg.Do<WorkerResource>(m => workerResources.Add(m)), Arg.Any<object>(), Arg.Any<CancellationToken>());
+
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-1", Name = "PoolA", Slug = "workerpool-1", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-1")});
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-2", Name = "PoolB", Slug = "workerpool-2", WorkerPoolType = WorkerPoolType.DynamicWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-2")});
+
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "MyMachine";
+            operation.TentacleHostname = "mymachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.WorkerPools = new[] {"PoolA", "PoolB"};
+
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            workerResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://mymachine.test.com:10930/")));
+        }
+
+        [Test]
+        public async Task ShouldCreateNewPollingKubernetesTentacle()
+        {
+            var workerResources = new List<WorkerResource>();
+            await client.Create("/api/workers", Arg.Do<WorkerResource>(m => workerResources.Add(m)), Arg.Any<object>(), Arg.Any<CancellationToken>());
+        
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-1", Name = "PoolA", Slug = "workerpool-1", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-1")});
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-2", Name = "PoolB", Slug = "workerpool-2", WorkerPoolType = WorkerPoolType.DynamicWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-2")});
+        
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "MyOtherMachine";
+            operation.TentacleHostname = "myothermachine.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentacleActive;
+            operation.WorkerPools = new[] {"workerpool-2"};
+            operation.SubscriptionId = new Uri("poll://ckyhfyfkcbmzjl8sfgch/");
+        
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+        
+            workerResources.Should().ContainSingle().Which.Endpoint.Should().BeOfType<KubernetesTentacleEndpointResource>().Which.Should().BeEquivalentTo(new KubernetesTentacleEndpointResource(new PollingTentacleEndpointConfigurationResource("ABCDEF", "poll://ckyhfyfkcbmzjl8sfgch/")));
+        }
+
+        [Test]
+        public async Task ShouldOnlyUpdateEndpointConnectionConfigurationOnExistingWorker()
+        {
+            var updatedWorkers = await GetUpdatedWorkerAfterOperation(false);
+
+            var worker = updatedWorkers.Should().ContainSingle().Which; 
+            worker.Should().BeEquivalentTo(new
+            {
+                Id = "workers-84",
+                Name = "MyWorker",
+                WorkerPoolIds = new ReferenceCollection("WorkerPools-1"),
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://my-new-worker.test.com:10930/") {ProxyId = "proxy-1"}),
+                Links = LinkCollection.Self("/machines/workers-84")
+            });
+        }
+        
+        [Test]
+        public async Task ShouldUpdateExistingWorkerWhenForceIsEnabled()
+        {
+            var updatedWorkers = await GetUpdatedWorkerAfterOperation(true);
+            
+            var worker =updatedWorkers.Should().ContainSingle().Which; 
+            worker.Should().BeEquivalentTo(new
+            {
+                Id = "workers-84",
+                Name = "MyWorker",
+                WorkerPoolIds = new ReferenceCollection("WorkerPools-2"),
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("ABCDEF", "https://my-new-worker.test.com:10930/") {ProxyId = "proxy-1"}),
+                Links = LinkCollection.Self("/machines/workers-84")
+            });
+        }
+
+        async Task<List<WorkerResource>> GetUpdatedWorkerAfterOperation(bool allowOverwrite)
+        {
+            var updatedWorkers = new List<WorkerResource>();
+            await client.Update("/machines/workers-84", Arg.Do<WorkerResource>(m => updatedWorkers.Add(m)), Arg.Any<object>(), Arg.Any<CancellationToken>());
+            
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-1", Name = "PoolA", Slug = "workerpool-1", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-1")});
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-2", Name = "PoolB", Slug = "workerpool-2", WorkerPoolType = WorkerPoolType.DynamicWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-2")});
+        
+            workers.Items.Add(new WorkerResource
+            {
+                Id = "workers-84", WorkerPoolIds = new ReferenceCollection(new[] { "WorkerPools-1" }), Name = "MyWorker", Links = LinkCollection.Self("/machines/workers-84"),
+                Endpoint = new KubernetesTentacleEndpointResource(new ListeningTentacleEndpointConfigurationResource("123456", "myworker.test.com") { ProxyId = "proxy-2" })
+            });
+            
+            proxies.Items.Add(new ProxyResource { Id = "proxy-1", Name = "MyNewProxy", Links = LinkCollection.Self("/api/proxies/proxy-1") });
+        
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "MyWorker";
+            operation.TentacleHostname = "my-new-worker.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.WorkerPools = new[] {"PoolB"};
+            operation.ProxyName = "MyNewProxy";
+            operation.AllowOverwrite = allowOverwrite;
+        
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+
+            return updatedWorkers;
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterMachineOperationFixture.cs
@@ -61,38 +61,38 @@ namespace Octopus.Client.Tests.Operations
         }
 
         [Test]
-        public void ShouldThrowIfEnvironmentNameNotFound()
+        public async Task ShouldThrowIfEnvironmentNameNotFound()
         {
             operation.EnvironmentNames = new[] {"Atlantis"};
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environment named Atlantis on the Octopus Server. Ensure the environment exists and you have permission to access it.");
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environment named Atlantis on the Octopus Server. Ensure the environment exists and you have permission to access it.");
         }
         
         [Test]
-        public void ShouldThrowIfEnvironmentNameNotFoundEvenWhenEnvironmentsHasValid()
+        public async Task ShouldThrowIfEnvironmentNameNotFoundEvenWhenEnvironmentsHasValid()
         {
             environments.Items.Add(new EnvironmentResource { Id = "environments-2", Name = "Production", Links = LinkCollection.Self("/api/environments/environments-2").Add("Machines", "/api/environments/environments-2/machines") });
 
             operation.EnvironmentNames = new[] {"Atlantis"};
             operation.Environments = new[] {"Production"};
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environment named Atlantis on the Octopus Server. Ensure the environment exists and you have permission to access it.");
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environment named Atlantis on the Octopus Server. Ensure the environment exists and you have permission to access it.");
         }
         
         [Test]
-        public void ShouldThrowIfEnvironmentNotFoundBySlug()
+        public async Task ShouldThrowIfEnvironmentNotFoundBySlug()
         {
             operation.Environments = new[] {"atlantis-slug"};
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environment with name, slug or Id atlantis-slug on the Octopus Server. Ensure the environment exists and you have permission to access it.");
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environment with name, slug or Id atlantis-slug on the Octopus Server. Ensure the environment exists and you have permission to access it.");
         }
         
         [Test]
-        public void ShouldThrowIfEnvironmentNotFoundByIdOrSlug()
+        public async Task ShouldThrowIfEnvironmentNotFoundByIdOrSlug()
         {
             operation.Environments = new[] {"Environments-12345","atlantis-slug" };
             Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
-            exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environment with names, slugs or Ids: Environments-12345, \"atlantis-slug\" on the Octopus Server. Ensure the environment exists and you have permission to access it.");
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the environments with names, slugs or Ids: Environments-12345, atlantis-slug on the Octopus Server. Ensure the environments exist and you have permission to access them.");
         }
 
         [Test]

--- a/source/Octopus.Client.Tests/Operations/RegisterWorkerOperationFixture.cs
+++ b/source/Octopus.Client.Tests/Operations/RegisterWorkerOperationFixture.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Model.Endpoints;
+using Octopus.Client.Operations;
+
+namespace Octopus.Client.Tests.Operations
+{
+    [TestFixture]
+    public class RegisterWorkerOperationFixture
+    {
+        RegisterWorkerOperation operation;
+        IOctopusClientFactory clientFactory;
+        IOctopusAsyncClient client;
+        OctopusServerEndpoint serverEndpoint;
+        ResourceCollection<WorkerPoolResource> workerPools;
+        ResourceCollection<WorkerResource> workers;
+
+        [SetUp]
+        public void SetUp()
+        {
+            clientFactory = Substitute.For<IOctopusClientFactory>();
+            client = Substitute.For<IOctopusAsyncClient>();
+            clientFactory.CreateAsyncClient(Arg.Any<OctopusServerEndpoint>()).Returns(client);
+            operation = new RegisterWorkerOperation(clientFactory);
+            serverEndpoint = new OctopusServerEndpoint("http://octopus", "ABC123");
+
+            workerPools = new ResourceCollection<WorkerPoolResource>(Array.Empty<WorkerPoolResource>(), LinkCollection.Self("/foo"));
+            workers = new ResourceCollection<WorkerResource>(Array.Empty<WorkerResource>(), LinkCollection.Self("/foo"));
+            var rootDocument = new RootResource
+            {
+                ApiVersion = "3.0.0",
+                Version = "2099.0.0",
+                Links = LinkCollection.Self("/api")
+                    .Add("Workers", "/api/workers")
+                    .Add("WorkerPools", "/api/workerpools")
+                    .Add("CurrentUser", "/api/users/me")
+                    .Add("SpaceHome", "/api/spaces")
+            };
+            
+            client.Get<RootResource>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(rootDocument);
+            client.Repository.HasLink(Arg.Any<string>()).Returns(ci => rootDocument.HasLink(ci.Arg<string>()));
+            client.Repository.Link(Arg.Any<string>()).Returns(ci => rootDocument.Link(ci.Arg<string>()));
+
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<WorkerPoolResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<WorkerPoolResource>, bool>>()(workerPools));
+            client.When(x => x.Paginate(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<Func<ResourceCollection<WorkerResource>, bool>>(), Arg.Any<CancellationToken>()))
+                .Do(ci => ci.Arg<Func<ResourceCollection<WorkerResource>, bool>>()(workers));
+        }
+
+        [Test]
+        public async Task ShouldThrowIfWorkerPoolNameNotFound()
+        {
+            operation.WorkerPoolNames = new[] {"Atlantis"};
+            Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the worker pool named Atlantis on the Octopus Server. Ensure the worker pool exists and you have permission to access it.");
+        }
+        
+        [Test]
+        public async Task ShouldThrowIfWorkerPoolNameNotFoundEvenWhenWorkerPoolsHaveValid()
+        {
+            workerPools.Items.Add(new WorkerPoolResource { Id = "WorkerPools-2", Name = "MyWorkerPool", Links = LinkCollection.Self("/api/workerpools/workerpools-2") });
+        
+            operation.WorkerPoolNames = new[] {"Atlantis"};
+            operation.WorkerPools = new[] {"MyWorkerPool"};
+            Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the worker pool named Atlantis on the Octopus Server. Ensure the worker pool exists and you have permission to access it.");
+        }
+        
+        [Test]
+        public async Task ShouldThrowIfWorkerPoolNotFoundBySlug()
+        {
+            operation.WorkerPools = new[] {"atlantis-slug"};
+            Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the worker pool with name, slug or Id atlantis-slug on the Octopus Server. Ensure the worker pool exists and you have permission to access it.");
+        }
+        
+        [Test]
+        public async Task ShouldThrowIfWorkerPoolNotFoundByIdOrSlug()
+        {
+            operation.WorkerPools = new[] {"WorkerPools-12345","atlantis-slug" };
+            Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the worker pools with names, slugs or Ids: WorkerPools-12345, atlantis-slug on the Octopus Server. Ensure the worker pools exist and you have permission to access them.");
+        }
+        
+        [Test]
+        public async Task ShouldThrowIfAnyWorkerPoolNotFound()
+        {
+            workerPools.Items.Add(new WorkerPoolResource { Id = "WorkerPools-2", Name = "MyWorkerPool", Links = LinkCollection.Self("/api/workerpools/WorkerPools-2") });
+        
+            operation.WorkerPools = new[] {"WorkerPools-2", "Atlantis", "ImaginaryPool"};
+            Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
+            await exec.Should().ThrowAsync<ArgumentException>().WithMessage("Could not find the worker pools with names, slugs or Ids: Atlantis, ImaginaryPool on the Octopus Server. Ensure the worker pools exist and you have permission to access them.");
+        }
+        
+        [Test]
+        public async Task ShouldCreateNewWorker()
+        {
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-1", Name = "PoolA", Slug = "workerpool-1", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-1")});
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-2", Name = "PoolB", Slug = "workerpool-2", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-2")});
+
+            operation.WorkerPools = new[] { "workerpool-1", "PoolB" };
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "MyWorker";
+            operation.TentacleHostname = "myworker.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+        
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+        
+            await client.Received().Create("/api/workers", Arg.Is<WorkerResource>(m =>
+                    m.Name == "MyWorker"
+                    && m.WorkerPoolIds.SetEquals(new []{ "WorkerPools-1", "WorkerPools-2" })
+                    && ((ListeningTentacleEndpointResource)m.Endpoint).Uri == "https://myworker.test.com:10930/"),
+                    Arg.Any<object>(), Arg.Any<CancellationToken>())
+                .ConfigureAwait(false);
+        }
+    
+        [Test]
+        public async Task ShouldNotUpdateExistingWorkerWhenForceIsNotEnabled()
+        {
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-1", Name = "PoolA", Slug = "workerpool-1", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-1")});
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-2", Name = "PoolB", Slug = "workerpool-2", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-2")});
+        
+            workers.Items.Add(new WorkerResource {Id = "Worker-1", Name = "ExistingWorker", WorkerPoolIds = new ReferenceCollection(new[] {"workerpool-2"}), Links = LinkCollection.Self("/workers/Worker-1")});
+        
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "ExistingWorker";
+            operation.TentacleHostname = "newworker.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.WorkerPools = new[] { "workerpool-1", "PoolB" };
+        
+            Func<Task> exec = () => operation.ExecuteAsync(serverEndpoint);
+            await exec.Should().ThrowAsync<ArgumentException>();
+        }
+    
+        [Test]
+        public async Task ShouldUpdateExistingWorkerWhenForceIsEnabled()
+        {
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-1", Name = "PoolA", Slug = "workerpool-1", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-1")});
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-2", Name = "PoolB", Slug = "workerpool-2", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-2")});
+        
+            workers.Items.Add(new WorkerResource {Id = "Worker-1", Name = "ExistingWorker", WorkerPoolIds = new ReferenceCollection(new[] {"workerpool-2"}), Links = LinkCollection.Self("/workers/Worker-1")});
+        
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "ExistingWorker";
+            operation.TentacleHostname = "newworker.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.WorkerPools = new[] { "workerpool-1", "PoolB" };
+            operation.AllowOverwrite = true;
+        
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+            
+            await client.Received().Update("/workers/Worker-1", Arg.Is<WorkerResource>(m =>
+                        m.Name == "ExistingWorker"
+                        && m.WorkerPoolIds.SetEquals(new []{ "WorkerPools-1", "WorkerPools-2" })
+                        && ((ListeningTentacleEndpointResource)m.Endpoint).Uri == "https://newworker.test.com:10930/"),
+                    Arg.Any<object>(), Arg.Any<CancellationToken>())
+                .ConfigureAwait(false);
+        }
+        
+        [Test]
+        public async Task ShouldDeduplicateWorkerPools()
+        {
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-1", Name = "PoolA", Slug = "workerpool-slug-1", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-1")});
+            workerPools.Items.Add(new WorkerPoolResource {Id = "WorkerPools-2", Name = "PoolB", Slug = "workerpool-slug-2", WorkerPoolType = WorkerPoolType.StaticWorkerPool, Links = LinkCollection.Self("/api/workerpools/WorkerPools-2")});
+    
+            operation.TentacleThumbprint = "ABCDEF";
+            operation.TentaclePort = 10930;
+            operation.MachineName = "MyWorker";
+            operation.TentacleHostname = "myworker.test.com";
+            operation.CommunicationStyle = CommunicationStyle.TentaclePassive;
+            operation.WorkerPoolNames = new[] {"PoolA"};
+            operation.WorkerPools = new[] {"workerpool-slug-1", "workerpool-slug-2"};
+    
+            await operation.ExecuteAsync(serverEndpoint).ConfigureAwait(false);
+    
+            await client.Received().Create("/api/workers", Arg.Is<WorkerResource>(m =>
+                        m.Name == "MyWorker"
+                        && ((ListeningTentacleEndpointResource)m.Endpoint).Uri == "https://myworker.test.com:10930/"
+                        && m.WorkerPoolIds.SetEquals(new []{"WorkerPools-1","WorkerPools-2"})),
+                    Arg.Any<object>(), Arg.Any<CancellationToken>())
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -9232,12 +9232,13 @@ Octopus.Client.Repositories.Async
     Task<TelemetryConfigurationResource> ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
   }
   interface ITenantRepository
+    Octopus.Client.Repositories.Async.IFindBySlug<TenantResource>
+    Octopus.Client.Repositories.Async.IPaginate<TenantResource>
     Octopus.Client.Repositories.Async.ICreate<TenantResource>
     Octopus.Client.Repositories.Async.IModify<TenantResource>
     Octopus.Client.Repositories.Async.IGet<TenantResource>
     Octopus.Client.Repositories.Async.IDelete<TenantResource>
     Octopus.Client.Repositories.Async.IFindByName<TenantResource>
-    Octopus.Client.Repositories.Async.IPaginate<TenantResource>
     Octopus.Client.Repositories.Async.IGetAll<TenantResource>
     Octopus.Client.Repositories.Async.IFindByPartialName<TenantResource>
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7617,6 +7617,17 @@ Octopus.Client.Operations
   {
     String DefaultNamespace { get; set; }
   }
+  interface IRegisterKubernetesDeploymentTargetOperation
+    Octopus.Client.Operations.IRegisterMachineOperation
+    Octopus.Client.Operations.IRegisterMachineOperationBase
+  {
+    String DefaultNamespace { get; set; }
+  }
+  interface IRegisterKubernetesWorkerOperation
+    Octopus.Client.Operations.IRegisterWorkerOperation
+    Octopus.Client.Operations.IRegisterMachineOperationBase
+  {
+  }
   interface IRegisterMachineOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
   {
@@ -7649,6 +7660,7 @@ Octopus.Client.Operations
     Octopus.Client.Operations.IRegisterMachineOperationBase
   {
     String[] WorkerPoolNames { get; set; }
+    String[] WorkerPools { get; set; }
   }
   class RegisterKubernetesClusterOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -7659,6 +7671,25 @@ Octopus.Client.Operations
     .ctor()
     .ctor(Octopus.Client.IOctopusClientFactory)
     String DefaultNamespace { get; set; }
+  }
+  class RegisterKubernetesDeploymentTargetOperation
+    Octopus.Client.Operations.IRegisterMachineOperationBase
+    Octopus.Client.Operations.IRegisterMachineOperation
+    Octopus.Client.Operations.IRegisterKubernetesDeploymentTargetOperation
+    Octopus.Client.Operations.RegisterMachineOperation
+  {
+    .ctor()
+    .ctor(Octopus.Client.IOctopusClientFactory)
+    String DefaultNamespace { get; set; }
+  }
+  class RegisterKubernetesWorkerOperation
+    Octopus.Client.Operations.IRegisterMachineOperationBase
+    Octopus.Client.Operations.IRegisterWorkerOperation
+    Octopus.Client.Operations.IRegisterKubernetesWorkerOperation
+    Octopus.Client.Operations.RegisterWorkerOperation
+  {
+    .ctor()
+    .ctor(Octopus.Client.IOctopusClientFactory)
   }
   class RegisterMachineOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -7704,6 +7735,7 @@ Octopus.Client.Operations
     .ctor()
     .ctor(Octopus.Client.IOctopusClientFactory)
     String[] WorkerPoolNames { get; set; }
+    String[] WorkerPools { get; set; }
     void Execute(Octopus.Client.IOctopusSpaceRepository)
     Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
   }
@@ -8427,8 +8459,9 @@ Octopus.Client.Repositories
     Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
   }
   interface IWorkerPoolRepository
-    Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
+    Octopus.Client.Repositories.IFindBySlug<WorkerPoolResource>
     Octopus.Client.Repositories.IPaginate<WorkerPoolResource>
+    Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
     Octopus.Client.Repositories.IGet<WorkerPoolResource>
     Octopus.Client.Repositories.ICreate<WorkerPoolResource>
     Octopus.Client.Repositories.IModify<WorkerPoolResource>
@@ -9293,8 +9326,9 @@ Octopus.Client.Repositories.Async
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String, CancellationToken)
   }
   interface IWorkerPoolRepository
-    Octopus.Client.Repositories.Async.IFindByName<WorkerPoolResource>
+    Octopus.Client.Repositories.Async.IFindBySlug<WorkerPoolResource>
     Octopus.Client.Repositories.Async.IPaginate<WorkerPoolResource>
+    Octopus.Client.Repositories.Async.IFindByName<WorkerPoolResource>
     Octopus.Client.Repositories.Async.IGet<WorkerPoolResource>
     Octopus.Client.Repositories.Async.ICreate<WorkerPoolResource>
     Octopus.Client.Repositories.Async.IModify<WorkerPoolResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7642,6 +7642,17 @@ Octopus.Client.Operations
   {
     String DefaultNamespace { get; set; }
   }
+  interface IRegisterKubernetesDeploymentTargetOperation
+    Octopus.Client.Operations.IRegisterMachineOperation
+    Octopus.Client.Operations.IRegisterMachineOperationBase
+  {
+    String DefaultNamespace { get; set; }
+  }
+  interface IRegisterKubernetesWorkerOperation
+    Octopus.Client.Operations.IRegisterWorkerOperation
+    Octopus.Client.Operations.IRegisterMachineOperationBase
+  {
+  }
   interface IRegisterMachineOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
   {
@@ -7674,6 +7685,7 @@ Octopus.Client.Operations
     Octopus.Client.Operations.IRegisterMachineOperationBase
   {
     String[] WorkerPoolNames { get; set; }
+    String[] WorkerPools { get; set; }
   }
   class RegisterKubernetesClusterOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -7684,6 +7696,25 @@ Octopus.Client.Operations
     .ctor()
     .ctor(Octopus.Client.IOctopusClientFactory)
     String DefaultNamespace { get; set; }
+  }
+  class RegisterKubernetesDeploymentTargetOperation
+    Octopus.Client.Operations.IRegisterMachineOperationBase
+    Octopus.Client.Operations.IRegisterMachineOperation
+    Octopus.Client.Operations.IRegisterKubernetesDeploymentTargetOperation
+    Octopus.Client.Operations.RegisterMachineOperation
+  {
+    .ctor()
+    .ctor(Octopus.Client.IOctopusClientFactory)
+    String DefaultNamespace { get; set; }
+  }
+  class RegisterKubernetesWorkerOperation
+    Octopus.Client.Operations.IRegisterMachineOperationBase
+    Octopus.Client.Operations.IRegisterWorkerOperation
+    Octopus.Client.Operations.IRegisterKubernetesWorkerOperation
+    Octopus.Client.Operations.RegisterWorkerOperation
+  {
+    .ctor()
+    .ctor(Octopus.Client.IOctopusClientFactory)
   }
   class RegisterMachineOperation
     Octopus.Client.Operations.IRegisterMachineOperationBase
@@ -7729,6 +7760,7 @@ Octopus.Client.Operations
     .ctor()
     .ctor(Octopus.Client.IOctopusClientFactory)
     String[] WorkerPoolNames { get; set; }
+    String[] WorkerPools { get; set; }
     void Execute(Octopus.Client.IOctopusSpaceRepository)
     Task ExecuteAsync(Octopus.Client.IOctopusSpaceAsyncRepository)
   }
@@ -8452,8 +8484,9 @@ Octopus.Client.Repositories
     Octopus.Client.Model.VariableSetResource GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String)
   }
   interface IWorkerPoolRepository
-    Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
+    Octopus.Client.Repositories.IFindBySlug<WorkerPoolResource>
     Octopus.Client.Repositories.IPaginate<WorkerPoolResource>
+    Octopus.Client.Repositories.IFindByName<WorkerPoolResource>
     Octopus.Client.Repositories.IGet<WorkerPoolResource>
     Octopus.Client.Repositories.ICreate<WorkerPoolResource>
     Octopus.Client.Repositories.IModify<WorkerPoolResource>
@@ -9318,8 +9351,9 @@ Octopus.Client.Repositories.Async
     Task<VariableSetResource> GetVariablePreview(Octopus.Client.Model.ProjectResource, String, String, String, String, String, String, String, String, CancellationToken)
   }
   interface IWorkerPoolRepository
-    Octopus.Client.Repositories.Async.IFindByName<WorkerPoolResource>
+    Octopus.Client.Repositories.Async.IFindBySlug<WorkerPoolResource>
     Octopus.Client.Repositories.Async.IPaginate<WorkerPoolResource>
+    Octopus.Client.Repositories.Async.IFindByName<WorkerPoolResource>
     Octopus.Client.Repositories.Async.IGet<WorkerPoolResource>
     Octopus.Client.Repositories.Async.ICreate<WorkerPoolResource>
     Octopus.Client.Repositories.Async.IModify<WorkerPoolResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -9257,12 +9257,13 @@ Octopus.Client.Repositories.Async
     Task<TelemetryConfigurationResource> ModifyTelemetryConfiguration(Octopus.Client.Model.TelemetryConfigurationResource)
   }
   interface ITenantRepository
+    Octopus.Client.Repositories.Async.IFindBySlug<TenantResource>
+    Octopus.Client.Repositories.Async.IPaginate<TenantResource>
     Octopus.Client.Repositories.Async.ICreate<TenantResource>
     Octopus.Client.Repositories.Async.IModify<TenantResource>
     Octopus.Client.Repositories.Async.IGet<TenantResource>
     Octopus.Client.Repositories.Async.IDelete<TenantResource>
     Octopus.Client.Repositories.Async.IFindByName<TenantResource>
-    Octopus.Client.Repositories.Async.IPaginate<TenantResource>
     Octopus.Client.Repositories.Async.IGetAll<TenantResource>
     Octopus.Client.Repositories.Async.IFindByPartialName<TenantResource>
   {

--- a/source/Octopus.Server.Client/Operations/IRegisterKubernetesClusterOperation.cs
+++ b/source/Octopus.Server.Client/Operations/IRegisterKubernetesClusterOperation.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace Octopus.Client.Operations;
 
+[Obsolete($"Use {nameof(IRegisterKubernetesDeploymentTargetOperation)} instead.")]
 public interface IRegisterKubernetesClusterOperation : IRegisterMachineOperation
 {
     string DefaultNamespace { get; set; }

--- a/source/Octopus.Server.Client/Operations/IRegisterKubernetesDeploymentTargetOperation.cs
+++ b/source/Octopus.Server.Client/Operations/IRegisterKubernetesDeploymentTargetOperation.cs
@@ -1,0 +1,6 @@
+namespace Octopus.Client.Operations;
+
+public interface IRegisterKubernetesDeploymentTargetOperation : IRegisterMachineOperation
+{
+    string DefaultNamespace { get; set; }
+}

--- a/source/Octopus.Server.Client/Operations/IRegisterKubernetesWorkerOperation.cs
+++ b/source/Octopus.Server.Client/Operations/IRegisterKubernetesWorkerOperation.cs
@@ -1,0 +1,5 @@
+namespace Octopus.Client.Operations;
+
+public interface IRegisterKubernetesWorkerOperation : IRegisterWorkerOperation
+{
+}

--- a/source/Octopus.Server.Client/Operations/IRegisterWorkerOperation.cs
+++ b/source/Octopus.Server.Client/Operations/IRegisterWorkerOperation.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading.Tasks;
-using Octopus.Client.Model;
 
 namespace Octopus.Client.Operations
 {
@@ -12,6 +10,12 @@ namespace Octopus.Client.Operations
         /// <summary>
         /// Gets or sets the worker pools that this machine should be added to.
         /// </summary>
+        [Obsolete($"Use the {nameof(WorkerPools)} property as it supports worker pool names, slugs and Ids.")]
         string[] WorkerPoolNames { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the worker pools that this machine should be added to. These can be worker pool names, slugs or Ids
+        /// </summary>
+        string[] WorkerPools { get; set; }
     }
 }

--- a/source/Octopus.Server.Client/Operations/RegisterKubernetesDeploymentTargetOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterKubernetesDeploymentTargetOperation.cs
@@ -4,14 +4,13 @@ using Octopus.Client.Model.Endpoints;
 
 namespace Octopus.Client.Operations;
 
-[Obsolete($"Use {nameof(RegisterKubernetesDeploymentTargetOperation)} instead.")]
-public class RegisterKubernetesClusterOperation : RegisterMachineOperation, IRegisterKubernetesClusterOperation
+public class RegisterKubernetesDeploymentTargetOperation : RegisterMachineOperation, IRegisterKubernetesClusterOperation
 {
-    public RegisterKubernetesClusterOperation() : this(null)
+    public RegisterKubernetesDeploymentTargetOperation() : this(null)
     {
     }
 
-    public RegisterKubernetesClusterOperation(IOctopusClientFactory clientFactory) : base(clientFactory)
+    public RegisterKubernetesDeploymentTargetOperation(IOctopusClientFactory clientFactory) : base(clientFactory)
     {
     }
 

--- a/source/Octopus.Server.Client/Operations/RegisterKubernetesDeploymentTargetOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterKubernetesDeploymentTargetOperation.cs
@@ -4,7 +4,7 @@ using Octopus.Client.Model.Endpoints;
 
 namespace Octopus.Client.Operations;
 
-public class RegisterKubernetesDeploymentTargetOperation : RegisterMachineOperation, IRegisterKubernetesClusterOperation
+public class RegisterKubernetesDeploymentTargetOperation : RegisterMachineOperation, IRegisterKubernetesDeploymentTargetOperation
 {
     public RegisterKubernetesDeploymentTargetOperation() : this(null)
     {

--- a/source/Octopus.Server.Client/Operations/RegisterKubernetesWorkerOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterKubernetesWorkerOperation.cs
@@ -1,0 +1,35 @@
+using System;
+using Octopus.Client.Model;
+using Octopus.Client.Model.Endpoints;
+
+namespace Octopus.Client.Operations;
+
+public class RegisterKubernetesWorkerOperation : RegisterWorkerOperation, IRegisterKubernetesWorkerOperation
+{
+    public RegisterKubernetesWorkerOperation() : this(null)
+    {
+    }
+
+    public RegisterKubernetesWorkerOperation(IOctopusClientFactory clientFactory) : base(clientFactory)
+    {
+    }
+    
+    protected override void PrepareWorkerForReRegistration(WorkerResource worker, string proxyId)
+    {
+        worker.Endpoint = GenerateEndpoint(proxyId);
+    }
+    
+    protected override EndpointResource GenerateEndpoint(string proxyId)
+    {
+        var endpoint = CommunicationStyle switch
+        {
+            CommunicationStyle.TentaclePassive => new KubernetesTentacleEndpointResource(
+                new ListeningTentacleEndpointConfigurationResource(TentacleThumbprint, GetListeningUri()) { ProxyId = proxyId }),
+            CommunicationStyle.TentacleActive => new KubernetesTentacleEndpointResource(
+                new PollingTentacleEndpointConfigurationResource(TentacleThumbprint, SubscriptionId.ToString())),
+            _ => throw new ArgumentOutOfRangeException(nameof(CommunicationStyle), CommunicationStyle, $"Must be either {CommunicationStyle.TentacleActive} or {CommunicationStyle.TentaclePassive} for this operation")
+        };
+        
+        return endpoint;
+    }
+}

--- a/source/Octopus.Server.Client/Operations/RegisterWorkerOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterWorkerOperation.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
-using Octopus.Client.Model.Endpoints;
 
 namespace Octopus.Client.Operations
 {

--- a/source/Octopus.Server.Client/Operations/RegisterWorkerOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterWorkerOperation.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
+using Octopus.Client.Util;
+using IWorkerPoolRepository = Octopus.Client.Repositories.IWorkerPoolRepository;
+using IAsyncWorkerPoolRepository = Octopus.Client.Repositories.Async.IWorkerPoolRepository;
 
 namespace Octopus.Client.Operations
 {
@@ -48,48 +50,24 @@ namespace Octopus.Client.Operations
         /// </exception>
         public override void Execute(IOctopusSpaceRepository repository)
         {
-            var selectedPools = GetWorkerPools(repository);
-            var machinePolicy = GetMachinePolicy(repository);
-            var machine = GetWorker(repository);
+            var worker = GetWorker(repository);
             var proxy = GetProxy(repository);
 
-            ApplyBaseChanges(machine, machinePolicy, proxy);
-
-            machine.WorkerPoolIds = new ReferenceCollection(selectedPools.Select(p => p.Id).ToArray());
-
-            if (machine.Id != null)
-                repository.Workers.Modify(machine);
+            if (!IsExistingWorker(worker) || AllowOverwrite)
+            {
+                var machinePolicy = GetMachinePolicy(repository);
+                ApplyBaseChanges(worker, machinePolicy, proxy);
+                var selectedPools = GetWorkerPools(repository);
+                worker.WorkerPoolIds = new ReferenceCollection(selectedPools.Select(p => p.Id).ToArray());
+            }
             else
-                repository.Workers.Create(machine);
-        }
-
-        List<WorkerPoolResource> GetWorkerPools(IOctopusSpaceRepository repository)
-        {
-            var selectedPools = repository.WorkerPools.FindByNames(WorkerPoolNames);
-
-            var missing = WorkerPoolNames.Except(selectedPools.Select(p => p.Name), StringComparer.OrdinalIgnoreCase).ToList();
-
-            if (missing.Any())
-                throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("worker pool", missing.ToArray()));
-
-            return selectedPools;
-        }
-
-        WorkerResource GetWorker(IOctopusSpaceRepository repository)
-        {
-            var existing = default(WorkerResource);
-            try
             {
-                existing = repository.Workers.FindByName(MachineName);
-                if (!AllowOverwrite && existing?.Id != null)
-                    throw new InvalidRegistrationArgumentsException($"A worker named '{MachineName}' already exists. Use the 'force' parameter if you intended to update the existing machine.");
+                PrepareWorkerForReRegistration(worker, proxy?.Id);
             }
-            catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
-            {
-            }
-            return existing ?? new WorkerResource();
+            
+            ModifyOrCreateWorker(repository, worker);
         }
-
+        
         /// <summary>
         /// Executes the operation against the specified Octopus Deploy server.
         /// </summary>
@@ -98,20 +76,83 @@ namespace Octopus.Client.Operations
         /// </exception>
         public override async Task ExecuteAsync(IOctopusSpaceAsyncRepository repository)
         {
-            var selectedPools = GetWorkerPools(repository).ConfigureAwait(false);
-            var machinePolicy = GetMachinePolicy(repository).ConfigureAwait(false);
-            var machineTask = GetWorker(repository).ConfigureAwait(false);
-            var proxy = GetProxy(repository).ConfigureAwait(false);
+            var worker = await GetWorker(repository).ConfigureAwait(false);
+            var proxy = await GetProxy(repository).ConfigureAwait(false);
 
-            var machine = await machineTask;
-            ApplyBaseChanges(machine, await machinePolicy, await proxy);
-
-            machine.WorkerPoolIds = new ReferenceCollection((await selectedPools).Select(p => p.Id).ToArray());
-
-            if (machine.Id != null)
-                await repository.Workers.Modify(machine).ConfigureAwait(false);
+            if (!IsExistingWorker(worker) || AllowOverwrite)
+            {
+                var machinePolicy = await GetMachinePolicy(repository).ConfigureAwait(false);
+                ApplyBaseChanges(worker, machinePolicy, proxy);
+                var selectedPools = GetWorkerPools(repository).ConfigureAwait(false);
+                worker.WorkerPoolIds = new ReferenceCollection((await selectedPools).Select(p => p.Id).ToArray());
+            }
             else
-                await repository.Workers.Create(machine).ConfigureAwait(false);
+            {
+                PrepareWorkerForReRegistration(worker, proxy?.Id);
+            }
+
+            await ModifyOrCreateWorker(repository, worker);
+        }
+        
+        static bool IsExistingWorker(WorkerResource worker)
+        {
+            return worker.Id != null;
+        }
+
+        protected virtual void PrepareWorkerForReRegistration(WorkerResource workerResource, string proxyId)
+        {
+            throw new InvalidRegistrationArgumentsException(
+                $"A worker named '{MachineName}' already exists in the environment. Use the 'force' parameter if you intended to update the existing worker.");
+        }
+        
+        WorkerResource GetWorker(IOctopusSpaceRepository repository)
+        {
+            var existing = default(WorkerResource);
+            try
+            {
+                existing = repository.Workers.FindByName(MachineName);
+            }
+            catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
+            {
+            }
+            return existing ?? new WorkerResource();
+        }
+        
+        async Task<WorkerResource> GetWorker(IOctopusSpaceAsyncRepository repository)
+        {
+            var existing = default(WorkerResource);
+            try
+            {
+                existing = await repository.Workers.FindByName(MachineName).ConfigureAwait(false);
+            }
+            catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
+            {
+            }
+            return existing ?? new WorkerResource();
+        }
+        
+        List<WorkerPoolResource> GetWorkerPools(IOctopusSpaceRepository repository)
+        {
+            List<WorkerPoolResource> workerPools = new();
+            if (WorkerPoolNames is not null && WorkerPoolNames.Any())
+            {
+                var workerPoolsByName = repository.WorkerPools.FindByNames(WorkerPoolNames);
+                workerPools.AddRange(workerPoolsByName);
+
+                var missingByNameOnly = WorkerPoolNames.Except(workerPoolsByName.Select(p => p.Name), StringComparer.OrdinalIgnoreCase).ToList();
+
+                if (missingByNameOnly.Any())
+                    throw new InvalidRegistrationArgumentsException(CouldNotFindByNameMessage("worker pool", missingByNameOnly.ToArray()));
+            }
+            
+            if (WorkerPools is not null && WorkerPools.Any())
+            {
+                var workerPoolsByNameIdOrSlug =
+                    repository.WorkerPools.FindByNameIdOrSlugs<WorkerPoolResource, IWorkerPoolRepository>(WorkerPools, missing => CouldNotFindByMultipleMessage("worker pool", missing.ToArray()));
+                workerPools.AddRange(workerPoolsByNameIdOrSlug);
+            }
+            
+            return workerPools;
         }
 
         async Task<List<WorkerPoolResource>> GetWorkerPools(IOctopusSpaceAsyncRepository repository)
@@ -130,50 +171,29 @@ namespace Octopus.Client.Operations
             
             if (WorkerPools is not null && WorkerPools.Any())
             {
-                var workerPoolsByName = await repository.WorkerPools.FindByNames(WorkerPools).ConfigureAwait(false);
-                workerPools.AddRange(workerPoolsByName);
-
-                var missing = WorkerPools
-                    .Except(workerPoolsByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
-                    .ToArray();
-
-                //use the missing names to try and find by slug
-                var workerPoolsBySlug = await repository.WorkerPools.FindBySlugs(missing, CancellationToken.None)
-                    .ConfigureAwait(false);
-                workerPools.AddRange(workerPoolsBySlug);
-
-                missing = missing
-                    .Except(workerPoolsBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
-                    .ToArray();
-
-                //any other missing slugs/names could be Id's, so looks again
-                var workerPoolsByIds = await repository.WorkerPools.Get(missing).ConfigureAwait(false);
-                workerPools.AddRange(workerPoolsByIds);
-
-                missing = missing
-                    .Except(workerPoolsByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
-                    .ToArray();
-
-                if (missing.Any())
-                    throw new InvalidRegistrationArgumentsException(CouldNotFindByMultipleMessage("worker pool", missing.ToArray()));
+                var workerPoolsByNameIdOrSlug =
+                    await repository.WorkerPools.FindByNameIdOrSlugs<WorkerPoolResource, IAsyncWorkerPoolRepository>(
+                        WorkerPools, missing => CouldNotFindByMultipleMessage("worker pool", missing.ToArray()));
+                workerPools.AddRange(workerPoolsByNameIdOrSlug);
             }
             
             return workerPools;
         }
-
-        async Task<WorkerResource> GetWorker(IOctopusSpaceAsyncRepository repository)
+        
+        static void ModifyOrCreateWorker(IOctopusSpaceRepository repository, WorkerResource worker)
         {
-            var existing = default(WorkerResource);
-            try
-            {
-                existing = await repository.Workers.FindByName(MachineName).ConfigureAwait(false);
-                if (!AllowOverwrite && existing?.Id != null)
-                    throw new InvalidRegistrationArgumentsException($"A worker named '{MachineName}' already exists. Use the 'force' parameter if you intended to update the existing machine.");
-            }
-            catch (OctopusDeserializationException) // eat it, probably caused by resource incompatability between versions
-            {
-            }
-            return existing ?? new WorkerResource();
+            if (IsExistingWorker(worker))
+                repository.Workers.Modify(worker);
+            else
+                repository.Workers.Create(worker);
+        }
+        
+        static async Task ModifyOrCreateWorker(IOctopusSpaceAsyncRepository repository, WorkerResource worker)
+        {
+            if (IsExistingWorker(worker))
+                await repository.Workers.Modify(worker);
+            else
+                await repository.Workers.Create(worker);
         }
     }
 }

--- a/source/Octopus.Server.Client/Operations/RegisterWorkerOperation.cs
+++ b/source/Octopus.Server.Client/Operations/RegisterWorkerOperation.cs
@@ -130,7 +130,7 @@ namespace Octopus.Client.Operations
             }
             return existing ?? new WorkerResource();
         }
-        
+
         List<WorkerPoolResource> GetWorkerPools(IOctopusSpaceRepository repository)
         {
             List<WorkerPoolResource> workerPools = new();

--- a/source/Octopus.Server.Client/Repositories/Async/TenantRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/TenantRepository.cs
@@ -7,7 +7,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
-    public interface ITenantRepository : ICreate<TenantResource>, IModify<TenantResource>, IGet<TenantResource>, IDelete<TenantResource>, IFindByName<TenantResource>, IGetAll<TenantResource>, IFindByPartialName<TenantResource>
+    public interface ITenantRepository : IFindBySlug<TenantResource>, ICreate<TenantResource>, IModify<TenantResource>, IGet<TenantResource>, IDelete<TenantResource>, IFindByName<TenantResource>, IGetAll<TenantResource>, IFindByPartialName<TenantResource>
     {
         Task<MultiTenancyStatusResource> Status();
         Task SetLogo(TenantResource tenant, string fileName, Stream contents);

--- a/source/Octopus.Server.Client/Repositories/Async/WorkerPoolRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/WorkerPoolRepository.cs
@@ -6,7 +6,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories.Async
 {
-    public interface IWorkerPoolRepository : IFindByName<WorkerPoolResource>, IGet<WorkerPoolResource>, ICreate<WorkerPoolResource>, IModify<WorkerPoolResource>, IDelete<WorkerPoolResource>, IGetAll<WorkerPoolResource>
+    public interface IWorkerPoolRepository : IFindBySlug<WorkerPoolResource>, IFindByName<WorkerPoolResource>, IGet<WorkerPoolResource>, ICreate<WorkerPoolResource>, IModify<WorkerPoolResource>, IDelete<WorkerPoolResource>, IGetAll<WorkerPoolResource>
     {
         Task<List<WorkerResource>> GetMachines(WorkerPoolResource workerPool,
             int? skip = 0,

--- a/source/Octopus.Server.Client/Repositories/WorkerPoolRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/WorkerPoolRepository.cs
@@ -4,7 +4,7 @@ using Octopus.Client.Model;
 
 namespace Octopus.Client.Repositories
 {
-    public interface IWorkerPoolRepository : IFindByName<WorkerPoolResource>, IGet<WorkerPoolResource>, ICreate<WorkerPoolResource>, IModify<WorkerPoolResource>, IDelete<WorkerPoolResource>, IGetAll<WorkerPoolResource>
+    public interface IWorkerPoolRepository : IFindBySlug<WorkerPoolResource>, IFindByName<WorkerPoolResource>, IGet<WorkerPoolResource>, ICreate<WorkerPoolResource>, IModify<WorkerPoolResource>, IDelete<WorkerPoolResource>, IGetAll<WorkerPoolResource>
     {
         List<WorkerResource> GetMachines(WorkerPoolResource workerPool,
             int? skip = 0,

--- a/source/Octopus.Server.Client/Util/AsyncRepositoryExtensions.cs
+++ b/source/Octopus.Server.Client/Util/AsyncRepositoryExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Operations;
+using Octopus.Client.Repositories.Async;
+
+namespace Octopus.Client.Util;
+
+internal static class AsyncRepositoryExtensions
+{
+    public static async Task<List<TResource>> FindByNameIdOrSlugs<TResource, TRepository>(this TRepository repository,
+        string[] searchIdentifiers, Func<string[], string> exceptionMessageGenerator = null)
+        where TRepository : IFindBySlug<TResource>, IFindByName<TResource>, IGet<TResource>
+        where TResource : IResource, INamedResource, IHaveSlugResource
+    {
+        List<TResource> resources = new();
+
+        var resourcesByName = await repository.FindByNames(searchIdentifiers).ConfigureAwait(false);
+        resources.AddRange(resourcesByName);
+
+        var missing = searchIdentifiers
+            .Except(resourcesByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        // use the missing names to try and find by slug
+        var resourcesBySlug = await repository.FindBySlugs(missing, CancellationToken.None)
+            .ConfigureAwait(false);
+        resources.AddRange(resourcesBySlug);
+
+        missing = missing
+            .Except(resourcesBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        // any other missing slugs/names could be Id's, so look again
+        var resourcesByIds = await repository.Get(missing).ConfigureAwait(false);
+        resources.AddRange(resourcesByIds);
+
+        missing = missing
+            .Except(resourcesByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (missing.Any())
+            throw new InvalidRegistrationArgumentsException(exceptionMessageGenerator is not null
+                ? exceptionMessageGenerator(missing)
+                : $"Failed to find the following: {string.Join(", ", missing)}");
+
+        return resources;
+    }
+}

--- a/source/Octopus.Server.Client/Util/RepositoryExtensions.cs
+++ b/source/Octopus.Server.Client/Util/RepositoryExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Octopus.Client.Extensibility;
+using Octopus.Client.Model;
+using Octopus.Client.Operations;
+using Octopus.Client.Repositories;
+
+namespace Octopus.Client.Util;
+
+internal static class RepositoryExtensions
+{
+    public static List<TResource> FindByNameIdOrSlugs<TResource, TRepository>(this TRepository repository,
+        string[] searchIdentifiers, Func<string[], string> exceptionMessageGenerator = null)
+        where TRepository : IFindBySlug<TResource>, IFindByName<TResource>, IGet<TResource>
+        where TResource : IResource, INamedResource, IHaveSlugResource
+    {
+        List<TResource> resources = new();
+
+        var resourcesByName = repository.FindByNames(searchIdentifiers);
+        resources.AddRange(resourcesByName);
+
+        var missing = searchIdentifiers
+            .Except(resourcesByName.Select(e => e.Name), StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        // use the missing names to try and find by slug
+        var resourcesBySlug = repository.FindBySlugs(missing);
+        resources.AddRange(resourcesBySlug);
+
+        missing = missing
+            .Except(resourcesBySlug.Select(e => e.Slug), StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        // any other missing slugs/names could be Id's, so look again
+        var resourcesByIds = repository.Get(missing);
+        resources.AddRange(resourcesByIds);
+
+        missing = missing
+            .Except(resourcesByIds.Select(e => e.Id), StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (missing.Any())
+            throw new InvalidRegistrationArgumentsException(exceptionMessageGenerator is not null
+                ? exceptionMessageGenerator(missing)
+                : $"Failed to find the following: {string.Join(", ", missing)}");
+
+        return resources;
+    }
+}


### PR DESCRIPTION
## Background

We would like to support running the Kubernetes Agent as a worker. To do this, Tentacle must have a way to call the worker registration API of Octopus Server. It communicates with Server via Octopus.Client Operations, which act as an abstraction over the API library.

### Associated PRs
- [Helm chart](https://github.com/OctopusDeploy/helm-charts/pull/196)
- [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/pull/969)

[sc-82021]

## Result

- Introduces an `IRegisterKubernetesWorkerOperation`
- Deprecates the existing `IRegisterKubernetesClusterOperation` and rebrands it as `IRegisterKubernetesDeploymentTargetOperation` as we want to be clear in the distinction between the two (the functionality is still the same)