### PR TITLE
Add support for multiple Git dependencies

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5224,6 +5224,7 @@ Octopus.Client.Model
     .ctor(String, Octopus.Client.Model.Git.GitReferenceResource)
     String ActionName { get; set; }
     Octopus.Client.Model.Git.GitReferenceResource GitReferenceResource { get; set; }
+    String GitResourceReferenceName { get; set; }
   }
   class SelectedPackage
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5243,6 +5243,7 @@ Octopus.Client.Model
     .ctor(String, Octopus.Client.Model.Git.GitReferenceResource)
     String ActionName { get; set; }
     Octopus.Client.Model.Git.GitReferenceResource GitReferenceResource { get; set; }
+    String GitResourceReferenceName { get; set; }
   }
   class SelectedPackage
   {

--- a/source/Octopus.Server.Client/Model/GitDependencyResource.cs
+++ b/source/Octopus.Server.Client/Model/GitDependencyResource.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Octopus.Client.Model;
 
@@ -24,6 +26,7 @@ public class GitDependencyResource
         FilePathFilters = filePathFilters ?? Array.Empty<string>();
         Name = name ?? string.Empty;
         StepPackageInputsReferenceId = stepPackageInputsReferenceId;
+        Properties = new Dictionary<string, string>();
     }
 
     public string Name { get; }
@@ -33,4 +36,15 @@ public class GitDependencyResource
     public string GitCredentialType { get; }
     public string? GitCredentialId { get; }
     public string? StepPackageInputsReferenceId { get; set; }
+    
+    [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]
+    public IDictionary<string, string> Properties { get; private set; }
+    
+    public GitDependencyResource Clone()
+    {
+        return new GitDependencyResource(RepositoryUri, DefaultBranch, GitCredentialType, GitCredentialId, FilePathFilters, Name, StepPackageInputsReferenceId)
+        {
+            Properties = new Dictionary<string, string>(Properties)
+        };
+    }
 }

--- a/source/Octopus.Server.Client/Model/GitDependencyResource.cs
+++ b/source/Octopus.Server.Client/Model/GitDependencyResource.cs
@@ -1,7 +1,5 @@
 ﻿#nullable enable
 using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Octopus.Client.Model;
 

--- a/source/Octopus.Server.Client/Model/GitDependencyResource.cs
+++ b/source/Octopus.Server.Client/Model/GitDependencyResource.cs
@@ -26,7 +26,6 @@ public class GitDependencyResource
         FilePathFilters = filePathFilters ?? Array.Empty<string>();
         Name = name ?? string.Empty;
         StepPackageInputsReferenceId = stepPackageInputsReferenceId;
-        Properties = new Dictionary<string, string>();
     }
 
     public string Name { get; }
@@ -36,15 +35,4 @@ public class GitDependencyResource
     public string GitCredentialType { get; }
     public string? GitCredentialId { get; }
     public string? StepPackageInputsReferenceId { get; set; }
-    
-    [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]
-    public IDictionary<string, string> Properties { get; private set; }
-    
-    public GitDependencyResource Clone()
-    {
-        return new GitDependencyResource(RepositoryUri, DefaultBranch, GitCredentialType, GitCredentialId, FilePathFilters, Name, StepPackageInputsReferenceId)
-        {
-            Properties = new Dictionary<string, string>(Properties)
-        };
-    }
 }

--- a/source/Octopus.Server.Client/Model/SelectedGitResource.cs
+++ b/source/Octopus.Server.Client/Model/SelectedGitResource.cs
@@ -25,4 +25,10 @@ public class SelectedGitResource
     /// The selected Git reference
     /// </summary>
     public GitReferenceResource GitReferenceResource { get; set; }
+    
+    /// <summary>
+    /// The name of the Git resource reference
+    /// </summary>
+    /// <remarks>May be empty for steps which have a primary Git resource</remarks>
+    public string GitResourceReferenceName { get; set; } = "";
 }


### PR DESCRIPTION
We're adding support for non-primary Git dependencies: this PR adds client support for it.

The `GitResourceReferenceName` indicates whether or not it's a primary resource: no name makes it primary, specifying a name makes it non-primary.

See the equivalent property for Packages here: 
https://github.com/OctopusDeploy/OctopusClients/blob/f6d191220b086ebdc4c2684ed8e1296c790fffca/source/Octopus.Server.Client/Model/SelectedPackage.cs#L45