### PR TITLE
Add debug property to runbookruns deployments and execution resource

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2865,7 +2865,6 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -2876,6 +2875,7 @@ Octopus.Client.Model
     Boolean ForcePackageDownload { get; set; }
     Boolean ForcePackageRedeployment { get; set; }
     Dictionary<String, String> FormValues { get; set; }
+    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String Priority { get; set; }
@@ -3475,7 +3475,6 @@ Octopus.Client.Model
   {
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -3484,6 +3483,7 @@ Octopus.Client.Model
     Boolean FailureEncountered { get; }
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
+    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String ProjectId { get; set; }
@@ -5008,12 +5008,12 @@ Octopus.Client.Model
   class RunbookRunParameters
   {
     .ctor()
-    Nullable<Boolean> Debug { get; set; }
     String EnvironmentId { get; set; }
     String[] EnvironmentIds { get; set; }
     String[] ExcludedMachineIds { get; set; }
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
+    Nullable<Boolean> IsDebugEnabled { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
@@ -5045,7 +5045,6 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -5055,6 +5054,7 @@ Octopus.Client.Model
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
     String FrozenRunbookProcessId { get; set; }
+    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String ProjectId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2865,6 +2865,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -3474,6 +3475,7 @@ Octopus.Client.Model
   {
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -5006,6 +5008,7 @@ Octopus.Client.Model
   class RunbookRunParameters
   {
     .ctor()
+    Nullable<Boolean> Debug { get; set; }
     String EnvironmentId { get; set; }
     String[] EnvironmentIds { get; set; }
     String[] ExcludedMachineIds { get; set; }
@@ -5042,6 +5045,7 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2675,11 +2675,11 @@ Octopus.Client.Model
     Object ReadJson(JsonReader, Type, Object, JsonSerializer)
     void WriteJson(JsonWriter, Object, JsonSerializer)
   }
-  DebugMode
+  abstract class DebugMode
   {
-      None = 0
-      Log = 1
-      Debug = 2
+    static System.String Debug
+    static System.String Log
+    static System.String None
   }
   class Defect
   {
@@ -2871,7 +2871,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Octopus.Client.Model.DebugMode DebugMode { get; set; }
+    String DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -3496,7 +3496,7 @@ Octopus.Client.Model
   {
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Octopus.Client.Model.DebugMode DebugMode { get; set; }
+    String DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -5057,7 +5057,7 @@ Octopus.Client.Model
   class RunbookRunParameters
   {
     .ctor()
-    Nullable<DebugMode> DebugMode { get; set; }
+    String DebugMode { get; set; }
     String EnvironmentId { get; set; }
     String[] EnvironmentIds { get; set; }
     String[] ExcludedMachineIds { get; set; }
@@ -5106,7 +5106,7 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Octopus.Client.Model.DebugMode DebugMode { get; set; }
+    String DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2675,6 +2675,12 @@ Octopus.Client.Model
     Object ReadJson(JsonReader, Type, Object, JsonSerializer)
     void WriteJson(JsonWriter, Object, JsonSerializer)
   }
+  DebugMode
+  {
+      None = 0
+      Log = 1
+      Debug = 2
+  }
   class Defect
   {
     .ctor()
@@ -2865,6 +2871,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Octopus.Client.Model.DebugMode DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -2875,7 +2882,6 @@ Octopus.Client.Model
     Boolean ForcePackageDownload { get; set; }
     Boolean ForcePackageRedeployment { get; set; }
     Dictionary<String, String> FormValues { get; set; }
-    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String Priority { get; set; }
@@ -3475,6 +3481,7 @@ Octopus.Client.Model
   {
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Octopus.Client.Model.DebugMode DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -3483,7 +3490,6 @@ Octopus.Client.Model
     Boolean FailureEncountered { get; }
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
-    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String ProjectId { get; set; }
@@ -5008,12 +5014,12 @@ Octopus.Client.Model
   class RunbookRunParameters
   {
     .ctor()
+    Nullable<DebugMode> DebugMode { get; set; }
     String EnvironmentId { get; set; }
     String[] EnvironmentIds { get; set; }
     String[] ExcludedMachineIds { get; set; }
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
-    Nullable<Boolean> IsDebugEnabled { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
@@ -5045,6 +5051,7 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Octopus.Client.Model.DebugMode DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -5054,7 +5061,6 @@ Octopus.Client.Model
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
     String FrozenRunbookProcessId { get; set; }
-    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String ProjectId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2692,11 +2692,11 @@ Octopus.Client.Model
     Object ReadJson(JsonReader, Type, Object, JsonSerializer)
     void WriteJson(JsonWriter, Object, JsonSerializer)
   }
-  DebugMode
+  abstract class DebugMode
   {
-      None = 0
-      Log = 1
-      Debug = 2
+    static System.String Debug
+    static System.String Log
+    static System.String None
   }
   class Defect
   {
@@ -2888,7 +2888,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Octopus.Client.Model.DebugMode DebugMode { get; set; }
+    String DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -3513,7 +3513,7 @@ Octopus.Client.Model
   {
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Octopus.Client.Model.DebugMode DebugMode { get; set; }
+    String DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -5076,7 +5076,7 @@ Octopus.Client.Model
   class RunbookRunParameters
   {
     .ctor()
-    Nullable<DebugMode> DebugMode { get; set; }
+    String DebugMode { get; set; }
     String EnvironmentId { get; set; }
     String[] EnvironmentIds { get; set; }
     String[] ExcludedMachineIds { get; set; }
@@ -5125,7 +5125,7 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Octopus.Client.Model.DebugMode DebugMode { get; set; }
+    String DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2692,6 +2692,12 @@ Octopus.Client.Model
     Object ReadJson(JsonReader, Type, Object, JsonSerializer)
     void WriteJson(JsonWriter, Object, JsonSerializer)
   }
+  DebugMode
+  {
+      None = 0
+      Log = 1
+      Debug = 2
+  }
   class Defect
   {
     .ctor()
@@ -2882,6 +2888,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Octopus.Client.Model.DebugMode DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -2892,7 +2899,6 @@ Octopus.Client.Model
     Boolean ForcePackageDownload { get; set; }
     Boolean ForcePackageRedeployment { get; set; }
     Dictionary<String, String> FormValues { get; set; }
-    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String Priority { get; set; }
@@ -3492,6 +3498,7 @@ Octopus.Client.Model
   {
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Octopus.Client.Model.DebugMode DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -3500,7 +3507,6 @@ Octopus.Client.Model
     Boolean FailureEncountered { get; }
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
-    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String ProjectId { get; set; }
@@ -5027,12 +5033,12 @@ Octopus.Client.Model
   class RunbookRunParameters
   {
     .ctor()
+    Nullable<DebugMode> DebugMode { get; set; }
     String EnvironmentId { get; set; }
     String[] EnvironmentIds { get; set; }
     String[] ExcludedMachineIds { get; set; }
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
-    Nullable<Boolean> IsDebugEnabled { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
@@ -5064,6 +5070,7 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Octopus.Client.Model.DebugMode DebugMode { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -5073,7 +5080,6 @@ Octopus.Client.Model
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
     String FrozenRunbookProcessId { get; set; }
-    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String ProjectId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2882,6 +2882,7 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -3491,6 +3492,7 @@ Octopus.Client.Model
   {
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -5025,6 +5027,7 @@ Octopus.Client.Model
   class RunbookRunParameters
   {
     .ctor()
+    Nullable<Boolean> Debug { get; set; }
     String EnvironmentId { get; set; }
     String[] EnvironmentIds { get; set; }
     String[] ExcludedMachineIds { get; set; }
@@ -5061,6 +5064,7 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
+    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2882,7 +2882,6 @@ Octopus.Client.Model
     String ChannelId { get; set; }
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -2893,6 +2892,7 @@ Octopus.Client.Model
     Boolean ForcePackageDownload { get; set; }
     Boolean ForcePackageRedeployment { get; set; }
     Dictionary<String, String> FormValues { get; set; }
+    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String Priority { get; set; }
@@ -3492,7 +3492,6 @@ Octopus.Client.Model
   {
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -3501,6 +3500,7 @@ Octopus.Client.Model
     Boolean FailureEncountered { get; }
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
+    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String ProjectId { get; set; }
@@ -5027,12 +5027,12 @@ Octopus.Client.Model
   class RunbookRunParameters
   {
     .ctor()
-    Nullable<Boolean> Debug { get; set; }
     String EnvironmentId { get; set; }
     String[] EnvironmentIds { get; set; }
     String[] ExcludedMachineIds { get; set; }
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
+    Nullable<Boolean> IsDebugEnabled { get; set; }
     String ProjectId { get; set; }
     Nullable<DateTimeOffset> QueueTime { get; set; }
     Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
@@ -5064,7 +5064,6 @@ Octopus.Client.Model
     .ctor()
     String Comments { get; set; }
     DateTimeOffset Created { get; set; }
-    Boolean Debug { get; set; }
     String DeployedBy { get; set; }
     String DeployedById { get; set; }
     Octopus.Client.Model.ReferenceCollection DeployedToMachineIds { get; set; }
@@ -5074,6 +5073,7 @@ Octopus.Client.Model
     Boolean ForcePackageDownload { get; set; }
     Dictionary<String, String> FormValues { get; set; }
     String FrozenRunbookProcessId { get; set; }
+    Boolean IsDebugEnabled { get; set; }
     String ManifestVariableSetId { get; set; }
     String Name { get; set; }
     String ProjectId { get; set; }

--- a/source/Octopus.Server.Client/Model/DebugMode.cs
+++ b/source/Octopus.Server.Client/Model/DebugMode.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace Octopus.Client.Model
 {
-    public enum DebugMode
+    public static class DebugMode
     {
-        None = 0,
-        Log = 1,
-        Debug = 2,
+        public static readonly string None = "None";
+        public static readonly string Log = "Log";
+        public static readonly string Debug = "Debug";
     }
 }

--- a/source/Octopus.Server.Client/Model/DebugMode.cs
+++ b/source/Octopus.Server.Client/Model/DebugMode.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Octopus.Client.Model
+{
+    public enum DebugMode
+    {
+        None = 0,
+        Log = 1,
+        Debug = 2,
+    }
+}

--- a/source/Octopus.Server.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentResource.cs
@@ -76,7 +76,7 @@ namespace Octopus.Client.Model
         /// When enabled sets the OctopusPrintVariables and OctopusPrintEvaluatedVariables variables to the runbook run
         /// </summary>
         [WriteableOnCreate]
-        public bool Debug { get; set; }
+        public bool IsDebugEnabled { get; set; }
 
         /// <summary>
         /// One of the values from <see cref="DeploymentPriority"/>

--- a/source/Octopus.Server.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentResource.cs
@@ -76,7 +76,7 @@ namespace Octopus.Client.Model
         /// When enabled sets the OctopusPrintVariables and OctopusPrintEvaluatedVariables variables to the runbook run
         /// </summary>
         [WriteableOnCreate]
-        public bool IsDebugEnabled { get; set; }
+        public DebugMode DebugMode { get; set; }
 
         /// <summary>
         /// One of the values from <see cref="DeploymentPriority"/>

--- a/source/Octopus.Server.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentResource.cs
@@ -76,7 +76,7 @@ namespace Octopus.Client.Model
         /// When enabled sets the OctopusPrintVariables and OctopusPrintEvaluatedVariables variables to the runbook run
         /// </summary>
         [WriteableOnCreate]
-        public DebugMode DebugMode { get; set; }
+        public string DebugMode { get; set; }
 
         /// <summary>
         /// One of the values from <see cref="DeploymentPriority"/>

--- a/source/Octopus.Server.Client/Model/DeploymentResource.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentResource.cs
@@ -71,6 +71,12 @@ namespace Octopus.Client.Model
         /// </summary>
         [WriteableOnCreate]
         public bool UseGuidedFailure { get; set; }
+        
+        /// <summary>
+        /// When enabled sets the OctopusPrintVariables and OctopusPrintEvaluatedVariables variables to the runbook run
+        /// </summary>
+        [WriteableOnCreate]
+        public bool Debug { get; set; }
 
         /// <summary>
         /// One of the values from <see cref="DeploymentPriority"/>

--- a/source/Octopus.Server.Client/Model/IExecutionResource.cs
+++ b/source/Octopus.Server.Client/Model/IExecutionResource.cs
@@ -14,7 +14,7 @@ namespace Octopus.Client.Model
         ReferenceCollection SpecificMachineIds { get; set; }
         ReferenceCollection ExcludedMachineIds { get; set; }
         bool UseGuidedFailure { get; set; }
-        DebugMode DebugMode { get; set; }
+        string DebugMode { get; set; }
         RetentionPeriod TentacleRetentionPeriod { get; set; }
         string EnvironmentId { get; set; }
         string TenantId { get; set; }

--- a/source/Octopus.Server.Client/Model/IExecutionResource.cs
+++ b/source/Octopus.Server.Client/Model/IExecutionResource.cs
@@ -14,6 +14,7 @@ namespace Octopus.Client.Model
         ReferenceCollection SpecificMachineIds { get; set; }
         ReferenceCollection ExcludedMachineIds { get; set; }
         bool UseGuidedFailure { get; set; }
+        bool Debug { get; set; }
         RetentionPeriod TentacleRetentionPeriod { get; set; }
         string EnvironmentId { get; set; }
         string TenantId { get; set; }

--- a/source/Octopus.Server.Client/Model/IExecutionResource.cs
+++ b/source/Octopus.Server.Client/Model/IExecutionResource.cs
@@ -14,7 +14,7 @@ namespace Octopus.Client.Model
         ReferenceCollection SpecificMachineIds { get; set; }
         ReferenceCollection ExcludedMachineIds { get; set; }
         bool UseGuidedFailure { get; set; }
-        bool Debug { get; set; }
+        bool IsDebugEnabled { get; set; }
         RetentionPeriod TentacleRetentionPeriod { get; set; }
         string EnvironmentId { get; set; }
         string TenantId { get; set; }

--- a/source/Octopus.Server.Client/Model/IExecutionResource.cs
+++ b/source/Octopus.Server.Client/Model/IExecutionResource.cs
@@ -14,7 +14,7 @@ namespace Octopus.Client.Model
         ReferenceCollection SpecificMachineIds { get; set; }
         ReferenceCollection ExcludedMachineIds { get; set; }
         bool UseGuidedFailure { get; set; }
-        bool IsDebugEnabled { get; set; }
+        DebugMode DebugMode { get; set; }
         RetentionPeriod TentacleRetentionPeriod { get; set; }
         string EnvironmentId { get; set; }
         string TenantId { get; set; }

--- a/source/Octopus.Server.Client/Model/RunbookRunParameters.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunParameters.cs
@@ -30,7 +30,7 @@ namespace Octopus.Client.Model
         public string[] EnvironmentIds { get; set; }
         public bool ForcePackageDownload { get; set; }
         public bool? UseGuidedFailure { get; set; }
-        public bool? Debug { get; set; }
+        public bool? IsDebugEnabled { get; set; }
         public string[] SpecificMachineIds { get; set; }
         public string[] ExcludedMachineIds { get; set; }
         public string TenantId { get; set; }
@@ -51,7 +51,7 @@ namespace Octopus.Client.Model
                 EnvironmentId = runbookRun.EnvironmentId,
                 ForcePackageDownload = runbookRun.ForcePackageDownload,
                 UseGuidedFailure = runbookRun.UseGuidedFailure,
-                Debug = runbookRun.Debug,
+                IsDebugEnabled = runbookRun.IsDebugEnabled,
                 SpecificMachineIds = runbookRun.SpecificMachineIds != null ? runbookRun.SpecificMachineIds.ToArray() : new string[0],
                 ExcludedMachineIds = runbookRun.ExcludedMachineIds != null ? runbookRun.ExcludedMachineIds.ToArray() : new string[0],
                 TenantId = runbookRun.TenantId,

--- a/source/Octopus.Server.Client/Model/RunbookRunParameters.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunParameters.cs
@@ -30,6 +30,7 @@ namespace Octopus.Client.Model
         public string[] EnvironmentIds { get; set; }
         public bool ForcePackageDownload { get; set; }
         public bool? UseGuidedFailure { get; set; }
+        public bool? Debug { get; set; }
         public string[] SpecificMachineIds { get; set; }
         public string[] ExcludedMachineIds { get; set; }
         public string TenantId { get; set; }
@@ -50,6 +51,7 @@ namespace Octopus.Client.Model
                 EnvironmentId = runbookRun.EnvironmentId,
                 ForcePackageDownload = runbookRun.ForcePackageDownload,
                 UseGuidedFailure = runbookRun.UseGuidedFailure,
+                Debug = runbookRun.Debug,
                 SpecificMachineIds = runbookRun.SpecificMachineIds != null ? runbookRun.SpecificMachineIds.ToArray() : new string[0],
                 ExcludedMachineIds = runbookRun.ExcludedMachineIds != null ? runbookRun.ExcludedMachineIds.ToArray() : new string[0],
                 TenantId = runbookRun.TenantId,

--- a/source/Octopus.Server.Client/Model/RunbookRunParameters.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunParameters.cs
@@ -30,7 +30,7 @@ namespace Octopus.Client.Model
         public string[] EnvironmentIds { get; set; }
         public bool ForcePackageDownload { get; set; }
         public bool? UseGuidedFailure { get; set; }
-        public DebugMode? DebugMode { get; set; }
+        public string DebugMode { get; set; }
         public string[] SpecificMachineIds { get; set; }
         public string[] ExcludedMachineIds { get; set; }
         public string TenantId { get; set; }

--- a/source/Octopus.Server.Client/Model/RunbookRunParameters.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunParameters.cs
@@ -30,7 +30,7 @@ namespace Octopus.Client.Model
         public string[] EnvironmentIds { get; set; }
         public bool ForcePackageDownload { get; set; }
         public bool? UseGuidedFailure { get; set; }
-        public bool? IsDebugEnabled { get; set; }
+        public DebugMode? DebugMode { get; set; }
         public string[] SpecificMachineIds { get; set; }
         public string[] ExcludedMachineIds { get; set; }
         public string TenantId { get; set; }
@@ -51,7 +51,7 @@ namespace Octopus.Client.Model
                 EnvironmentId = runbookRun.EnvironmentId,
                 ForcePackageDownload = runbookRun.ForcePackageDownload,
                 UseGuidedFailure = runbookRun.UseGuidedFailure,
-                IsDebugEnabled = runbookRun.IsDebugEnabled,
+                DebugMode = runbookRun.DebugMode,
                 SpecificMachineIds = runbookRun.SpecificMachineIds != null ? runbookRun.SpecificMachineIds.ToArray() : new string[0],
                 ExcludedMachineIds = runbookRun.ExcludedMachineIds != null ? runbookRun.ExcludedMachineIds.ToArray() : new string[0],
                 TenantId = runbookRun.TenantId,

--- a/source/Octopus.Server.Client/Model/RunbookRunResource.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunResource.cs
@@ -67,7 +67,7 @@ namespace Octopus.Client.Model
         /// When enabled contributes the OctopusPrintVariables and OctopusPrintEvaluatedVariables variables to true
         /// </summary>
         [WriteableOnCreate]
-        public bool IsDebugEnabled { get; set; }
+        public DebugMode DebugMode { get; set; }
 
         [WriteableOnCreate]
         public string Comments { get; set; }

--- a/source/Octopus.Server.Client/Model/RunbookRunResource.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunResource.cs
@@ -67,7 +67,7 @@ namespace Octopus.Client.Model
         /// When enabled contributes the OctopusPrintVariables and OctopusPrintEvaluatedVariables variables to true
         /// </summary>
         [WriteableOnCreate]
-        public bool Debug { get; set; }
+        public bool IsDebugEnabled { get; set; }
 
         [WriteableOnCreate]
         public string Comments { get; set; }

--- a/source/Octopus.Server.Client/Model/RunbookRunResource.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunResource.cs
@@ -67,7 +67,7 @@ namespace Octopus.Client.Model
         /// When enabled contributes the OctopusPrintVariables and OctopusPrintEvaluatedVariables variables to true
         /// </summary>
         [WriteableOnCreate]
-        public DebugMode DebugMode { get; set; }
+        public string DebugMode { get; set; }
 
         [WriteableOnCreate]
         public string Comments { get; set; }

--- a/source/Octopus.Server.Client/Model/RunbookRunResource.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunResource.cs
@@ -62,6 +62,12 @@ namespace Octopus.Client.Model
         /// </summary>
         [WriteableOnCreate]
         public bool UseGuidedFailure { get; set; }
+        
+        /// <summary>
+        /// When enabled contributes the OctopusPrintVariables and OctopusPrintEvaluatedVariables variables to true
+        /// </summary>
+        [WriteableOnCreate]
+        public bool Debug { get; set; }
 
         [WriteableOnCreate]
         public string Comments { get; set; }


### PR DESCRIPTION
Adds the debug property to RunbookRun, Deployment and IExecution. This is part of work on [sc-100842](https://app.shortcut.com/octopusdeploy/story/100842/debug-checkbox-on-deployment-page) which adds support for a debug option on the create deployment and runbook run now layout pages. The field itself triggers the ExecutionManifest to contribute both the OctopusPrintVariables and OctopusPrintEvaluatedVariables properties as true.