### PR TITLE
Update SMTP Configuration with Google OAuth details

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5447,6 +5447,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
+    String CredentialType { get; set; }
     Boolean EnableSsl { get; set; }
     String GoogleAudience { get; set; }
     String GoogleServiceAccount { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -5448,6 +5448,8 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean EnableSsl { get; set; }
+    String GoogleAudience { get; set; }
+    String GoogleServiceAccount { get; set; }
     String NewSmtpPassword { get; set; }
     String SendEmailFrom { get; set; }
     String SmtpHost { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5467,6 +5467,8 @@ Octopus.Client.Model
   {
     .ctor()
     Boolean EnableSsl { get; set; }
+    String GoogleAudience { get; set; }
+    String GoogleServiceAccount { get; set; }
     String NewSmtpPassword { get; set; }
     String SendEmailFrom { get; set; }
     String SmtpHost { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -5466,6 +5466,7 @@ Octopus.Client.Model
     Octopus.Client.Model.Resource
   {
     .ctor()
+    String CredentialType { get; set; }
     Boolean EnableSsl { get; set; }
     String GoogleAudience { get; set; }
     String GoogleServiceAccount { get; set; }

--- a/source/Octopus.Server.Client/Model/SmtpConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/SmtpConfigurationResource.cs
@@ -28,10 +28,10 @@ namespace Octopus.Client.Model
         public SensitiveValue SmtpPassword { get; set; }
         
         [Writeable]
-        public bool GoogleAudience { get; set; }
+        public string GoogleAudience { get; set; }
         
         [Writeable]
-        public int? GoogleServiceAccount { get; set; }
+        public string GoogleServiceAccount { get; set; }
 
         [NotReadable]
         [Writeable]

--- a/source/Octopus.Server.Client/Model/SmtpConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/SmtpConfigurationResource.cs
@@ -26,6 +26,12 @@ namespace Octopus.Client.Model
 
         [Writeable]
         public SensitiveValue SmtpPassword { get; set; }
+        
+        [Writeable]
+        public bool GoogleAudience { get; set; }
+        
+        [Writeable]
+        public int? GoogleServiceAccount { get; set; }
 
         [NotReadable]
         [Writeable]

--- a/source/Octopus.Server.Client/Model/SmtpConfigurationResource.cs
+++ b/source/Octopus.Server.Client/Model/SmtpConfigurationResource.cs
@@ -28,6 +28,9 @@ namespace Octopus.Client.Model
         public SensitiveValue SmtpPassword { get; set; }
         
         [Writeable]
+        public string CredentialType { get; set; }
+        
+        [Writeable]
         public string GoogleAudience { get; set; }
         
         [Writeable]


### PR DESCRIPTION
Update the SMTP configuration to include credential type and Google OAuth details for new Google SMTP OAuth 2.0 feature.

[sc-100819]