### PR TITLE
Retrieve default/missing tenant project variables

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7531,17 +7531,17 @@ Octopus.Client.Model.TenantVariables
   }
   class TenantProjectVariable
   {
-      .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.ProjectVariableScope)
-      String Id { get; set; }
-      String ProjectId { get; set; }
-      String ProjectName { get; set; }
-      Octopus.Client.Model.TenantVariables.ProjectVariableScope Scope { get; set; }
-      Octopus.Client.Model.ActionTemplateParameterResource Template { get; set; }
-      String TemplateId { get; set; }
-      Octopus.Client.Model.PropertyValueResource Value { get; set; }
-    }
+    .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.ProjectVariableScope)
+    String Id { get; set; }
+    String ProjectId { get; set; }
+    String ProjectName { get; set; }
+    Octopus.Client.Model.TenantVariables.ProjectVariableScope Scope { get; set; }
+    Octopus.Client.Model.ActionTemplateParameterResource Template { get; set; }
+    String TemplateId { get; set; }
+    Octopus.Client.Model.PropertyValueResource Value { get; set; }
+  }
   class TenantProjectVariablePayload
-    {
+  {
     .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.ProjectVariableScope)
     String Id { get; set; }
     String ProjectId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7453,7 +7453,7 @@ Octopus.Client.Model.TenantVariables
   class GetCommonVariablesByTenantIdRequest
   {
     .ctor(String, String)
-    Boolean IncludeMissingCommonVariables { get; set; }
+    Boolean IncludeMissingVariables { get; set; }
     String SpaceId { get; set; }
     String TenantId { get; set; }
   }
@@ -7467,7 +7467,7 @@ Octopus.Client.Model.TenantVariables
   class GetProjectVariablesByTenantIdRequest
   {
     .ctor(String, String)
-    Boolean IncludeMissingProjectVariables { get; set; }
+    Boolean IncludeMissingVariables { get; set; }
     String SpaceId { get; set; }
     String TenantId { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7467,12 +7467,14 @@ Octopus.Client.Model.TenantVariables
   class GetProjectVariablesByTenantIdRequest
   {
     .ctor(String, String)
+    Boolean IncludeMissingProjectVariables { get; set; }
     String SpaceId { get; set; }
     String TenantId { get; set; }
   }
   class GetProjectVariablesByTenantIdResponse
   {
     .ctor(String, Octopus.Client.Model.TenantVariables.TenantProjectVariable[])
+    Octopus.Client.Model.TenantVariables.TenantProjectVariable[] MissingProjectVariables { get; set; }
     Octopus.Client.Model.TenantVariables.TenantProjectVariable[] ProjectVariables { get; set; }
     String TenantId { get; set; }
   }
@@ -7491,10 +7493,10 @@ Octopus.Client.Model.TenantVariables
   }
   class ModifyProjectVariablesByTenantIdCommand
   {
-    .ctor(String, String, Octopus.Client.Model.TenantVariables.TenantProjectVariable[])
+    .ctor(String, String, Octopus.Client.Model.TenantVariables.TenantProjectVariablePayload[])
     String SpaceId { get; set; }
     String TenantId { get; set; }
-    Octopus.Client.Model.TenantVariables.TenantProjectVariable[] Variables { get; set; }
+    Octopus.Client.Model.TenantVariables.TenantProjectVariablePayload[] Variables { get; set; }
   }
   class ModifyProjectVariablesByTenantIdResponse
   {
@@ -7529,6 +7531,17 @@ Octopus.Client.Model.TenantVariables
   }
   class TenantProjectVariable
   {
+      .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.ProjectVariableScope)
+      String Id { get; set; }
+      String ProjectId { get; set; }
+      String ProjectName { get; set; }
+      Octopus.Client.Model.TenantVariables.ProjectVariableScope Scope { get; set; }
+      Octopus.Client.Model.ActionTemplateParameterResource Template { get; set; }
+      String TemplateId { get; set; }
+      Octopus.Client.Model.PropertyValueResource Value { get; set; }
+    }
+  class TenantProjectVariablePayload
+    {
     .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.ProjectVariableScope)
     String Id { get; set; }
     String ProjectId { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7477,7 +7477,7 @@ Octopus.Client.Model.TenantVariables
   class GetCommonVariablesByTenantIdRequest
   {
     .ctor(String, String)
-    Boolean IncludeMissingCommonVariables { get; set; }
+    Boolean IncludeMissingVariables { get; set; }
     String SpaceId { get; set; }
     String TenantId { get; set; }
   }
@@ -7491,7 +7491,7 @@ Octopus.Client.Model.TenantVariables
   class GetProjectVariablesByTenantIdRequest
   {
     .ctor(String, String)
-    Boolean IncludeMissingProjectVariables { get; set; }
+    Boolean IncludeMissingVariables { get; set; }
     String SpaceId { get; set; }
     String TenantId { get; set; }
   }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -7491,12 +7491,14 @@ Octopus.Client.Model.TenantVariables
   class GetProjectVariablesByTenantIdRequest
   {
     .ctor(String, String)
+    Boolean IncludeMissingProjectVariables { get; set; }
     String SpaceId { get; set; }
     String TenantId { get; set; }
   }
   class GetProjectVariablesByTenantIdResponse
   {
     .ctor(String, Octopus.Client.Model.TenantVariables.TenantProjectVariable[])
+    Octopus.Client.Model.TenantVariables.TenantProjectVariable[] MissingProjectVariables { get; set; }
     Octopus.Client.Model.TenantVariables.TenantProjectVariable[] ProjectVariables { get; set; }
     String TenantId { get; set; }
   }
@@ -7515,10 +7517,10 @@ Octopus.Client.Model.TenantVariables
   }
   class ModifyProjectVariablesByTenantIdCommand
   {
-    .ctor(String, String, Octopus.Client.Model.TenantVariables.TenantProjectVariable[])
+    .ctor(String, String, Octopus.Client.Model.TenantVariables.TenantProjectVariablePayload[])
     String SpaceId { get; set; }
     String TenantId { get; set; }
-    Octopus.Client.Model.TenantVariables.TenantProjectVariable[] Variables { get; set; }
+    Octopus.Client.Model.TenantVariables.TenantProjectVariablePayload[] Variables { get; set; }
   }
   class ModifyProjectVariablesByTenantIdResponse
   {
@@ -7552,6 +7554,17 @@ Octopus.Client.Model.TenantVariables
     Octopus.Client.Model.PropertyValueResource Value { get; set; }
   }
   class TenantProjectVariable
+  {
+    .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.ProjectVariableScope)
+    String Id { get; set; }
+    String ProjectId { get; set; }
+    String ProjectName { get; set; }
+    Octopus.Client.Model.TenantVariables.ProjectVariableScope Scope { get; set; }
+    Octopus.Client.Model.ActionTemplateParameterResource Template { get; set; }
+    String TemplateId { get; set; }
+    Octopus.Client.Model.PropertyValueResource Value { get; set; }
+  }
+  class TenantProjectVariablePayload
   {
     .ctor(String, String, Octopus.Client.Model.PropertyValueResource, Octopus.Client.Model.TenantVariables.ProjectVariableScope)
     String Id { get; set; }

--- a/source/Octopus.Server.Client/Model/TenantVariables/GetCommonVariablesByTenantIdRequest.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/GetCommonVariablesByTenantIdRequest.cs
@@ -6,7 +6,7 @@ public class GetCommonVariablesByTenantIdRequest(string tenantId, string spaceId
 
     public string SpaceId { get; set; } = spaceId;
     
-    public bool IncludeMissingCommonVariables { get; set; } = false;
+    public bool IncludeMissingVariables { get; set; } = false;
 }
 
 public class GetCommonVariablesByTenantIdResponse(string tenantId, TenantCommonVariable[] commonVariables)

--- a/source/Octopus.Server.Client/Model/TenantVariables/GetProjectVariablesByTenantIdRequest.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/GetProjectVariablesByTenantIdRequest.cs
@@ -5,6 +5,8 @@ public class GetProjectVariablesByTenantIdRequest(string tenantId, string spaceI
     public string TenantId { get; set; } = tenantId;
 
     public string SpaceId { get; set; } = spaceId;
+    
+    public bool IncludeMissingProjectVariables { get; set; } = false;
 }
 
 public class GetProjectVariablesByTenantIdResponse(string tenantId, TenantProjectVariable[] projectVariables)
@@ -12,4 +14,5 @@ public class GetProjectVariablesByTenantIdResponse(string tenantId, TenantProjec
     public string TenantId { get; set; } = tenantId;
 
     public TenantProjectVariable[] ProjectVariables { get; set; } = projectVariables;
+    public TenantProjectVariable[] MissingProjectVariables { get; set; } = null;
 }

--- a/source/Octopus.Server.Client/Model/TenantVariables/GetProjectVariablesByTenantIdRequest.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/GetProjectVariablesByTenantIdRequest.cs
@@ -6,7 +6,7 @@ public class GetProjectVariablesByTenantIdRequest(string tenantId, string spaceI
 
     public string SpaceId { get; set; } = spaceId;
     
-    public bool IncludeMissingProjectVariables { get; set; } = false;
+    public bool IncludeMissingVariables { get; set; } = false;
 }
 
 public class GetProjectVariablesByTenantIdResponse(string tenantId, TenantProjectVariable[] projectVariables)

--- a/source/Octopus.Server.Client/Model/TenantVariables/ModifyProjectVariablesByTenantIdCommand.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/ModifyProjectVariablesByTenantIdCommand.cs
@@ -1,15 +1,15 @@
 ﻿namespace Octopus.Client.Model.TenantVariables;
 
-public class ModifyProjectVariablesByTenantIdCommand(string tenantId, string spaceId, TenantProjectVariable[] variables)
+public class ModifyProjectVariablesByTenantIdCommand(string tenantId, string spaceId, TenantProjectVariablePayload[] variables)
 {
     public string TenantId { get; set; } = tenantId;
 
     public string SpaceId { get; set; } = spaceId;
 
-    public TenantProjectVariable[] Variables { get; set; } = variables;
+    public TenantProjectVariablePayload[] Variables { get; set; } = variables;
 }
 
-public class TenantProjectVariable(
+public class TenantProjectVariablePayload(
     string projectId,
     string templateId,
     PropertyValueResource value,
@@ -24,11 +24,6 @@ public class TenantProjectVariable(
     public PropertyValueResource Value { get; set; } = value;
 
     public ProjectVariableScope Scope { get; set; } = scope;
-}
-
-public class ProjectVariableScope(ReferenceCollection environmentIds)
-{
-    public ReferenceCollection EnvironmentIds { get; set; } = environmentIds;
 }
 
 public class ModifyProjectVariablesByTenantIdResponse(string tenantId, TenantProjectVariable[] projectVariables)

--- a/source/Octopus.Server.Client/Model/TenantVariables/TenantProjectVariable.cs
+++ b/source/Octopus.Server.Client/Model/TenantVariables/TenantProjectVariable.cs
@@ -1,0 +1,23 @@
+﻿namespace Octopus.Client.Model.TenantVariables;
+
+public class TenantProjectVariable(string projectId, string templateId, PropertyValueResource value, ProjectVariableScope scope)
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string ProjectId { get; set; } = projectId;
+
+    public string ProjectName { get; set; }
+
+    public string TemplateId { get; set; } = templateId;
+
+    public ActionTemplateParameterResource Template { get; set; }
+
+    public PropertyValueResource Value { get; set; } = value;
+
+    public ProjectVariableScope Scope { get; set; } = scope;
+}
+
+public class ProjectVariableScope(ReferenceCollection environmentIds)
+{
+    public ReferenceCollection EnvironmentIds { get; set; } = environmentIds;
+}

--- a/source/Octopus.Server.Client/Repositories/Async/TenantVariablesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/TenantVariablesRepository.cs
@@ -37,10 +37,10 @@ namespace Octopus.Client.Repositories.Async
         public async Task<GetCommonVariablesByTenantIdResponse> Get(GetCommonVariablesByTenantIdRequest request,
             CancellationToken cancellationToken)
         {
-            const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables?includeMissingCommonVariables={includeMissingCommonVariables}";
+            const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables?includeMissingVariables={includeMissingVariables}";
 
             var response =
-                await Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingCommonVariables },
+                await Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingVariables },
                     cancellationToken);
             return response;
         }
@@ -48,10 +48,10 @@ namespace Octopus.Client.Repositories.Async
         public async Task<GetProjectVariablesByTenantIdResponse> Get(GetProjectVariablesByTenantIdRequest request,
             CancellationToken cancellationToken)
         {
-            const string link = "/api/{spaceId}/tenants/{tenantId}/projectvariables?includeMissingProjectVariables={includeMissingProjectVariables}";
+            const string link = "/api/{spaceId}/tenants/{tenantId}/projectvariables?includeMissingVariables={includeMissingVariables}";
 
             var response =
-                await Client.Get<GetProjectVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingProjectVariables },
+                await Client.Get<GetProjectVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingVariables },
                     cancellationToken);
             return response;
         }

--- a/source/Octopus.Server.Client/Repositories/Async/TenantVariablesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/TenantVariablesRepository.cs
@@ -48,10 +48,10 @@ namespace Octopus.Client.Repositories.Async
         public async Task<GetProjectVariablesByTenantIdResponse> Get(GetProjectVariablesByTenantIdRequest request,
             CancellationToken cancellationToken)
         {
-            const string link = "/api/{spaceId}/tenants/{tenantId}/projectvariables";
+            const string link = "/api/{spaceId}/tenants/{tenantId}/projectvariables?includeMissingProjectVariables={includeMissingProjectVariables}";
 
             var response =
-                await Client.Get<GetProjectVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId },
+                await Client.Get<GetProjectVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingProjectVariables },
                     cancellationToken);
             return response;
         }

--- a/source/Octopus.Server.Client/Repositories/TenantVariablesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/TenantVariablesRepository.cs
@@ -27,10 +27,10 @@ namespace Octopus.Client.Repositories
 
         public GetProjectVariablesByTenantIdResponse Get(GetProjectVariablesByTenantIdRequest request)
         {
-            const string link = "/api/{spaceId}/tenants/{tenantId}/projectvariables";
+            const string link = "/api/{spaceId}/tenants/{tenantId}/projectvariables?includeMissingProjectVariables={includeMissingProjectVariables}";
 
             var response =
-                Client.Get<GetProjectVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId });
+                Client.Get<GetProjectVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingProjectVariables });
             return response;
         }
 

--- a/source/Octopus.Server.Client/Repositories/TenantVariablesRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/TenantVariablesRepository.cs
@@ -18,19 +18,19 @@ namespace Octopus.Client.Repositories
     {
         public GetCommonVariablesByTenantIdResponse Get(GetCommonVariablesByTenantIdRequest request)
         {
-            const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables?includeMissingCommonVariables={includeMissingCommonVariables}";
+            const string link = "/api/{spaceId}/tenants/{tenantId}/commonvariables?includeMissingVariables={includeMissingVariables}";
 
             var response =
-                Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingCommonVariables });
+                Client.Get<GetCommonVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingVariables });
             return response;
         }
 
         public GetProjectVariablesByTenantIdResponse Get(GetProjectVariablesByTenantIdRequest request)
         {
-            const string link = "/api/{spaceId}/tenants/{tenantId}/projectvariables?includeMissingProjectVariables={includeMissingProjectVariables}";
+            const string link = "/api/{spaceId}/tenants/{tenantId}/projectvariables?includeMissingVariables={includeMissingVariables}";
 
             var response =
-                Client.Get<GetProjectVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingProjectVariables });
+                Client.Get<GetProjectVariablesByTenantIdResponse>(link, new { request.SpaceId, request.TenantId, request.IncludeMissingVariables });
             return response;
         }
 


### PR DESCRIPTION
[SC-103510]



Previously, all templates were returned by the Get Tenant Variables endpoint which allowed Octopus UI and the Go CLI to find any missing/default values. When creating the new api/{SpaceId}/tenants/{TenantId}/projectvariables endpoint, we removed this functionality and only included templates for assigned variables. This PR adds a new array of missing and default variables to ensure that users can continue to access this data as required.

Default values are used for variables where a project variable template or project variable template has a default value set, but no value is explicitly set for one or more environment scopes.

Missing variables are similar to default variables, but are identified as having no default value for the template.

The new IncludeMissingProjectVariables boolean flag allows users to exclude missing variables if they are not required to avoid unnecessary queries by Octopus Server.