### PR TITLE
Add prioritize task permission

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4349,6 +4349,7 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission MachinePolicyEdit
     static Octopus.Client.Model.Permission MachinePolicyView
     static Octopus.Client.Model.Permission MachineView
+    static Octopus.Client.Model.Permission PrioritizeTask
     static Octopus.Client.Model.Permission ProcessEdit
     static Octopus.Client.Model.Permission ProcessView
     static Octopus.Client.Model.Permission ProjectCreate

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -4349,7 +4349,6 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission MachinePolicyEdit
     static Octopus.Client.Model.Permission MachinePolicyView
     static Octopus.Client.Model.Permission MachineView
-    static Octopus.Client.Model.Permission PrioritizeTask
     static Octopus.Client.Model.Permission ProcessEdit
     static Octopus.Client.Model.Permission ProcessView
     static Octopus.Client.Model.Permission ProjectCreate
@@ -4389,6 +4388,7 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission TaskCancel
     static Octopus.Client.Model.Permission TaskCreate
     static Octopus.Client.Model.Permission TaskEdit
+    static Octopus.Client.Model.Permission TaskPrioritize
     static Octopus.Client.Model.Permission TaskView
     static Octopus.Client.Model.Permission TaskViewLog
     static Octopus.Client.Model.Permission TeamCreate

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4369,6 +4369,7 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission MachinePolicyEdit
     static Octopus.Client.Model.Permission MachinePolicyView
     static Octopus.Client.Model.Permission MachineView
+    static Octopus.Client.Model.Permission PrioritizeTask
     static Octopus.Client.Model.Permission ProcessEdit
     static Octopus.Client.Model.Permission ProcessView
     static Octopus.Client.Model.Permission ProjectCreate

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -4369,7 +4369,6 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission MachinePolicyEdit
     static Octopus.Client.Model.Permission MachinePolicyView
     static Octopus.Client.Model.Permission MachineView
-    static Octopus.Client.Model.Permission PrioritizeTask
     static Octopus.Client.Model.Permission ProcessEdit
     static Octopus.Client.Model.Permission ProcessView
     static Octopus.Client.Model.Permission ProjectCreate
@@ -4409,6 +4408,7 @@ Octopus.Client.Model
     static Octopus.Client.Model.Permission TaskCancel
     static Octopus.Client.Model.Permission TaskCreate
     static Octopus.Client.Model.Permission TaskEdit
+    static Octopus.Client.Model.Permission TaskPrioritize
     static Octopus.Client.Model.Permission TaskView
     static Octopus.Client.Model.Permission TaskViewLog
     static Octopus.Client.Model.Permission TeamCreate

--- a/source/Octopus.Server.Client/Model/Permission.cs
+++ b/source/Octopus.Server.Client/Model/Permission.cs
@@ -127,6 +127,7 @@ namespace Octopus.Client.Model
 
         [Description("Edit server tasks")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants)] public static readonly Permission TaskEdit = new Permission("TaskEdit");
 
+        [Description("Create deployments that are prioritized")] public static readonly Permission TaskPrioritize = new("TaskPrioritize");
 
         [Description("View interruptions generated during deployments")] [SupportsRestriction(PermissionScope.Projects, PermissionScope.Environments, PermissionScope.Tenants, ExplicitTenantScopeRequired = true)] public static readonly Permission InterruptionView = new Permission("InterruptionView");
 
@@ -275,8 +276,6 @@ namespace Octopus.Client.Model
         [Description("View deployment target tags")] public static readonly Permission TargetTagView = new("TargetTagView");
         
         [Description("Create, edit, delete deployment target tags")] public static readonly Permission TargetTagAdminister = new("TargetTagAdminister");
-
-        [Description("Create deployments and runbooks that are prioritized")] public static readonly Permission PrioritizeTask = new("PrioritizeTask");
         
         public Permission(string id)
         {

--- a/source/Octopus.Server.Client/Model/Permission.cs
+++ b/source/Octopus.Server.Client/Model/Permission.cs
@@ -275,6 +275,8 @@ namespace Octopus.Client.Model
         [Description("View deployment target tags")] public static readonly Permission TargetTagView = new("TargetTagView");
         
         [Description("Create, edit, delete deployment target tags")] public static readonly Permission TargetTagAdminister = new("TargetTagAdminister");
+
+        [Description("Create deployments and runbooks that are prioritized")] public static readonly Permission PrioritizeTask = new("PrioritizeTask");
         
         public Permission(string id)
         {


### PR DESCRIPTION
Adds `PrioritizeTask` permission to control who can create prioritized deployments.