### PR TITLE
🧹 Added dependabot and implemented hash pinning for third party actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,7 +57,7 @@ jobs:
       # Unit test reports
 
       - name: Windows .NET 4.6.2 unit test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Windows .Net 4.6.2 unit test results
@@ -66,7 +66,7 @@ jobs:
           fail-on-error: true
 
       - name: Windows .NET 4.8 unit test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Windows.Net 4.8 unit test results
@@ -75,7 +75,7 @@ jobs:
           fail-on-error: true
 
       - name: Windows .NET 8.0 unit test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Windows .Net 8.0 unit test results
@@ -86,7 +86,7 @@ jobs:
       # E2E test reports
 
       - name: Windows .NET 4.6.2 E2E test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Windows .NET 4.6.2 E2E test results
@@ -95,7 +95,7 @@ jobs:
           fail-on-error: true
 
       - name: Windows .NET 4.8 E2E test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Windows .NET 4.8 E2E test results
@@ -104,7 +104,7 @@ jobs:
           fail-on-error: true
 
       - name: Windows .NET 8.0 E2E test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Windows .NET 8.0 E2E test results
@@ -148,7 +148,7 @@ jobs:
         run: dotnet test ./source/Octopus.Client.Tests/Octopus.Client.Tests.csproj  --configuration:Release --logger:"trx;LogFilePrefix=Linux" --results-directory ./TestResults
 
       - name: Linux unit test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Linux unit tests results
@@ -180,7 +180,7 @@ jobs:
         run: dotnet test ./source/Octopus.Client.Tests/Octopus.Client.Tests.csproj  --configuration:Release --logger:"trx;LogFilePrefix=Mac" --results-directory ./TestResults
 
       - name: Mac OS unit test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Mac OS unit test results


### PR DESCRIPTION
Added dependabot to check github actions and pinned third party actions, have left the default github and the internal actions.

Dependabot will now run weekly for this repo and check the github actions for updates

Also updated dorny/test-reporter to v2, and pinned release.

Before Merge:

- [x] ❓ We publish extensive test reports, Have we confirmed that these are not used elsewhere, and we are happy with the v2 change that will no longer publish them in the same way, but add to the summary.

