### PR TITLE
Change HttpRouteExtractor access modifier to public to match interface

### DIFF
--- a/source/Octopus.Server.Client/HttpRouting/HttpRouteExtractor.cs
+++ b/source/Octopus.Server.Client/HttpRouting/HttpRouteExtractor.cs
@@ -17,7 +17,7 @@ using HttpMethod = System.Net.Http.HttpMethod;
 
 namespace Octopus.Client.HttpRouting
 {
-    internal class HttpRouteExtractor : IHttpRouteExtractor
+    public class HttpRouteExtractor : IHttpRouteExtractor
     {
         private static readonly Regex TokensRegex = new Regex("({.+?})",
             RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);


### PR DESCRIPTION
`OctopusAsyncClient` takes an `IHttpRouteExtractor` in its constructor, but the default implementation `HttpRouteExtractor` is not public.

Changing this class to public makes any inheritance of `OctopusAsyncClient` (and `HttpRouteExtractor` itself) much simpler.