### PR TITLE
Add Runbooks are in Git to the Projects Conversion state

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3314,6 +3314,7 @@ Octopus.Client.Model
   class GitPersistenceSettingsConversionStateResource
   {
     .ctor()
+    Boolean RunbooksAreInGit { get; set; }
     Boolean VariablesAreInGit { get; set; }
   }
   class GitPersistenceSettingsResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3331,6 +3331,7 @@ Octopus.Client.Model
   class GitPersistenceSettingsConversionStateResource
   {
     .ctor()
+    Boolean RunbooksAreInGit { get; set; }
     Boolean VariablesAreInGit { get; set; }
   }
   class GitPersistenceSettingsResource

--- a/source/Octopus.Server.Client/Model/PersistenceSettings.cs
+++ b/source/Octopus.Server.Client/Model/PersistenceSettings.cs
@@ -42,5 +42,7 @@ namespace Octopus.Client.Model
     public class GitPersistenceSettingsConversionStateResource
     {
         public bool VariablesAreInGit { get; set; }
+        
+        public bool RunbooksAreInGit { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
 This change added the RunbooksAreInGit property to the conversion state of projects.
 
## The Change
As part of Project Git Runbooks we are currently updating the RunbookBuilder and RunbookProcessBuilder in the Octopus Deploy integration test library. The change to the builders will allow us  to quickly create Runbook test data, without needing to manually craft OCL. This change facilitates the builder being able to determine if it should be  an existing DB Runbook, or one of the new Git Runbooks.