### PR TITLE
Replace OctopusRepositoryExtensions with methods that reuse RootResource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -89,6 +89,8 @@ Octopus.Client
     Octopus.Client.IOctopusCommonAsyncRepository
     Octopus.Client.IOctopusSystemAsyncRepository
   {
+    Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
+    Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
   }
   interface IOctopusClient
     IDisposable
@@ -168,6 +170,8 @@ Octopus.Client
     Octopus.Client.IOctopusCommonRepository
     Octopus.Client.IOctopusSystemRepository
   {
+    Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
+    Octopus.Client.IOctopusSystemRepository ForSystem()
   }
   interface IOctopusSpaceAsyncRepository
     Octopus.Client.IOctopusCommonAsyncRepository
@@ -440,6 +444,8 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IVariableSetRepository VariableSets { get; }
     Octopus.Client.Repositories.Async.IWorkerPoolRepository WorkerPools { get; }
     Octopus.Client.Repositories.Async.IWorkerRepository Workers { get; }
+    Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
+    Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
     Task<Boolean> HasLink(String)
     Task<Boolean> HasLinkParameter(String, String)
     Task<String> Link(String)
@@ -582,6 +588,8 @@ Octopus.Client
     Octopus.Client.Repositories.IVariableSetRepository VariableSets { get; }
     Octopus.Client.Repositories.IWorkerPoolRepository WorkerPools { get; }
     Octopus.Client.Repositories.IWorkerRepository Workers { get; }
+    Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
+    Octopus.Client.IOctopusSystemRepository ForSystem()
     Boolean HasLink(String)
     Boolean HasLinkParameter(String, String)
     String Link(String)
@@ -591,10 +599,6 @@ Octopus.Client
   abstract class OctopusRepositoryExtensions
   {
     static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
-    static Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.IOctopusAsyncRepository, Octopus.Client.Model.SpaceResource)
-    static Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.IOctopusRepository, Octopus.Client.Model.SpaceResource)
-    static Octopus.Client.IOctopusSystemAsyncRepository ForSystem(Octopus.Client.IOctopusAsyncRepository)
-    static Octopus.Client.IOctopusSystemRepository ForSystem(Octopus.Client.IOctopusRepository)
   }
   class OctopusRequest
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -89,6 +89,8 @@ Octopus.Client
     Octopus.Client.IOctopusCommonAsyncRepository
     Octopus.Client.IOctopusSystemAsyncRepository
   {
+    Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
+    Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
   }
   interface IOctopusClient
     IDisposable
@@ -168,6 +170,8 @@ Octopus.Client
     Octopus.Client.IOctopusCommonRepository
     Octopus.Client.IOctopusSystemRepository
   {
+    Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
+    Octopus.Client.IOctopusSystemRepository ForSystem()
   }
   interface IOctopusSpaceAsyncRepository
     Octopus.Client.IOctopusCommonAsyncRepository
@@ -440,6 +444,8 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IVariableSetRepository VariableSets { get; }
     Octopus.Client.Repositories.Async.IWorkerPoolRepository WorkerPools { get; }
     Octopus.Client.Repositories.Async.IWorkerRepository Workers { get; }
+    Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.Model.SpaceResource)
+    Octopus.Client.IOctopusSystemAsyncRepository ForSystem()
     Task<Boolean> HasLink(String)
     Task<Boolean> HasLinkParameter(String, String)
     Task<String> Link(String)
@@ -580,6 +586,8 @@ Octopus.Client
     Octopus.Client.Repositories.IVariableSetRepository VariableSets { get; }
     Octopus.Client.Repositories.IWorkerPoolRepository WorkerPools { get; }
     Octopus.Client.Repositories.IWorkerRepository Workers { get; }
+    Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.Model.SpaceResource)
+    Octopus.Client.IOctopusSystemRepository ForSystem()
     Boolean HasLink(String)
     Boolean HasLinkParameter(String, String)
     String Link(String)
@@ -589,10 +597,6 @@ Octopus.Client
   abstract class OctopusRepositoryExtensions
   {
     static Octopus.Client.IOctopusAsyncRepository CreateRepository(Octopus.Client.IOctopusAsyncClient, Octopus.Client.RepositoryScope)
-    static Octopus.Client.IOctopusSpaceAsyncRepository ForSpace(Octopus.Client.IOctopusAsyncRepository, Octopus.Client.Model.SpaceResource)
-    static Octopus.Client.IOctopusSpaceRepository ForSpace(Octopus.Client.IOctopusRepository, Octopus.Client.Model.SpaceResource)
-    static Octopus.Client.IOctopusSystemAsyncRepository ForSystem(Octopus.Client.IOctopusAsyncRepository)
-    static Octopus.Client.IOctopusSystemRepository ForSystem(Octopus.Client.IOctopusRepository)
   }
   class OctopusRequest
   {

--- a/source/Octopus.Server.Client/IOctopusAsyncRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusAsyncRepository.cs
@@ -1,5 +1,4 @@
-using System.Threading.Tasks;
-using Octopus.Client.Repositories.Async;
+using Octopus.Client.Model;
 
 namespace Octopus.Client
 {
@@ -10,5 +9,7 @@ namespace Octopus.Client
     /// </summary>
     public interface IOctopusAsyncRepository: IOctopusSpaceAsyncRepository, IOctopusSystemAsyncRepository
     {
+        IOctopusSpaceAsyncRepository ForSpace(SpaceResource space);
+        IOctopusSystemAsyncRepository ForSystem();
     }
 }

--- a/source/Octopus.Server.Client/IOctopusRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusRepository.cs
@@ -1,3 +1,5 @@
+using Octopus.Client.Model;
+
 namespace Octopus.Client
 {
     /// <summary>
@@ -7,5 +9,7 @@ namespace Octopus.Client
     /// </summary>
     public interface IOctopusRepository: IOctopusSpaceRepository, IOctopusSystemRepository
     {
+        IOctopusSpaceRepository ForSpace(SpaceResource space);
+        IOctopusSystemRepository ForSystem();
     }
 }


### PR DESCRIPTION
`IOctopusAsyncRepository` and `IOctopusRepository` have extension methods `ForSpace` and `ForSystem` which return a new repository with a different scope. This had the unintended consequence of discarding a cached `RootResource` if the repository had one, meaning the repository with the changed scope will have to do a fresh HTTP request to `/api` to get the root resource that could potentially have been avoided.

This PR replaces these extension methods with methods on the repository themselves, which call a new constructor that is able to keep track of the cached `RootResource` if there was one, solving this problem.

While I would expect most consumers to be unaffected by this change, it is technically a breaking change for certain niche scenarios. A few examples:

* a consumer had declared their own `ForSpace`/`ForSystem` extension methods, but now method resolution prefers the actual instance methods over those extension methods; solvable via renaming the extension method(s) to avoid the conflict
* a consumer created a class that inherits from a repository that was declaring its own `ForSpace`/`ForSystem` method(s); these now must specify the `override` keyword
* a consumer created a custom class that implements `IOctopus(Async)Repository`; now they have two new methods to implement themselves

As such, I will bump the major version here with `+semver: breaking`.