### PR TITLE
Make ProjectResource.AllowIgnoreChannelRules nullable

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4566,7 +4566,7 @@ Octopus.Client.Model
   {
     .ctor()
     .ctor(String, String, String)
-    Boolean AllowIgnoreChannelRules { get; set; }
+    Nullable<Boolean> AllowIgnoreChannelRules { get; set; }
     Boolean AutoCreateRelease { get; set; }
     ISet<AutoDeployReleaseOverrideResource> AutoDeployReleaseOverrides { get; }
     String ClonedFromProjectId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4586,7 +4586,7 @@ Octopus.Client.Model
   {
     .ctor()
     .ctor(String, String, String)
-    Boolean AllowIgnoreChannelRules { get; set; }
+    Nullable<Boolean> AllowIgnoreChannelRules { get; set; }
     Boolean AutoCreateRelease { get; set; }
     ISet<AutoDeployReleaseOverrideResource> AutoDeployReleaseOverrides { get; }
     String ClonedFromProjectId { get; set; }

--- a/source/Octopus.Server.Client/Model/ProjectResource.cs
+++ b/source/Octopus.Server.Client/Model/ProjectResource.cs
@@ -131,7 +131,7 @@ namespace Octopus.Client.Model
         public bool ForcePackageDownload { get; set; }
 
         [Writeable]
-        public bool AllowIgnoreChannelRules { get; set;}
+        public bool? AllowIgnoreChannelRules { get; set;}
         
         [Writeable]
         public bool? ExecuteDeploymentsOnResilientPipeline { get; set;}


### PR DESCRIPTION
https://github.com/OctopusDeploy/OctopusClients/pull/859 introduced ProjectResource.AllowIgnoreChannelRules. This is an optional new field to allow users enable or disable bypassing of channel version rules (they are currently always able to be bypassed)

This feature is currently in early preview and all existing projects have this value set to true. If no value is provided in an API call, the value is not changed. If users update to this new version of the client and don't provide a value, the client will send false which may change the existing value.

To reduce the risk of existing users bringing in this unexpectedly changing the existing value, we're making this field nullable. We may change this again in the future, but this will be some other breaking change down the line.