### PR TITLE
Add Config as Code Runbooks support

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -3354,6 +3354,21 @@ Octopus.Client.Model
     Octopus.Client.Model.PersistenceSettingsType Type { get; }
     String Url { get; set; }
   }
+  class GitRunbookRunParameters
+  {
+    .ctor(String)
+    String Comments { get; set; }
+    String EnvironmentId { get; set; }
+    String[] ExcludedMachineIds { get; set; }
+    Boolean ForcePackageDownload { get; set; }
+    Dictionary<String, String> FormValues { get; set; }
+    Nullable<DateTimeOffset> QueueTime { get; set; }
+    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
+    String[] SkipActions { get; set; }
+    String[] SpecificMachineIds { get; set; }
+    String TenantId { get; set; }
+    Boolean UseGuidedFailure { get; set; }
+  }
   class GitTagResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -4046,6 +4061,29 @@ Octopus.Client.Model
     Octopus.Client.Extensibility.IHaveSpaceResource
     Octopus.Client.Model.ICommitCommand
     Octopus.Client.Model.DeploymentSettingsResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
+  class ModifyRunbookCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.RunbookResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
+  class ModifyRunbookProcessCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IProcessResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.RunbookProcessResource
   {
     .ctor()
     String ChangeDescription { get; set; }
@@ -5003,6 +5041,11 @@ Octopus.Client.Model
     Int32 QuantityToKeep { get; set; }
     Boolean ShouldKeepForever { get; set; }
   }
+  class RunbookRunGitResource
+  {
+    .ctor(Octopus.Client.Model.RunbookRunResource[])
+    Octopus.Client.Model.RunbookRunResource[] Resources { get; set; }
+  }
   class RunbookRunParameters
   {
     .ctor()
@@ -5025,12 +5068,24 @@ Octopus.Client.Model
     Nullable<Boolean> UseGuidedFailure { get; set; }
     static Octopus.Client.Model.RunbookRunParameters MapFrom(Octopus.Client.Model.RunbookRunResource)
   }
+  class RunbookRunPreviewParameters
+  {
+    .ctor(Octopus.Client.Model.RunbookRunPreviewTarget[])
+    Octopus.Client.Model.RunbookRunPreviewTarget[] DeploymentPreviews { get; set; }
+    Boolean IncludeDisabledSteps { get; set; }
+  }
   class RunbookRunPreviewResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.DeploymentPreviewBaseResource
   {
     .ctor()
+  }
+  class RunbookRunPreviewTarget
+  {
+    .ctor(String)
+    String EnvironmentId { get; set; }
+    String TenantId { get; set; }
   }
   class RunbookRunResource
     Octopus.Client.Extensibility.IResource
@@ -5105,6 +5160,14 @@ Octopus.Client.Model
     .ctor()
     String NextNameIncrement { get; set; }
     String RunbookProcessId { get; set; }
+  }
+  class RunGitRunbookParameters
+  {
+    .ctor(Octopus.Client.Model.GitRunbookRunParameters[])
+    String Notes { get; set; }
+    Octopus.Client.Model.GitRunbookRunParameters[] Runs { get; set; }
+    List<SelectedGitResource> SelectedGitResources { get; set; }
+    List<SelectedPackage> SelectedPackages { get; set; }
   }
   class S3FeedResource
     Octopus.Client.Extensibility.IResource
@@ -9193,7 +9256,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<RunbookProcessResource>
     Octopus.Client.Repositories.Async.IModify<RunbookProcessResource>
   {
+    Task<RunbookProcessResource> Get(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookSnapshotTemplateResource> GetTemplate(Octopus.Client.Model.RunbookProcessResource)
+    Task<RunbookProcessResource> Modify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.RunbookProcessResource, String, CancellationToken)
   }
   interface IRunbookRepository
     Octopus.Client.Repositories.Async.IFindByName<RunbookResource>
@@ -9203,13 +9268,21 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<RunbookResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookResource>
   {
+    Task<RunbookResource> Create(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.RunbookResource, String, CancellationToken)
     Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
+    Task Delete(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.RunbookResource, String, CancellationToken)
     Task<RunbookResource> FindByName(Octopus.Client.Model.ProjectResource, String)
+    Task<RunbookResource> Get(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
+    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.ProjectResource, String, String, Octopus.Client.Model.RunbookRunPreviewParameters, CancellationToken)
     Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.RunbookResource)
+    Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.RunbookResource)
+    Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
+    Task<RunbookResource> Modify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.RunbookResource, String, CancellationToken)
     Task<RunbookRunResource> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunResource)
     Task<RunbookRunResource[]> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunParameters)
+    Task<RunbookRunGitResource> Run(Octopus.Client.Model.ProjectResource, String, String, Octopus.Client.Model.RunGitRunbookParameters, CancellationToken)
   }
   interface IRunbookRunRepository
     Octopus.Client.Repositories.Async.IGet<RunbookRunResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -9294,6 +9294,7 @@ Octopus.Client.Repositories.Async
     Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
+    Task<RunbookRunResource> Retry(Octopus.Client.Model.RunbookRunResource, CancellationToken)
   }
   interface IRunbookSnapshotRepository
     Octopus.Client.Repositories.Async.IGet<RunbookSnapshotResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -9274,7 +9274,7 @@ Octopus.Client.Repositories.Async
     Task<RunbookResource> FindByName(Octopus.Client.Model.ProjectResource, String)
     Task<RunbookResource> Get(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.ProjectResource, String, String, Octopus.Client.Model.RunbookRunPreviewParameters, CancellationToken)
+    Task<RunbookRunPreviewResource[]> GetPreview(Octopus.Client.Model.ProjectResource, String, String, Octopus.Client.Model.RunbookRunPreviewParameters, CancellationToken)
     Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.RunbookResource)
     Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.RunbookResource)

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -3371,6 +3371,21 @@ Octopus.Client.Model
     Octopus.Client.Model.PersistenceSettingsType Type { get; }
     String Url { get; set; }
   }
+  class GitRunbookRunParameters
+  {
+    .ctor(String)
+    String Comments { get; set; }
+    String EnvironmentId { get; set; }
+    String[] ExcludedMachineIds { get; set; }
+    Boolean ForcePackageDownload { get; set; }
+    Dictionary<String, String> FormValues { get; set; }
+    Nullable<DateTimeOffset> QueueTime { get; set; }
+    Nullable<DateTimeOffset> QueueTimeExpiry { get; set; }
+    String[] SkipActions { get; set; }
+    String[] SpecificMachineIds { get; set; }
+    String TenantId { get; set; }
+    Boolean UseGuidedFailure { get; set; }
+  }
   class GitTagResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
@@ -4063,6 +4078,29 @@ Octopus.Client.Model
     Octopus.Client.Extensibility.IHaveSpaceResource
     Octopus.Client.Model.ICommitCommand
     Octopus.Client.Model.DeploymentSettingsResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
+  class ModifyRunbookCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Extensibility.INamedResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.IHaveSlugResource
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.RunbookResource
+  {
+    .ctor()
+    String ChangeDescription { get; set; }
+  }
+  class ModifyRunbookProcessCommand
+    Octopus.Client.Extensibility.IResource
+    Octopus.Client.Model.IAuditedResource
+    Octopus.Client.Model.IProcessResource
+    Octopus.Client.Extensibility.IHaveSpaceResource
+    Octopus.Client.Model.ICommitCommand
+    Octopus.Client.Model.RunbookProcessResource
   {
     .ctor()
     String ChangeDescription { get; set; }
@@ -5022,6 +5060,11 @@ Octopus.Client.Model
     Int32 QuantityToKeep { get; set; }
     Boolean ShouldKeepForever { get; set; }
   }
+  class RunbookRunGitResource
+  {
+    .ctor(Octopus.Client.Model.RunbookRunResource[])
+    Octopus.Client.Model.RunbookRunResource[] Resources { get; set; }
+  }
   class RunbookRunParameters
   {
     .ctor()
@@ -5044,12 +5087,24 @@ Octopus.Client.Model
     Nullable<Boolean> UseGuidedFailure { get; set; }
     static Octopus.Client.Model.RunbookRunParameters MapFrom(Octopus.Client.Model.RunbookRunResource)
   }
+  class RunbookRunPreviewParameters
+  {
+    .ctor(Octopus.Client.Model.RunbookRunPreviewTarget[])
+    Octopus.Client.Model.RunbookRunPreviewTarget[] DeploymentPreviews { get; set; }
+    Boolean IncludeDisabledSteps { get; set; }
+  }
   class RunbookRunPreviewResource
     Octopus.Client.Extensibility.IResource
     Octopus.Client.Model.IAuditedResource
     Octopus.Client.Model.DeploymentPreviewBaseResource
   {
     .ctor()
+  }
+  class RunbookRunPreviewTarget
+  {
+    .ctor(String)
+    String EnvironmentId { get; set; }
+    String TenantId { get; set; }
   }
   class RunbookRunResource
     Octopus.Client.Extensibility.IResource
@@ -5124,6 +5179,14 @@ Octopus.Client.Model
     .ctor()
     String NextNameIncrement { get; set; }
     String RunbookProcessId { get; set; }
+  }
+  class RunGitRunbookParameters
+  {
+    .ctor(Octopus.Client.Model.GitRunbookRunParameters[])
+    String Notes { get; set; }
+    Octopus.Client.Model.GitRunbookRunParameters[] Runs { get; set; }
+    List<SelectedGitResource> SelectedGitResources { get; set; }
+    List<SelectedPackage> SelectedPackages { get; set; }
   }
   class S3FeedResource
     Octopus.Client.Extensibility.IResource
@@ -9218,7 +9281,9 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IGet<RunbookProcessResource>
     Octopus.Client.Repositories.Async.IModify<RunbookProcessResource>
   {
+    Task<RunbookProcessResource> Get(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookSnapshotTemplateResource> GetTemplate(Octopus.Client.Model.RunbookProcessResource)
+    Task<RunbookProcessResource> Modify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.RunbookProcessResource, String, CancellationToken)
   }
   interface IRunbookRepository
     Octopus.Client.Repositories.Async.IFindByName<RunbookResource>
@@ -9228,13 +9293,21 @@ Octopus.Client.Repositories.Async
     Octopus.Client.Repositories.Async.IModify<RunbookResource>
     Octopus.Client.Repositories.Async.IDelete<RunbookResource>
   {
+    Task<RunbookResource> Create(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.RunbookResource, String, CancellationToken)
     Task<RunbookEditor> CreateOrModify(Octopus.Client.Model.ProjectResource, String, String)
+    Task Delete(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.RunbookResource, String, CancellationToken)
     Task<RunbookResource> FindByName(Octopus.Client.Model.ProjectResource, String)
+    Task<RunbookResource> Get(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
+    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.ProjectResource, String, String, Octopus.Client.Model.RunbookRunPreviewParameters, CancellationToken)
     Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.RunbookResource)
+    Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.RunbookResource)
+    Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
+    Task<RunbookResource> Modify(Octopus.Client.Model.ProjectResource, String, Octopus.Client.Model.RunbookResource, String, CancellationToken)
     Task<RunbookRunResource> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunResource)
     Task<RunbookRunResource[]> Run(Octopus.Client.Model.RunbookResource, Octopus.Client.Model.RunbookRunParameters)
+    Task<RunbookRunGitResource> Run(Octopus.Client.Model.ProjectResource, String, String, Octopus.Client.Model.RunGitRunbookParameters, CancellationToken)
   }
   interface IRunbookRunRepository
     Octopus.Client.Repositories.Async.IGet<RunbookRunResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -9319,6 +9319,7 @@ Octopus.Client.Repositories.Async
     Task<TaskResource> GetTask(Octopus.Client.Model.RunbookRunResource)
     Task Paginate(String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
     Task Paginate(String[], String[], String[], String[], Func<ResourceCollection<RunbookRunResource>, Boolean>)
+    Task<RunbookRunResource> Retry(Octopus.Client.Model.RunbookRunResource, CancellationToken)
   }
   interface IRunbookSnapshotRepository
     Octopus.Client.Repositories.Async.IGet<RunbookSnapshotResource>

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -9299,7 +9299,7 @@ Octopus.Client.Repositories.Async
     Task<RunbookResource> FindByName(Octopus.Client.Model.ProjectResource, String)
     Task<RunbookResource> Get(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.DeploymentPromotionTarget)
-    Task<RunbookRunPreviewResource> GetPreview(Octopus.Client.Model.ProjectResource, String, String, Octopus.Client.Model.RunbookRunPreviewParameters, CancellationToken)
+    Task<RunbookRunPreviewResource[]> GetPreview(Octopus.Client.Model.ProjectResource, String, String, Octopus.Client.Model.RunbookRunPreviewParameters, CancellationToken)
     Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.RunbookResource)
     Task<RunbookRunTemplateResource> GetRunbookRunTemplate(Octopus.Client.Model.ProjectResource, String, String, CancellationToken)
     Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(Octopus.Client.Model.RunbookResource)

--- a/source/Octopus.Server.Client/Model/ModifyRunbookCommand.cs
+++ b/source/Octopus.Server.Client/Model/ModifyRunbookCommand.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model
+{
+    public class ModifyRunbookCommand : RunbookResource, ICommitCommand
+    {
+        public string ChangeDescription { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/ModifyRunbookProcessCommand.cs
+++ b/source/Octopus.Server.Client/Model/ModifyRunbookProcessCommand.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Client.Model
+{
+    public class ModifyRunbookProcessCommand : RunbookProcessResource, ICommitCommand
+    {
+        public string ChangeDescription { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/RunbookRunGitParameters.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunGitParameters.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Client.Model
+{
+    public class RunGitRunbookParameters(GitRunbookRunParameters[] runs)
+    {
+        public GitRunbookRunParameters[] Runs { get; set; } = runs;
+        public string Notes { get; set; }
+        public List<SelectedPackage> SelectedPackages { get; set; } = new();
+        public List<SelectedGitResource> SelectedGitResources { get; set; } = new();
+    }
+
+    public class GitRunbookRunParameters(string environmentId)
+    {
+        public string EnvironmentId { get; set; } = environmentId;
+
+        public string TenantId { get; set; }
+
+        public bool ForcePackageDownload { get; set; } = false;
+
+        public string[] SkipActions { get; set; } = [];
+
+        public string[] SpecificMachineIds { get; set; } = [];
+
+        public string[] ExcludedMachineIds { get; set; } = [];
+
+        public bool UseGuidedFailure { get; set; } = false;
+
+        public Dictionary<string, string> FormValues { get; set; } = new();
+
+        public DateTimeOffset? QueueTime { get; set; }
+
+        public DateTimeOffset? QueueTimeExpiry { get; set; }
+
+        public string Comments { get; set; }
+    }
+}

--- a/source/Octopus.Server.Client/Model/RunbookRunGitResource.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunGitResource.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Client.Model;
+
+public class RunbookRunGitResource(RunbookRunResource[] resources)
+{
+    public RunbookRunResource[] Resources { get; set; } = resources;
+}

--- a/source/Octopus.Server.Client/Model/RunbookRunPreviewParameters.cs
+++ b/source/Octopus.Server.Client/Model/RunbookRunPreviewParameters.cs
@@ -1,0 +1,15 @@
+namespace Octopus.Client.Model;
+
+public class RunbookRunPreviewParameters(RunbookRunPreviewTarget[] deploymentPreviews)
+{
+    public RunbookRunPreviewTarget[] DeploymentPreviews { get; set; } = deploymentPreviews;
+    public bool IncludeDisabledSteps { get; set; }
+}
+
+public class RunbookRunPreviewTarget(string environmentId)
+{
+
+    public string EnvironmentId { get; set; } = environmentId;
+
+    public string TenantId { get; set; }
+}

--- a/source/Octopus.Server.Client/Repositories/Async/RunbookProcessRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/RunbookProcessRepository.cs
@@ -1,15 +1,23 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Client.Model;
+using Octopus.Client.Serialization;
 
 namespace Octopus.Client.Repositories.Async
 {
     public interface IRunbookProcessRepository : IGet<RunbookProcessResource>, IModify<RunbookProcessResource>
     {
         Task<RunbookSnapshotTemplateResource> GetTemplate(RunbookProcessResource runbookProcess);
+
+        // Config as Code methods
+        Task<RunbookProcessResource> Get(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
+        Task<RunbookProcessResource> Modify(ProjectResource project, string gitRef, RunbookProcessResource runbookProcess, string commitMessage, CancellationToken cancellationToken);
     }
 
     class RunbookProcessRepository : BasicRepository<RunbookProcessResource>, IRunbookProcessRepository
     {
+        private readonly string baseGitUri = "~/api/{spaceId}/projects/{projectId}/{gitRef}";
+
         public RunbookProcessRepository(IOctopusAsyncRepository repository)
             : base(repository, "RunbookProcesses")
         {
@@ -18,6 +26,45 @@ namespace Octopus.Client.Repositories.Async
         public Task<RunbookSnapshotTemplateResource> GetTemplate(RunbookProcessResource runbookProcess)
         {
             return Client.Get<RunbookSnapshotTemplateResource>(runbookProcess.Link("RunbookSnapshotTemplate"));
+        }
+
+        public async Task<RunbookProcessResource> Get(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbookProcesses/{{id}}";
+
+            return await Client.Get<RunbookProcessResource>(
+                route,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    id = slug
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        public async Task<RunbookProcessResource> Modify(ProjectResource project, string gitRef, RunbookProcessResource runbookProcess, string commitMessage, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbookProcesses/{{id}}";
+
+            var json = Serializer.Serialize(runbookProcess);
+            var command = Serializer.Deserialize<ModifyRunbookProcessCommand>(json);
+            command.ChangeDescription = commitMessage;
+
+            return await Client.Update<ModifyRunbookProcessCommand, RunbookProcessResource>(
+                route,
+                command,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    id = runbookProcess.Id
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/RunbookProcessRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/RunbookProcessRepository.cs
@@ -10,7 +10,17 @@ namespace Octopus.Client.Repositories.Async
         Task<RunbookSnapshotTemplateResource> GetTemplate(RunbookProcessResource runbookProcess);
 
         // Config as Code methods
+
+        /// <summary>
+        /// Get a Runbook process for a specific Git ref and slug
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookProcessResource> Get(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Modifies a Runbook process for a specific Git ref and slug
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookProcessResource> Modify(ProjectResource project, string gitRef, RunbookProcessResource runbookProcess, string commitMessage, CancellationToken cancellationToken);
     }
 

--- a/source/Octopus.Server.Client/Repositories/Async/RunbookRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/RunbookRepository.cs
@@ -26,7 +26,7 @@ namespace Octopus.Client.Repositories.Async
         Task<RunbookRunGitResource> Run(ProjectResource project, string gitRef, string slug, RunGitRunbookParameters runbookRunParameters, CancellationToken cancellationToken);
         Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
         Task<RunbookRunTemplateResource> GetRunbookRunTemplate(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
-        Task<RunbookRunPreviewResource> GetPreview(ProjectResource project, string gitRef, string slug, RunbookRunPreviewParameters runbookRunParameters, CancellationToken cancellationToken);
+        Task<RunbookRunPreviewResource[]> GetPreview(ProjectResource project, string gitRef, string slug, RunbookRunPreviewParameters runbookRunParameters, CancellationToken cancellationToken);
     }
 
     class RunbookRepository : BasicRepository<RunbookResource>, IRunbookRepository
@@ -228,11 +228,11 @@ namespace Octopus.Client.Repositories.Async
             ).ConfigureAwait(false);
         }
 
-        public async Task<RunbookRunPreviewResource> GetPreview(ProjectResource project, string gitRef, string slug, RunbookRunPreviewParameters runbookRunPreviewParameters, CancellationToken cancellationToken)
+        public async Task<RunbookRunPreviewResource[]> GetPreview(ProjectResource project, string gitRef, string slug, RunbookRunPreviewParameters runbookRunPreviewParameters, CancellationToken cancellationToken)
         {
             var route = $"{baseGitUri}/runbooks/{{id}}/runbookRuns/previews";
 
-            return await Client.Post<RunbookRunPreviewParameters, RunbookRunPreviewResource>(
+            return await Client.Post<RunbookRunPreviewParameters, RunbookRunPreviewResource[]>(
                 route,
                 runbookRunPreviewParameters,
                 new

--- a/source/Octopus.Server.Client/Repositories/Async/RunbookRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/RunbookRepository.cs
@@ -19,13 +19,52 @@ namespace Octopus.Client.Repositories.Async
         Task<RunbookRunResource[]> Run(RunbookResource runbook, RunbookRunParameters runbookRunParameters);
 
         // Config as Code methods
+        /// <summary>
+        /// Returns a Runbook for a specific Git ref and slug
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookResource> Get(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Creates a new Runbook with an empty process for a specific Git ref and slug
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookResource> Create(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Modifies a Runbook for a specific Git ref and slug
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookResource> Modify(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Deletes a Runbook for a specific Git ref and slug
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task Delete(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Runs a Runbook for a specific Git ref and slug. Multiple runs for different environments and tenant combinations are configured in the run parameters.
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookRunGitResource> Run(ProjectResource project, string gitRef, string slug, RunGitRunbookParameters runbookRunParameters, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get a Runbook snapshot template for a specific Git ref and slug
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get a Runbook run template for a specific Git ref and slug
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookRunTemplateResource> GetRunbookRunTemplate(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get a Runbook run preview for a specific Git ref and slug. Multple previews for different environments and tenant combinations are configured in the run parameters.
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookRunPreviewResource[]> GetPreview(ProjectResource project, string gitRef, string slug, RunbookRunPreviewParameters runbookRunParameters, CancellationToken cancellationToken);
     }
 

--- a/source/Octopus.Server.Client/Repositories/Async/RunbookRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/RunbookRepository.cs
@@ -1,8 +1,10 @@
 ﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Editors.Async;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
+using Octopus.Client.Serialization;
 
 namespace Octopus.Client.Repositories.Async
 {
@@ -15,10 +17,21 @@ namespace Octopus.Client.Repositories.Async
         Task<RunbookRunPreviewResource> GetPreview(DeploymentPromotionTarget promotionTarget);
         Task<RunbookRunResource> Run(RunbookResource runbook, RunbookRunResource runbookRun);
         Task<RunbookRunResource[]> Run(RunbookResource runbook, RunbookRunParameters runbookRunParameters);
+
+        // Config as Code methods
+        Task<RunbookResource> Get(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
+        Task<RunbookResource> Create(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken);
+        Task<RunbookResource> Modify(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken);
+        Task Delete(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken);
+        Task<RunbookRunGitResource> Run(ProjectResource project, string gitRef, string slug, RunGitRunbookParameters runbookRunParameters, CancellationToken cancellationToken);
+        Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
+        Task<RunbookRunTemplateResource> GetRunbookRunTemplate(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken);
+        Task<RunbookRunPreviewResource> GetPreview(ProjectResource project, string gitRef, string slug, RunbookRunPreviewParameters runbookRunParameters, CancellationToken cancellationToken);
     }
 
     class RunbookRepository : BasicRepository<RunbookResource>, IRunbookRepository
     {
+        private readonly string baseGitUri = "~/api/{spaceId}/projects/{projectId}/{gitRef}";
         private readonly SemanticVersion integrationTestVersion;
         private readonly SemanticVersion versionAfterWhichRunbookRunParametersAreAvailable;
 
@@ -85,6 +98,161 @@ namespace Octopus.Client.Repositories.Async
                                                          $"Please update your Octopus Deploy server to 2020.3.* or newer to access this feature.");
 
             return await Client.Post<object, RunbookRunResource[]>(runbook.Link("CreateRunbookRun"), runbookRunParameters);
+        }
+
+        // Config as Code
+        public async Task<RunbookResource> Get(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbooks/{{id}}";
+
+            return await Client.Get<RunbookResource>(
+                route,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    id = slug
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        public async Task<RunbookResource> Create(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbooks/v2";
+            var command = AppendCommitMessage(runbook, commitMessage);
+
+            return await Client.Create<ModifyRunbookCommand, RunbookResource>(
+                route,
+                command,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        public async Task<RunbookResource> Modify(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbooks/{{id}}";
+            var command = AppendCommitMessage(runbook, commitMessage);
+
+            return await Client.Update<ModifyRunbookCommand, RunbookResource>(
+                route,
+                command,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    id = runbook.Id
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        public async Task Delete(ProjectResource project, string gitRef, RunbookResource runbook, string commitMessage, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbooks/{{id}}";
+
+            await Client.Delete(
+                route,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    slug = runbook.Id
+                },
+                new
+                {
+                    ChangeDescription = commitMessage
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        public async Task<RunbookRunGitResource> Run(ProjectResource project, string gitRef, string slug, RunGitRunbookParameters runbookRunParameters, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbooks/{{id}}/run/v1";
+
+            return await Client.Post<RunGitRunbookParameters, RunbookRunGitResource>(
+                route,
+                runbookRunParameters,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    id = slug
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        public async Task<RunbookSnapshotTemplateResource> GetRunbookSnapshotTemplate(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbooks/{{id}}/runbookSnapshotTemplate";
+
+            return await Client.Get<RunbookSnapshotTemplateResource>(
+                route,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    id = slug
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        public async Task<RunbookRunTemplateResource> GetRunbookRunTemplate(ProjectResource project, string gitRef, string slug, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbooks/{{id}}/runbookRunTemplate";
+
+            return await Client.Get<RunbookRunTemplateResource>(
+                route,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    id = slug
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        public async Task<RunbookRunPreviewResource> GetPreview(ProjectResource project, string gitRef, string slug, RunbookRunPreviewParameters runbookRunPreviewParameters, CancellationToken cancellationToken)
+        {
+            var route = $"{baseGitUri}/runbooks/{{id}}/runbookRuns/previews";
+
+            return await Client.Post<RunbookRunPreviewParameters, RunbookRunPreviewResource>(
+                route,
+                runbookRunPreviewParameters,
+                new
+                {
+                    spaceId = project.SpaceId,
+                    projectId = project.Id,
+                    gitRef = gitRef,
+                    id = slug
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        ModifyRunbookCommand AppendCommitMessage(RunbookResource runbook, string commitMessage)
+        {
+            var json = Serializer.Serialize(runbook);
+            var command = Serializer.Deserialize<ModifyRunbookCommand>(json);
+
+            command.ChangeDescription = commitMessage;
+            return command;
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/RunbookRunRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/RunbookRunRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 
@@ -20,6 +21,7 @@ namespace Octopus.Client.Repositories.Async
         Task<ResourceCollection<RunbookRunResource>> FindBy(string[] projects, string[] runbooks, string[] environments, int skip = 0, int? take = null);
         Task Paginate(string[] projects, string[] runbooks, string[] environments, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage);
         Task Paginate(string[] projects, string[] runbooks, string[] environments, string[] tenants, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage);
+        Task<RunbookRunResource> Retry(RunbookRunResource run, CancellationToken cancellationToken);
     }
 
     class RunbookRunRepository : BasicRepository<RunbookRunResource>, IRunbookRunRepository
@@ -47,6 +49,23 @@ namespace Octopus.Client.Repositories.Async
         public async Task Paginate(string[] projects, string[] runbooks, string[] environments, string[] tenants, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage)
         {
             await Client.Paginate(await Repository.Link("RunbookRuns").ConfigureAwait(false), new { projects = projects ?? new string[0], runbooks = runbooks ?? new string[0], environments = environments ?? new string[0], tenants = tenants ?? new string[0] }, getNextPage).ConfigureAwait(false);
+        }
+
+        public async Task<RunbookRunResource> Retry(RunbookRunResource run, CancellationToken cancellationToken)
+        {
+            var route = "~/api/{spaceId}/projects/{projectId}/runbookRuns/{id}/retry/v1";
+
+            return await Client.Post<object, RunbookRunResource>(
+                route,
+                null,
+                new
+                {
+                    spaceId = run.SpaceId,
+                    projectId = run.Id,
+                    id = run.Id
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
         }
     }
 }

--- a/source/Octopus.Server.Client/Repositories/Async/RunbookRunRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/RunbookRunRepository.cs
@@ -61,7 +61,7 @@ namespace Octopus.Client.Repositories.Async
                 new
                 {
                     spaceId = run.SpaceId,
-                    projectId = run.Id,
+                    projectId = run.ProjectId,
                     id = run.Id
                 },
                 cancellationToken

--- a/source/Octopus.Server.Client/Repositories/Async/RunbookRunRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/RunbookRunRepository.cs
@@ -21,6 +21,11 @@ namespace Octopus.Client.Repositories.Async
         Task<ResourceCollection<RunbookRunResource>> FindBy(string[] projects, string[] runbooks, string[] environments, int skip = 0, int? take = null);
         Task Paginate(string[] projects, string[] runbooks, string[] environments, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage);
         Task Paginate(string[] projects, string[] runbooks, string[] environments, string[] tenants, Func<ResourceCollection<RunbookRunResource>, bool> getNextPage);
+        
+        /// <summary>
+        /// Retries a specific Runbook Run for a Config as Code Runbook
+        /// </summary>
+        /// <remarks>This operation is for Config as Code Runbooks only</remarks>
         Task<RunbookRunResource> Retry(RunbookRunResource run, CancellationToken cancellationToken);
     }
 


### PR DESCRIPTION
Adds support for CaC Runbooks to the client library. The new CaC Runbook methods are not returned in links collections, so these methods are a little different to the older ones, and you now need to pass the Project resource, Git ref and slug to all of these new calls.

For now, we're only adding these new methods to the asynchronous repositories. We may expand these to the others eventually if there is enough demand for it.

## Runbook and Runbook process repository changes
The bulk of the changes are in the `RunbookRepository` and `RunbookProcessRepository` as this is where all of the new methods requiring Git references will live. 

### Running a CaC Runbook
You no longer need to create a snapshot and run directly when running a CaC Runbook. Instead just call the Run method for a given Git ref and slug, and the snapshot and run will be created in the background automatically. 

Once a CaC Runbook is executed, the snapshots, runs, and tasks that are created are pretty much exactly the same, so no major changes should be required there, with the exception of retries.k

### Runbook retries
CaC Runbooks are always executed directly from a Git ref (rather than creating and running a snapshot), so we've also added a new method to the `RunbookRunRepository` to allow you to re-run these Runbooks. While these snapshots still exist in the API, but you can't create or run them directly. If you need to retry a failed Runbook for any reason, you call `Retry` on the run to execute that exact run again (rather than creating a new run from the snapshot). 

## Testing
For folks with internal access, there is a PR with tests against the latest version of Octopus here: https://github.com/OctopusDeploy/OctopusDeploy/pull/30513

[sc-95377]