### PR TITLE
Add Version to PackageReference

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4219,6 +4219,7 @@ Octopus.Client.Model
     String PackageId { get; set; }
     IDictionary<String, String> Properties { get; }
     String StepPackageInputsReferenceId { get; set; }
+    String Version { get; set; }
     Octopus.Client.Model.PackageReference Clone()
   }
   class PackageReferenceCollection

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4239,6 +4239,7 @@ Octopus.Client.Model
     String PackageId { get; set; }
     IDictionary<String, String> Properties { get; }
     String StepPackageInputsReferenceId { get; set; }
+    String Version { get; set; }
     Octopus.Client.Model.PackageReference Clone()
   }
   class PackageReferenceCollection

--- a/source/Octopus.Server.Client/Model/PackageReference.cs
+++ b/source/Octopus.Server.Client/Model/PackageReference.cs
@@ -123,6 +123,12 @@ namespace Octopus.Client.Model
         public string AcquisitionLocation { get; set; }
 
         /// <summary>
+        ///    Specific version to use for this package. If not set, package can be 
+        ///    selected at release creation or runbook run time.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
         /// This reference identifier is populated when a step package step contains a package reference
         /// It allows us to correlate the reference within the step package inputs to this Server package reference
         /// </summary>


### PR DESCRIPTION
We are adding support for setting package versions on a step in both deployment and Runbook processes. This adds this new field to the `PackageReference`. This feature is not available yet - any values set before the feature is enabled on your instance will be retained, but will be ignored when creating releases or running Runbooks.