### PR TITLE
Add target tag permissions

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4340,6 +4340,8 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission TagSetCreate
     static Octopus.Client.Model.Permission TagSetDelete
     static Octopus.Client.Model.Permission TagSetEdit
+    static Octopus.Client.Model.Permission TargetTagAdminister
+    static Octopus.Client.Model.Permission TargetTagView
     static Octopus.Client.Model.Permission TaskCancel
     static Octopus.Client.Model.Permission TaskCreate
     static Octopus.Client.Model.Permission TaskEdit

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4360,6 +4360,8 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission TagSetCreate
     static Octopus.Client.Model.Permission TagSetDelete
     static Octopus.Client.Model.Permission TagSetEdit
+    static Octopus.Client.Model.Permission TargetTagAdminister
+    static Octopus.Client.Model.Permission TargetTagView
     static Octopus.Client.Model.Permission TaskCancel
     static Octopus.Client.Model.Permission TaskCreate
     static Octopus.Client.Model.Permission TaskEdit

--- a/source/Octopus.Server.Client/Model/Permission.cs
+++ b/source/Octopus.Server.Client/Model/Permission.cs
@@ -271,6 +271,11 @@ namespace Octopus.Client.Model
         [Description("Delete Insights reports")] public static readonly Permission InsightsReportDelete = new("InsightsReportDelete");
 
         [Description("Create, update, delete and override deployment freezes")] public static readonly Permission DeploymentFreezeAdminister = new("DeploymentFreezeAdminister");
+        
+        [Description("View deployment target tags")] public static readonly Permission TargetTagView = new("TargetTagView");
+        
+        [Description("Create, edit, delete deployment target tags")] public static readonly Permission TargetTagAdminister = new("TargetTagAdminister");
+        
         public Permission(string id)
         {
             Id = id;


### PR DESCRIPTION
Adds permissions required to view/edit deployment targets tags.

Related to https://github.com/OctopusDeploy/OctopusDeploy/pull/24387