### PR TITLE
Added semaphore to control number of requests

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -498,6 +498,7 @@ Octopus.Client
   }
   class OctopusClientOptions
   {
+    System.Int32 MaxSimultaneousRequests
     .ctor()
     Boolean AllowDefaultProxy { get; set; }
     Boolean IgnoreSslErrors { get; set; }

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -498,6 +498,7 @@ Octopus.Client
   }
   class OctopusClientOptions
   {
+    System.Int32 MaxSimultaneousRequests
     .ctor()
     Boolean AllowDefaultProxy { get; set; }
     String Proxy { get; set; }

--- a/source/Octopus.Server.Client/OctopusClientOptions.cs
+++ b/source/Octopus.Server.Client/OctopusClientOptions.cs
@@ -50,5 +50,10 @@ namespace Octopus.Client
         ///     into the appdomain, so a reasonably-well-filtered collection is recommended.
         /// </remarks>
         public Func<Type[]> ScanForHttpRouteTypes { get; set; } = AppDomainScanner.ScanForAllTypes;
+
+        /// <summary>
+        /// Maximum number of simultaneous requests to make to the server
+        /// </summary>
+        public int MaxSimultaneousRequests = int.MaxValue;
     }
 }


### PR DESCRIPTION
This adds a semaphore around the request sending for both the sync and async client. This is used to limit the number of requests that are made so that you don't DOS the Octopus Server.

The [alternate](https://github.com/OctopusDeploy/OctopusClients/pull/912) was rejected as it didn't apply to sync client and 
HTTP/2

I manually tested both clients and changing the value affects the duration of the requests.

I tested it out against our internal server and when limited to 30 connections it's almost as fast as when it's 100, showing limited benefit from increased parallelism.
