### PR TITLE
Change HttpRouteExtractor access modifier to public to match interface

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -1630,6 +1630,15 @@ Octopus.Client.Extensions
 }
 Octopus.Client.HttpRouting
 {
+  class HttpRouteExtractor
+    Octopus.Client.HttpRouting.IHttpRouteExtractor
+  {
+    .ctor(Func<Type[]>)
+    HttpMethod ExtractHttpMethod(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>)
+    HttpMethod ExtractHttpMethod(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>)
+    Uri ExtractHttpRoute(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>)
+    Uri ExtractHttpRoute(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>)
+  }
   interface IHttpRouteExtractor
   {
     HttpMethod ExtractHttpMethod(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -1645,6 +1645,15 @@ Octopus.Client.Extensions
 }
 Octopus.Client.HttpRouting
 {
+  class HttpRouteExtractor
+    Octopus.Client.HttpRouting.IHttpRouteExtractor
+  {
+    .ctor(Func<Type[]>)
+    HttpMethod ExtractHttpMethod(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>)
+    HttpMethod ExtractHttpMethod(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>)
+    Uri ExtractHttpRoute(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>)
+    Uri ExtractHttpRoute(Octopus.Server.MessageContracts.Base.IRequest<TRequest, TResponse>)
+  }
   interface IHttpRouteExtractor
   {
     HttpMethod ExtractHttpMethod(Octopus.Server.MessageContracts.Base.ICommand<TCommand, TResponse>)

--- a/source/Octopus.Server.Client/HttpRouting/HttpRouteExtractor.cs
+++ b/source/Octopus.Server.Client/HttpRouting/HttpRouteExtractor.cs
@@ -17,7 +17,7 @@ using HttpMethod = System.Net.Http.HttpMethod;
 
 namespace Octopus.Client.HttpRouting
 {
-    internal class HttpRouteExtractor : IHttpRouteExtractor
+    public class HttpRouteExtractor : IHttpRouteExtractor
     {
         private static readonly Regex TokensRegex = new Regex("({.+?})",
             RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);


### PR DESCRIPTION
`OctopusAsyncClient` takes an `IHttpRouteExtractor` in its constructor, but the default implementation `HttpRouteExtractor` is not public.

Changing this class to public makes any inheritance of `OctopusAsyncClient` (and `HttpRouteExtractor` itself) much simpler.

Clones https://github.com/OctopusDeploy/OctopusClients/pull/871

[sc-91741]