### PR TITLE
Update account usage resource to include tenant variables

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6391,7 +6391,7 @@ Octopus.Client.Model.Accounts.Usages
   class CommonTenantVariableUsage
   {
     .ctor()
-    List<CommonTenantVariableUsageEntry> LibraryVariableSets { get; set; }
+    ICollection<CommonTenantVariableUsageEntry> LibraryVariableSets { get; set; }
     String TenantId { get; set; }
   }
   class CommonTenantVariableUsageEntry
@@ -6409,14 +6409,14 @@ Octopus.Client.Model.Accounts.Usages
   class ProjectTenantVariableUsage
   {
     .ctor()
-    List<ProjectTenantVariableEntry> Projects { get; set; }
+    ICollection<ProjectTenantVariableEntry> Projects { get; set; }
     String TenantId { get; set; }
   }
   class ProjectTenantVariableEntry
   {
     .ctor()
     String ProjectId { get; set; }
-    List<String> TenantVariableIds { get; set; }
+    ICollection<String> TenantVariableIds { get; set; }
   }
   class ProjectVariableSetUsage
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6406,17 +6406,17 @@ Octopus.Client.Model.Accounts.Usages
     String LibraryVariableSetId { get; set; }
     String LibraryVariableSetName { get; set; }
   }
-  class ProjectTenantVariableUsage
-  {
-    .ctor()
-    ICollection<ProjectTenantVariableEntry> Projects { get; set; }
-    String TenantId { get; set; }
-  }
   class ProjectTenantVariableEntry
   {
     .ctor()
     String ProjectId { get; set; }
     ICollection<String> TenantVariableIds { get; set; }
+  }
+  class ProjectTenantVariableUsage
+  {
+    .ctor()
+    ICollection<ProjectTenantVariableEntry> Projects { get; set; }
+    String ProjectId { get; set; }
   }
   class ProjectVariableSetUsage
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6378,19 +6378,45 @@ Octopus.Client.Model.Accounts.Usages
     Octopus.Client.Model.Resource
   {
     .ctor()
+    ICollection<CommonTenantVariableUsage> CommonTenantVariables { get; set; }
     ICollection<StepUsage> DeploymentProcesses { get; set; }
     ICollection<LibraryVariableSetUsageEntry> LibraryVariableSets { get; set; }
+    ICollection<ProjectTenantVariableUsage> ProjectTenantVariables { get; set; }
     ICollection<ProjectVariableSetUsage> ProjectVariableSets { get; set; }
     ICollection<ReleaseUsage> Releases { get; set; }
     ICollection<RunbookStepUsage> RunbookProcesses { get; set; }
     ICollection<RunbookSnapshotUsage> RunbookSnapshots { get; set; }
     ICollection<TargetUsageEntry> Targets { get; set; }
   }
+  class CommonTenantVariableUsage
+  {
+    .ctor()
+    List<CommonTenantVariableUsageEntry> LibraryVariableSets { get; set; }
+    String TenantId { get; set; }
+  }
+  class CommonTenantVariableUsageEntry
+  {
+    .ctor()
+    String LibraryVariableSetId { get; set; }
+    String TenantVariableId { get; set; }
+  }
   class LibraryVariableSetUsageEntry
   {
     .ctor()
     String LibraryVariableSetId { get; set; }
     String LibraryVariableSetName { get; set; }
+  }
+  class ProjectTenantVariableUsage
+  {
+    .ctor()
+    List<ProjectTenantVariableEntry> Projects { get; set; }
+    String TenantId { get; set; }
+  }
+  class ProjectTenantVariableEntry
+  {
+    .ctor()
+    String ProjectId { get; set; }
+    List<String> TenantVariableIds { get; set; }
   }
   class ProjectVariableSetUsage
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6416,7 +6416,7 @@ Octopus.Client.Model.Accounts.Usages
   {
     .ctor()
     ICollection<ProjectTenantVariableEntry> Projects { get; set; }
-    String ProjectId { get; set; }
+    String TenantId { get; set; }
   }
   class ProjectVariableSetUsage
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6415,7 +6415,7 @@ Octopus.Client.Model.Accounts.Usages
   class CommonTenantVariableUsage
   {
     .ctor()
-    List<CommonTenantVariableUsageEntry> LibraryVariableSets { get; set; }
+    ICollection<CommonTenantVariableUsageEntry> LibraryVariableSets { get; set; }
     String TenantId { get; set; }
   }
   class CommonTenantVariableUsageEntry
@@ -6433,14 +6433,14 @@ Octopus.Client.Model.Accounts.Usages
   class ProjectTenantVariableUsage
   {
     .ctor()
-    List<ProjectTenantVariableEntry> Projects { get; set; }
+    ICollection<ProjectTenantVariableEntry> Projects { get; set; }
     String TenantId { get; set; }
   }
   class ProjectTenantVariableEntry
   {
     .ctor()
     String ProjectId { get; set; }
-    List<String> TenantVariableIds { get; set; }
+    ICollection<String> TenantVariableIds { get; set; }
   }
   class ProjectVariableSetUsage
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6430,17 +6430,17 @@ Octopus.Client.Model.Accounts.Usages
     String LibraryVariableSetId { get; set; }
     String LibraryVariableSetName { get; set; }
   }
+   class ProjectTenantVariableEntry
+  {
+    .ctor()
+    String ProjectId { get; set; }
+    ICollection<String> TenantVariableIds { get; set; }
+  }
   class ProjectTenantVariableUsage
   {
     .ctor()
     ICollection<ProjectTenantVariableEntry> Projects { get; set; }
     String TenantId { get; set; }
-  }
-  class ProjectTenantVariableEntry
-  {
-    .ctor()
-    String ProjectId { get; set; }
-    ICollection<String> TenantVariableIds { get; set; }
   }
   class ProjectVariableSetUsage
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6430,7 +6430,7 @@ Octopus.Client.Model.Accounts.Usages
     String LibraryVariableSetId { get; set; }
     String LibraryVariableSetName { get; set; }
   }
-   class ProjectTenantVariableEntry
+  class ProjectTenantVariableEntry
   {
     .ctor()
     String ProjectId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6402,19 +6402,45 @@ Octopus.Client.Model.Accounts.Usages
     Octopus.Client.Model.Resource
   {
     .ctor()
+    ICollection<CommonTenantVariableUsage> CommonTenantVariables { get; set; }
     ICollection<StepUsage> DeploymentProcesses { get; set; }
     ICollection<LibraryVariableSetUsageEntry> LibraryVariableSets { get; set; }
+    ICollection<ProjectTenantVariableUsage> ProjectTenantVariables { get; set; }
     ICollection<ProjectVariableSetUsage> ProjectVariableSets { get; set; }
     ICollection<ReleaseUsage> Releases { get; set; }
     ICollection<RunbookStepUsage> RunbookProcesses { get; set; }
     ICollection<RunbookSnapshotUsage> RunbookSnapshots { get; set; }
     ICollection<TargetUsageEntry> Targets { get; set; }
   }
+  class CommonTenantVariableUsage
+  {
+    .ctor()
+    List<CommonTenantVariableUsageEntry> LibraryVariableSets { get; set; }
+    String TenantId { get; set; }
+  }
+  class CommonTenantVariableUsageEntry
+  {
+    .ctor()
+    String LibraryVariableSetId { get; set; }
+    String TenantVariableId { get; set; }
+  }
   class LibraryVariableSetUsageEntry
   {
     .ctor()
     String LibraryVariableSetId { get; set; }
     String LibraryVariableSetName { get; set; }
+  }
+  class ProjectTenantVariableUsage
+  {
+    .ctor()
+    List<ProjectTenantVariableEntry> Projects { get; set; }
+    String TenantId { get; set; }
+  }
+  class ProjectTenantVariableEntry
+  {
+    .ctor()
+    String ProjectId { get; set; }
+    List<String> TenantVariableIds { get; set; }
   }
   class ProjectVariableSetUsage
   {

--- a/source/Octopus.Server.Client/Model/Accounts/Usages/AccountUsageResource.cs
+++ b/source/Octopus.Server.Client/Model/Accounts/Usages/AccountUsageResource.cs
@@ -14,6 +14,8 @@ namespace Octopus.Client.Model.Accounts.Usages
             LibraryVariableSets = new List<LibraryVariableSetUsageEntry>();
             RunbookProcesses = new List<RunbookStepUsage>();
             RunbookSnapshots = new List<RunbookSnapshotUsage>();
+            ProjectTenantVariables = new List<ProjectTenantVariableUsage>();
+            CommonTenantVariables = new List<CommonTenantVariableUsage>();
         }
 
         public ICollection<TargetUsageEntry> Targets { get; set; }
@@ -23,6 +25,8 @@ namespace Octopus.Client.Model.Accounts.Usages
         public ICollection<LibraryVariableSetUsageEntry> LibraryVariableSets { get; set; }
         public ICollection<RunbookStepUsage> RunbookProcesses { get; set; }
         public ICollection<RunbookSnapshotUsage> RunbookSnapshots { get; set; }
+        public ICollection<ProjectTenantVariableUsage> ProjectTenantVariables { get; set; }
+        public ICollection<CommonTenantVariableUsage> CommonTenantVariables { get; set; }
     }
 
     public class StepUsageBase
@@ -118,5 +122,42 @@ namespace Octopus.Client.Model.Accounts.Usages
     {
         public string SnapshotId { get; set; }
         public string SnapshotName { get; set; }
+    }
+    
+    public class ProjectTenantVariableUsage
+    {
+        public ProjectTenantVariableUsage()
+        {
+            Projects = new List<ProjectTenantVariableEntry>();
+        }
+        public string TenantId { get; set; }
+        public ICollection<ProjectTenantVariableEntry> Projects { get; set; }
+    }
+    
+    public class ProjectTenantVariableEntry
+    {
+        public ProjectTenantVariableEntry()
+        {
+            TenantVariableIds = new List<string>();
+        }
+        public string ProjectId { get; set; }
+        public ICollection<string> TenantVariableIds { get; set; }
+    }
+    
+    public class CommonTenantVariableUsage
+    {
+        public CommonTenantVariableUsage()
+        {
+            LibraryVariableSets = new List<CommonTenantVariableUsageEntry>();
+        }
+        public string TenantId { get; set; }
+        public ICollection<CommonTenantVariableUsageEntry> LibraryVariableSets { get; set; }
+        
+    }
+    
+    public class CommonTenantVariableUsageEntry
+    {
+        public string LibraryVariableSetId { get; set; }
+        public string TenantVariableId { get; set; }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/OctopusDeploy/Issues/issues/5890

https://github.com/OctopusDeploy/OctopusDeploy/pull/28543 Updates the Account Usage Resource to include `ProjectTenantVariables` and `CommonTenantVariables`

The Octopus Client needs to also be updates to match for the OctopusClientVersusServerResources Tests.