### PR TITLE
Add ability to configure the HttpClientHandler

### DIFF
--- a/source/Octopus.Server.Client/OctopusAsyncClient.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncClient.cs
@@ -75,6 +75,8 @@ namespace Octopus.Client
                 handler.Proxy = serverEndpoint.Proxy;
             }
 
+            clientOptions.ConfigureHttpClientHandler?.Invoke(handler);
+
             client = new HttpClient(handler, true);
             client.Timeout = clientOptions.Timeout;
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/source/Octopus.Server.Client/OctopusClient.cs
+++ b/source/Octopus.Server.Client/OctopusClient.cs
@@ -46,7 +46,12 @@ namespace Octopus.Client
         {
             this.serverEndpoint = serverEndpoint;
             options ??= new OctopusClientOptions();
-
+            
+            if(options.ConfigureHttpClientHandler != null)
+            {
+                throw new ArgumentException("The option ConfigureHttpClientHandler is only supported when using OctopusAsyncClient."); 
+            }
+            
             httpRouteExtractor = new HttpRouteExtractor(options.ScanForHttpRouteTypes);
             cookieOriginUri = BuildCookieUri(serverEndpoint);
             octopusCustomHeaders = new OctopusCustomHeaders(requestingTool);

--- a/source/Octopus.Server.Client/OctopusClientOptions.cs
+++ b/source/Octopus.Server.Client/OctopusClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Net.Http;
 using System.Security.Authentication;
 using Octopus.Client.Model;
 
@@ -50,5 +51,11 @@ namespace Octopus.Client
         ///     into the appdomain, so a reasonably-well-filtered collection is recommended.
         /// </remarks>
         public Func<Type[]> ScanForHttpRouteTypes { get; set; } = AppDomainScanner.ScanForAllTypes;
+
+        /// <summary>
+        /// Configures the HTTP client handler that is used to create the HttpClient used by the client. Only applies to OctopusAsyncClient and
+        /// cannot be configured for OctopusClient (sync client).
+        /// </summary>
+        public Action<HttpClientHandler> ConfigureHttpClientHandler { get; set; } = null;
     }
 }


### PR DESCRIPTION
The idea was to set MaxConnectionsPerServer to limit how many requests we did.

However the sync client doesn't use HttpClient. When the async client is running in Http/2 mode, it only uses one connection, so this setting is useless
