### PR TITLE
Pin FluentAssertions to v7

### DIFF
--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="NUnit" Version="4.2.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
-        <PackageReference Include="FluentAssertions" Version="6.12.2" />
+        <PackageReference Include="FluentAssertions" Version="[7.0.0]" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">

--- a/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
+++ b/source/Octopus.Client.E2ETests/Octopus.Client.E2ETests.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="NUnit" Version="4.2.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
-        <PackageReference Include="FluentAssertions" Version="[7.0.0]" />
+        <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
     <PackageReference Include="Assent" Version="1.9.3" />
     <PackageReference Include="Autofac" Version="8.1.1" />
-    <PackageReference Include="FluentAssertions" Version="[7.0.0]" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     <PackageReference Include="Nancy" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Serilog" Version="4.1.0" />

--- a/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
+++ b/source/Octopus.Client.Tests/Octopus.Client.Tests.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
     <PackageReference Include="Assent" Version="1.9.3" />
     <PackageReference Include="Autofac" Version="8.1.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FluentAssertions" Version="[7.0.0]" />
     <PackageReference Include="Nancy" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Serilog" Version="4.1.0" />


### PR DESCRIPTION
[sc-101162]

FluentAssertions v8 changes to a non-open-source license; Commercial Use requires a paid subscription at $129 USD per developer per year.

This PR pins the version of FluentAssertions to 7.0.0.