### PR TITLE
Retrieve default/missing tenant common variables

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7453,6 +7453,7 @@ Octopus.Client.Model.TenantVariables
   class GetCommonVariablesByTenantIdRequest
   {
     .ctor(String, String)
+    Boolean IncludeMissingCommonVariables { get; set; }
     String SpaceId { get; set; }
     String TenantId { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7478,10 +7478,10 @@ Octopus.Client.Model.TenantVariables
   }
   class ModifyCommonVariablesByTenantIdCommand
   {
-    .ctor(String, String, Octopus.Client.Model.TenantVariables.TenantCommonVariable[])
+    .ctor(String, String, Octopus.Client.Model.TenantVariables.TenantCommonVariablePayload[])
     String SpaceId { get; set; }
     String TenantId { get; set; }
-    Octopus.Client.Model.TenantVariables.TenantCommonVariable[] Variables { get; set; }
+    Octopus.Client.Model.TenantVariables.TenantCommonVariablePayload[] Variables { get; set; }
   }
   class ModifyCommonVariablesByTenantIdResponse
   {
@@ -7515,6 +7515,15 @@ Octopus.Client.Model.TenantVariables
     String LibraryVariableSetName { get; set; }
     Octopus.Client.Model.TenantVariables.CommonVariableScope Scope { get; set; }
     Octopus.Client.Model.ActionTemplateParameterResource Template { get; set; }
+    String TemplateId { get; set; }
+    Octopus.Client.Model.PropertyValueResource Value { get; set; }
+  }
+  class TenantCommonVariablePayload
+  {
+    .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.CommonVariableScope)
+    String Id { get; set; }
+    String LibraryVariableSetId { get; set; }
+    Octopus.Client.Model.TenantVariables.CommonVariableScope Scope { get; set; }
     String TemplateId { get; set; }
     Octopus.Client.Model.PropertyValueResource Value { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7461,6 +7461,7 @@ Octopus.Client.Model.TenantVariables
   {
     .ctor(String, Octopus.Client.Model.TenantVariables.TenantCommonVariable[])
     Octopus.Client.Model.TenantVariables.TenantCommonVariable[] CommonVariables { get; set; }
+    Octopus.Client.Model.TenantVariables.TenantCommonVariable[] MissingCommonVariables { get; set; }
     String TenantId { get; set; }
   }
   class GetProjectVariablesByTenantIdRequest

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7512,7 +7512,9 @@ Octopus.Client.Model.TenantVariables
     .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.CommonVariableScope)
     String Id { get; set; }
     String LibraryVariableSetId { get; set; }
+    String LibraryVariableSetName { get; set; }
     Octopus.Client.Model.TenantVariables.CommonVariableScope Scope { get; set; }
+    Octopus.Client.Model.ActionTemplateParameterResource Template { get; set; }
     String TemplateId { get; set; }
     Octopus.Client.Model.PropertyValueResource Value { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7502,10 +7502,10 @@ Octopus.Client.Model.TenantVariables
   }
   class ModifyCommonVariablesByTenantIdCommand
   {
-    .ctor(String, String, Octopus.Client.Model.TenantVariables.TenantCommonVariable[])
+    .ctor(String, String, Octopus.Client.Model.TenantVariables.TenantCommonVariablePayload[])
     String SpaceId { get; set; }
     String TenantId { get; set; }
-    Octopus.Client.Model.TenantVariables.TenantCommonVariable[] Variables { get; set; }
+    Octopus.Client.Model.TenantVariables.TenantCommonVariablePayload[] Variables { get; set; }
   }
   class ModifyCommonVariablesByTenantIdResponse
   {
@@ -7539,6 +7539,15 @@ Octopus.Client.Model.TenantVariables
     String LibraryVariableSetName { get; set; }
     Octopus.Client.Model.TenantVariables.CommonVariableScope Scope { get; set; }
     Octopus.Client.Model.ActionTemplateParameterResource Template { get; set; }
+    String TemplateId { get; set; }
+    Octopus.Client.Model.PropertyValueResource Value { get; set; }
+  }
+  class TenantCommonVariablePayload
+  {
+    .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.CommonVariableScope)
+    String Id { get; set; }
+    String LibraryVariableSetId { get; set; }
+    Octopus.Client.Model.TenantVariables.CommonVariableScope Scope { get; set; }
     String TemplateId { get; set; }
     Octopus.Client.Model.PropertyValueResource Value { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7477,6 +7477,7 @@ Octopus.Client.Model.TenantVariables
   class GetCommonVariablesByTenantIdRequest
   {
     .ctor(String, String)
+    Boolean IncludeMissingCommonVariables { get; set; }
     String SpaceId { get; set; }
     String TenantId { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7485,6 +7485,7 @@ Octopus.Client.Model.TenantVariables
   {
     .ctor(String, Octopus.Client.Model.TenantVariables.TenantCommonVariable[])
     Octopus.Client.Model.TenantVariables.TenantCommonVariable[] CommonVariables { get; set; }
+    Octopus.Client.Model.TenantVariables.TenantCommonVariable[] MissingCommonVariables { get; set; }
     String TenantId { get; set; }
   }
   class GetProjectVariablesByTenantIdRequest
@@ -7535,7 +7536,9 @@ Octopus.Client.Model.TenantVariables
     .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.CommonVariableScope)
     String Id { get; set; }
     String LibraryVariableSetId { get; set; }
+    String LibraryVariableSetName { get; set; }
     Octopus.Client.Model.TenantVariables.CommonVariableScope Scope { get; set; }
+    Octopus.Client.Model.ActionTemplateParameterResource Template { get; set; }
     String TemplateId { get; set; }
     Octopus.Client.Model.PropertyValueResource Value { get; set; }
   }

--- a/source/Octopus.Server.Client/Model/TenantVariables/GetCommonVariablesByTenantIdRequest.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/GetCommonVariablesByTenantIdRequest.cs
@@ -14,4 +14,5 @@ public class GetCommonVariablesByTenantIdResponse(string tenantId, TenantCommonV
     public string TenantId { get; set; } = tenantId;
 
     public TenantCommonVariable[] CommonVariables { get; set; } = commonVariables;
+    public TenantCommonVariable[] MissingCommonVariables { get; set; }
 }

--- a/source/Octopus.Server.Client/Model/TenantVariables/GetCommonVariablesByTenantIdRequest.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/GetCommonVariablesByTenantIdRequest.cs
@@ -14,5 +14,5 @@ public class GetCommonVariablesByTenantIdResponse(string tenantId, TenantCommonV
     public string TenantId { get; set; } = tenantId;
 
     public TenantCommonVariable[] CommonVariables { get; set; } = commonVariables;
-    public TenantCommonVariable[] MissingCommonVariables { get; set; }
+    public TenantCommonVariable[] MissingCommonVariables { get; set; } = null;
 }

--- a/source/Octopus.Server.Client/Model/TenantVariables/GetCommonVariablesByTenantIdRequest.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/GetCommonVariablesByTenantIdRequest.cs
@@ -5,6 +5,8 @@ public class GetCommonVariablesByTenantIdRequest(string tenantId, string spaceId
     public string TenantId { get; set; } = tenantId;
 
     public string SpaceId { get; set; } = spaceId;
+    
+    public bool IncludeMissingCommonVariables { get; set; } = false;
 }
 
 public class GetCommonVariablesByTenantIdResponse(string tenantId, TenantCommonVariable[] commonVariables)

--- a/source/Octopus.Server.Client/Model/TenantVariables/ModifyCommonVariablesByTenantIdCommand.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/ModifyCommonVariablesByTenantIdCommand.cs
@@ -15,8 +15,12 @@ public class TenantCommonVariable(string libraryVariableSetId, string templateId
     public string Id { get; set; } = string.Empty;
 
     public string LibraryVariableSetId { get; set; } = libraryVariableSetId;
+    
+    public string LibraryVariableSetName { get; set; }
 
     public string TemplateId { get; set; } = templateId;
+
+    public ActionTemplateParameterResource Template { get; set; }
 
     public PropertyValueResource Value { get; set; } = value;
 

--- a/source/Octopus.Server.Client/Model/TenantVariables/ModifyCommonVariablesByTenantIdCommand.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/ModifyCommonVariablesByTenantIdCommand.cs
@@ -1,35 +1,26 @@
 ﻿namespace Octopus.Client.Model.TenantVariables;
 
-public class ModifyCommonVariablesByTenantIdCommand(string tenantId, string spaceId, TenantCommonVariable[] variables)
+public class ModifyCommonVariablesByTenantIdCommand(string tenantId, string spaceId, TenantCommonVariablePayload[] variables)
 {
     public string TenantId { get; set; } = tenantId;
 
     public string SpaceId { get; set; } = spaceId;
 
-    public TenantCommonVariable[] Variables { get; set; } = variables;
+    public TenantCommonVariablePayload[] Variables { get; set; } = variables;
 }
 
 
-public class TenantCommonVariable(string libraryVariableSetId, string templateId, PropertyValueResource value, CommonVariableScope scope)
+public class TenantCommonVariablePayload(string libraryVariableSetId, string templateId, PropertyValueResource value, TenantCommonVariable.CommonVariableScope scope)
 {
     public string Id { get; set; } = string.Empty;
 
     public string LibraryVariableSetId { get; set; } = libraryVariableSetId;
-    
-    public string LibraryVariableSetName { get; set; }
 
     public string TemplateId { get; set; } = templateId;
 
-    public ActionTemplateParameterResource Template { get; set; }
-
     public PropertyValueResource Value { get; set; } = value;
 
-    public CommonVariableScope Scope { get; set; } = scope;
-}
-
-public class CommonVariableScope(ReferenceCollection environmentIds)
-{
-    public ReferenceCollection EnvironmentIds { get; set; } = environmentIds;
+    public TenantCommonVariable.CommonVariableScope Scope { get; set; } = scope;
 }
 
 public class ModifyCommonVariablesByTenantIdResponse(string tenantId, TenantCommonVariable[] commonVariables)

--- a/source/Octopus.Server.Client/Model/TenantVariables/ModifyCommonVariablesByTenantIdCommand.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/ModifyCommonVariablesByTenantIdCommand.cs
@@ -10,7 +10,7 @@ public class ModifyCommonVariablesByTenantIdCommand(string tenantId, string spac
 }
 
 
-public class TenantCommonVariablePayload(string libraryVariableSetId, string templateId, PropertyValueResource value, TenantCommonVariable.CommonVariableScope scope)
+public class TenantCommonVariablePayload(string libraryVariableSetId, string templateId, PropertyValueResource value, CommonVariableScope scope)
 {
     public string Id { get; set; } = string.Empty;
 
@@ -20,7 +20,7 @@ public class TenantCommonVariablePayload(string libraryVariableSetId, string tem
 
     public PropertyValueResource Value { get; set; } = value;
 
-    public TenantCommonVariable.CommonVariableScope Scope { get; set; } = scope;
+    public CommonVariableScope Scope { get; set; } = scope;
 }
 
 public class ModifyCommonVariablesByTenantIdResponse(string tenantId, TenantCommonVariable[] commonVariables)

--- a/source/Octopus.Server.Client/Model/TenantVariables/TenantCommonVariable.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/TenantCommonVariable.cs
@@ -1,0 +1,26 @@
+﻿namespace Octopus.Client.Model.TenantVariables;
+
+public class TenantCommonVariable
+{
+    public class TenantCommonVariablePayload(string libraryVariableSetId, string templateId, PropertyValueResource value, CommonVariableScope scope)
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string LibraryVariableSetId { get; set; } = libraryVariableSetId;
+    
+        public string LibraryVariableSetName { get; set; }
+
+        public string TemplateId { get; set; } = templateId;
+
+        public ActionTemplateParameterResource Template { get; set; }
+
+        public PropertyValueResource Value { get; set; } = value;
+
+        public CommonVariableScope Scope { get; set; } = scope;
+    }
+    
+    public class CommonVariableScope(ReferenceCollection environmentIds)
+    {
+        public ReferenceCollection EnvironmentIds { get; set; } = environmentIds;
+    }
+}

--- a/source/Octopus.Server.Client/Model/TenantVariables/TenantCommonVariable.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/TenantCommonVariable.cs
@@ -1,26 +1,23 @@
 ﻿namespace Octopus.Client.Model.TenantVariables;
 
-public class TenantCommonVariable
+public class TenantCommonVariable(string libraryVariableSetId, string templateId, PropertyValueResource value, CommonVariableScope scope)
 {
-    public class TenantCommonVariablePayload(string libraryVariableSetId, string templateId, PropertyValueResource value, CommonVariableScope scope)
-    {
-        public string Id { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
 
-        public string LibraryVariableSetId { get; set; } = libraryVariableSetId;
-    
-        public string LibraryVariableSetName { get; set; }
+    public string LibraryVariableSetId { get; set; } = libraryVariableSetId;
 
-        public string TemplateId { get; set; } = templateId;
+    public string LibraryVariableSetName { get; set; }
 
-        public ActionTemplateParameterResource Template { get; set; }
+    public string TemplateId { get; set; } = templateId;
 
-        public PropertyValueResource Value { get; set; } = value;
+    public ActionTemplateParameterResource Template { get; set; }
 
-        public CommonVariableScope Scope { get; set; } = scope;
-    }
-    
-    public class CommonVariableScope(ReferenceCollection environmentIds)
-    {
-        public ReferenceCollection EnvironmentIds { get; set; } = environmentIds;
-    }
+    public PropertyValueResource Value { get; set; } = value;
+
+    public CommonVariableScope Scope { get; set; } = scope;
+}
+
+public class CommonVariableScope(ReferenceCollection environmentIds)
+{
+    public ReferenceCollection EnvironmentIds { get; set; } = environmentIds;
 }

--- a/source/Octopus.Server.Client/Repositories/Async/TenantVariablesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/TenantVariablesRepository.cs
@@ -40,7 +40,7 @@ namespace Octopus.Client.Repositories.Async
             const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables";
 
             var response =
-                await Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId },
+                await Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingCommonVariables },
                     cancellationToken);
             return response;
         }

--- a/source/Octopus.Server.Client/Repositories/Async/TenantVariablesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/TenantVariablesRepository.cs
@@ -37,7 +37,7 @@ namespace Octopus.Client.Repositories.Async
         public async Task<GetCommonVariablesByTenantIdResponse> Get(GetCommonVariablesByTenantIdRequest request,
             CancellationToken cancellationToken)
         {
-            const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables";
+            const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables?includeMissingCommonVariables={includeMissingCommonVariables}";
 
             var response =
                 await Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingCommonVariables },

--- a/source/Octopus.Server.Client/Repositories/TenantVariablesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/TenantVariablesRepository.cs
@@ -18,7 +18,7 @@ namespace Octopus.Client.Repositories
     {
         public GetCommonVariablesByTenantIdResponse Get(GetCommonVariablesByTenantIdRequest request)
         {
-            const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables";
+            const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables?includeMissingCommonVariables={includeMissingCommonVariables}";
 
             var response =
                 Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingCommonVariables });

--- a/source/Octopus.Server.Client/Repositories/TenantVariablesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/TenantVariablesRepository.cs
@@ -21,7 +21,7 @@ namespace Octopus.Client.Repositories
             const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables";
 
             var response =
-                Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId });
+                Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingCommonVariables });
             return response;
         }
 


### PR DESCRIPTION
[SC-103509]

Required for: https://github.com/OctopusDeploy/OctopusDeploy/pull/31008

Previously, all templates were returned by the Get Tenant Variables endpoint which allowed Octopus UI and the Go CLI to find any missing/default values. When creating the new `api/{SpaceId}/tenants/{TenantId}/commonvariables` endpoint, we removed this functionality and only included templates for assigned variables. This PR adds a new array of missing and default variables to ensure that users can continue to access this data as required.

Default values are used for variables where a common variable template or project variable template has a default value set, but no value is explicitly set for one or more environment scopes.

Missing variables are similar to default variables, but are identified as having no default value for the template.

The new IncludeMissingCommonVariables boolean flag allows users to exclude missing variables if they are not required to avoid unnecessary queries by Octopus Server.