### PR TITLE
Upgrade artifact actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -136,7 +136,7 @@ jobs:
           fail-on-error: true
 
       - name: Upload NuGet package artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OctoClientsNuget
           path: ./artifacts/*.nupkg
@@ -245,7 +245,7 @@ jobs:
     needs: [ build, test-linux, test-macos ]
     steps:
       - name: Download nuget package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: OctoClientsNuget
           path: ./artifacts/


### PR DESCRIPTION
[sc-96974]

GitHub are deprecating v3 of the `upload-artifact` and `download-artifact` actions.
This PR upgrades those actions to v4.

None of the breaking changes affect this repo.

[Deprecation notice: v3 of the artifact actions - GitHub Changelog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)