### PR TITLE
Add SpaceId to MachineResource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3744,6 +3744,7 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Extensibility.INamedResource
     Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
     Octopus.Client.Model.Resource
   {
     String Architecture { get; set; }
@@ -3759,6 +3760,7 @@ Octopus.Client.Model
     String ShellVersion { get; set; }
     Boolean SkipInitialHealthCheck { get; set; }
     String Slug { get; set; }
+    String SpaceId { get; set; }
     Octopus.Client.Model.MachineModelStatus Status { get; set; }
     String StatusSummary { get; set; }
     String Thumbprint { get; set; }
@@ -3865,6 +3867,7 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Extensibility.INamedResource
     Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
     Octopus.Client.Model.MachineBasedResource
   {
     .ctor()
@@ -6029,7 +6032,6 @@ Octopus.Client.Model
     Octopus.Client.Model.MachineBasedResource
   {
     .ctor()
-    String SpaceId { get; set; }
     Octopus.Client.Model.ReferenceCollection WorkerPoolIds { get; set; }
     Octopus.Client.Model.WorkerResource AddOrUpdateWorkerPools(Octopus.Client.Model.WorkerPoolResource[])
     Octopus.Client.Model.WorkerResource ClearWorkerPools()

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3761,6 +3761,7 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Extensibility.INamedResource
     Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
     Octopus.Client.Model.Resource
   {
     String Architecture { get; set; }
@@ -3776,6 +3777,7 @@ Octopus.Client.Model
     String ShellVersion { get; set; }
     Boolean SkipInitialHealthCheck { get; set; }
     String Slug { get; set; }
+    String SpaceId { get; set; }
     Octopus.Client.Model.MachineModelStatus Status { get; set; }
     String StatusSummary { get; set; }
     String Thumbprint { get; set; }
@@ -3882,6 +3884,7 @@ Octopus.Client.Model
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Extensibility.INamedResource
     Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
     Octopus.Client.Model.MachineBasedResource
   {
     .ctor()
@@ -6052,7 +6055,6 @@ Octopus.Client.Model
     Octopus.Client.Model.MachineBasedResource
   {
     .ctor()
-    String SpaceId { get; set; }
     Octopus.Client.Model.ReferenceCollection WorkerPoolIds { get; set; }
     Octopus.Client.Model.WorkerResource AddOrUpdateWorkerPools(Octopus.Client.Model.WorkerPoolResource[])
     Octopus.Client.Model.WorkerResource ClearWorkerPools()

--- a/source/Octopus.Server.Client/Model/MachineBasedResource.cs
+++ b/source/Octopus.Server.Client/Model/MachineBasedResource.cs
@@ -4,11 +4,13 @@ using Octopus.Client.Model.Endpoints;
 
 namespace Octopus.Client.Model
 {
-    public abstract class MachineBasedResource : Resource, INamedResource, IHaveSlugResource
+    public abstract class MachineBasedResource : Resource, INamedResource, IHaveSlugResource, IHaveSpaceResource
     {
         [Trim]
         [Writeable]
         public string Name { get; set; }
+        
+        public string SpaceId { get; set; }
 
         /// <summary>
         /// Obsoleted as Server 3.4

--- a/source/Octopus.Server.Client/Model/WorkerResource.cs
+++ b/source/Octopus.Server.Client/Model/WorkerResource.cs
@@ -35,7 +35,5 @@ namespace Octopus.Client.Model
             WorkerPoolIds.Clear();
             return this;
         }
-
-        public string SpaceId { get; set; }
     }
 }


### PR DESCRIPTION
For some reason `MachineResource` was missing `SpaceId` which could lead to an error where machines would be added to the default space instead of the one specified.