### PR TITLE
Adds Generic OIDC accounts

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -814,6 +814,13 @@ Octopus.Client.Editors
     Octopus.Client.Editors.EnvironmentEditor Customize(Action<EnvironmentResource>)
     Octopus.Client.Editors.EnvironmentEditor Save()
   }
+  class GenericOidcAccountEditor
+    Octopus.Client.Editors.IResourceEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+    Octopus.Client.Editors.IResourceBuilder
+    Octopus.Client.Editors.AccountEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+  {
+    .ctor(Octopus.Client.Repositories.IAccountRepository)
+  }
   interface IResourceBuilder
   {
   }
@@ -1177,6 +1184,13 @@ Octopus.Client.Editors.Async
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Octopus.Client.Editors.Async.EnvironmentEditor Customize(Action<EnvironmentResource>)
     Task<EnvironmentEditor> Save()
+  }
+  class GenericOidcAccountEditor
+    Octopus.Client.Editors.Async.IResourceEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+    Octopus.Client.Editors.Async.IResourceBuilder
+    Octopus.Client.Editors.Async.AccountEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+  {
+    .ctor(Octopus.Client.Repositories.Async.IAccountRepository)
   }
   interface IResourceBuilder
   {
@@ -6025,6 +6039,7 @@ Octopus.Client.Model
       AzureAccount = 4
       WorkerPool = 5
       UsernamePasswordAccount = 6
+      GenericOidcAccount = 7
   }
   class VersioningStrategyResource
   {
@@ -6125,6 +6140,7 @@ Octopus.Client.Model.Accounts
       Token = 7
       GoogleCloudAccount = 8
       AzureOidc = 9
+      GenericOidcAccount = 10
   }
   class AmazonWebServicesAccountResource
     Octopus.Client.Extensibility.IResource
@@ -6257,6 +6273,21 @@ Octopus.Client.Model.Accounts
       String ResourceGroupName { get; set; }
       String Site { get; set; }
     }
+  }
+  class GenericOidcAccountResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Model.Accounts.AccountResource
+  {
+    .ctor()
+    String[] AccountTestSubjectKeys { get; set; }
+    Octopus.Client.Model.Accounts.AccountType AccountType { get; }
+    String Audience { get; set; }
+    String[] DeploymentSubjectKeys { get; set; }
+    String[] HealthCheckSubjectKeys { get; set; }
   }
   class GoogleCloudAccountResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -6283,11 +6283,9 @@ Octopus.Client.Model.Accounts
     Octopus.Client.Model.Accounts.AccountResource
   {
     .ctor()
-    String[] AccountTestSubjectKeys { get; set; }
     Octopus.Client.Model.Accounts.AccountType AccountType { get; }
     String Audience { get; set; }
     String[] DeploymentSubjectKeys { get; set; }
-    String[] HealthCheckSubjectKeys { get; set; }
   }
   class GoogleCloudAccountResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -815,6 +815,13 @@ Octopus.Client.Editors
     Octopus.Client.Editors.EnvironmentEditor Customize(Action<EnvironmentResource>)
     Octopus.Client.Editors.EnvironmentEditor Save()
   }
+  class GenericOidcAccountEditor
+    Octopus.Client.Editors.IResourceEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+    Octopus.Client.Editors.IResourceBuilder
+    Octopus.Client.Editors.AccountEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+  {
+    .ctor(Octopus.Client.Repositories.IAccountRepository)
+  }
   interface IResourceBuilder
   {
   }
@@ -1178,6 +1185,13 @@ Octopus.Client.Editors.Async
     Task<EnvironmentEditor> CreateOrModify(String, String)
     Octopus.Client.Editors.Async.EnvironmentEditor Customize(Action<EnvironmentResource>)
     Task<EnvironmentEditor> Save()
+  }
+  class GenericOidcAccountEditor
+    Octopus.Client.Editors.Async.IResourceEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+    Octopus.Client.Editors.Async.IResourceBuilder
+    Octopus.Client.Editors.Async.AccountEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+  {
+    .ctor(Octopus.Client.Repositories.Async.IAccountRepository)
   }
   interface IResourceBuilder
   {
@@ -6048,6 +6062,7 @@ Octopus.Client.Model
       AzureAccount = 4
       WorkerPool = 5
       UsernamePasswordAccount = 6
+      GenericOidcAccount = 7
   }
   class VersioningStrategyResource
   {
@@ -6148,6 +6163,7 @@ Octopus.Client.Model.Accounts
       Token = 7
       GoogleCloudAccount = 8
       AzureOidc = 9
+      GenericOidcAccount = 10
   }
   class AmazonWebServicesAccountResource
     Octopus.Client.Extensibility.IResource
@@ -6280,6 +6296,21 @@ Octopus.Client.Model.Accounts
       String ResourceGroupName { get; set; }
       String Site { get; set; }
     }
+  }
+  class GenericOidcAccountResource
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Model.Accounts.AccountResource
+  {
+    .ctor()
+    String[] AccountTestSubjectKeys { get; set; }
+    Octopus.Client.Model.Accounts.AccountType AccountType { get; }
+    String Audience { get; set; }
+    String[] DeploymentSubjectKeys { get; set; }
+    String[] HealthCheckSubjectKeys { get; set; }
   }
   class GoogleCloudAccountResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -6306,11 +6306,9 @@ Octopus.Client.Model.Accounts
     Octopus.Client.Model.Accounts.AccountResource
   {
     .ctor()
-    String[] AccountTestSubjectKeys { get; set; }
     Octopus.Client.Model.Accounts.AccountType AccountType { get; }
     String Audience { get; set; }
     String[] DeploymentSubjectKeys { get; set; }
-    String[] HealthCheckSubjectKeys { get; set; }
   }
   class GoogleCloudAccountResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Server.Client/Editors/Async/GenericOidcAccountEditor.cs
+++ b/source/Octopus.Server.Client/Editors/Async/GenericOidcAccountEditor.cs
@@ -1,0 +1,12 @@
+﻿using Octopus.Client.Model.Accounts;
+using Octopus.Client.Repositories.Async;
+
+namespace Octopus.Client.Editors.Async
+{
+    public class GenericOidcAccountEditor : AccountEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+    {
+        public GenericOidcAccountEditor(IAccountRepository repository) : base(repository)
+        {
+        }
+    }
+}

--- a/source/Octopus.Server.Client/Editors/GenericOidcAccountEditor.cs
+++ b/source/Octopus.Server.Client/Editors/GenericOidcAccountEditor.cs
@@ -1,0 +1,12 @@
+﻿using Octopus.Client.Model.Accounts;
+using Octopus.Client.Repositories;
+
+namespace Octopus.Client.Editors
+{
+    public class GenericOidcAccountEditor : AccountEditor<GenericOidcAccountResource, GenericOidcAccountEditor>
+    {
+        public GenericOidcAccountEditor(IAccountRepository repository) : base(repository)
+        {
+        }
+    }
+}

--- a/source/Octopus.Server.Client/Extensions/TypeExtensions.cs
+++ b/source/Octopus.Server.Client/Extensions/TypeExtensions.cs
@@ -30,6 +30,8 @@ namespace Octopus.Client.Extensions
                 accountType = AccountType.Token;
             else if (type == typeof(GoogleCloudAccountResource))
                 accountType = AccountType.GoogleCloudAccount;
+            else if (type == typeof(GenericOidcAccountResource))
+                accountType = AccountType.GenericOidcAccount;
             else
                 throw new ArgumentException($"Account type {type} is not supported");
 

--- a/source/Octopus.Server.Client/Model/Accounts/AccountType.cs
+++ b/source/Octopus.Server.Client/Model/Accounts/AccountType.cs
@@ -14,5 +14,6 @@ namespace Octopus.Client.Model.Accounts
         Token,
         GoogleCloudAccount,
         AzureOidc,
+        GenericOidcAccount,
     }
 }

--- a/source/Octopus.Server.Client/Model/Accounts/GenericOidcAccountResource.cs
+++ b/source/Octopus.Server.Client/Model/Accounts/GenericOidcAccountResource.cs
@@ -13,11 +13,5 @@ namespace Octopus.Client.Model.Accounts
 
         [Writeable]
         public string[] DeploymentSubjectKeys { get; set; }
-
-        [Writeable]
-        public string[] HealthCheckSubjectKeys { get; set; }
-
-        [Writeable]
-        public string[] AccountTestSubjectKeys { get; set; }
     }
 }

--- a/source/Octopus.Server.Client/Model/Accounts/GenericOidcAccountResource.cs
+++ b/source/Octopus.Server.Client/Model/Accounts/GenericOidcAccountResource.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Octopus.Client.Extensibility.Attributes;
+
+namespace Octopus.Client.Model.Accounts
+{
+    public class GenericOidcAccountResource : AccountResource
+    {
+        public override AccountType AccountType => AccountType.GenericOidcAccount;
+
+        [Trim]
+        [Writeable]
+        public string Audience { get; set; }
+
+        [Writeable]
+        public string[] DeploymentSubjectKeys { get; set; }
+
+        [Writeable]
+        public string[] HealthCheckSubjectKeys { get; set; }
+
+        [Writeable]
+        public string[] AccountTestSubjectKeys { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/VariableType.cs
+++ b/source/Octopus.Server.Client/Model/VariableType.cs
@@ -8,6 +8,7 @@
         AmazonWebServicesAccount,
         AzureAccount,
         WorkerPool,
-        UsernamePasswordAccount
+        UsernamePasswordAccount,
+        GenericOidcAccount
     }
 }

--- a/source/Octopus.Server.Client/Serialization/AccountConverter.cs
+++ b/source/Octopus.Server.Client/Serialization/AccountConverter.cs
@@ -16,7 +16,8 @@ namespace Octopus.Client.Serialization
                 {AccountType.SshKeyPair, typeof(SshKeyPairAccountResource)},
                 {AccountType.AmazonWebServicesAccount, typeof(AmazonWebServicesAccountResource)},
                 {AccountType.Token, typeof(TokenAccountResource)},
-                {AccountType.GoogleCloudAccount, typeof(GoogleCloudAccountResource)}
+                {AccountType.GoogleCloudAccount, typeof(GoogleCloudAccountResource)},
+                {AccountType.GenericOidcAccount, typeof(GenericOidcAccountResource)}
             };
 
         protected override IDictionary<AccountType, Type> DerivedTypeMappings => AccountTypeMappings;


### PR DESCRIPTION
This change adds support for generic Oidc accounts to the client for [#project-generic-oidc](https://octopusdeploy.slack.com/archives/C081K9EPXT9)