### PR TITLE
Add UseMachineCredentials for ECR feeds

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -2126,6 +2126,7 @@ Octopus.Client.Model
     Octopus.Client.Model.EcrOidcFeedAuthentication OidcAuthentication { get; set; }
     String Region { get; set; }
     Octopus.Client.Model.SensitiveValue SecretKey { get; set; }
+    Boolean UseMachineCredentials { get; set; }
   }
   class AzureContainerRegistryFeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -2143,6 +2143,7 @@ Octopus.Client.Model
     Octopus.Client.Model.EcrOidcFeedAuthentication OidcAuthentication { get; set; }
     String Region { get; set; }
     Octopus.Client.Model.SensitiveValue SecretKey { get; set; }
+    Boolean UseMachineCredentials { get; set; }
   }
   class AzureContainerRegistryFeedResource
     Octopus.Client.Extensibility.IResource

--- a/source/Octopus.Server.Client/Model/AwsElasticContainerRegistryFeedResource.cs
+++ b/source/Octopus.Server.Client/Model/AwsElasticContainerRegistryFeedResource.cs
@@ -21,6 +21,10 @@ namespace Octopus.Client.Model
 
         [Writeable]
         public EcrOidcFeedAuthentication? OidcAuthentication { get; set; }
+        
+        [Writeable]
+        public bool UseMachineCredentials { get; set; }
+
     }
 
     public class EcrOidcFeedAuthentication : IOidcFeedAuthentication


### PR DESCRIPTION
Adds UseMachineCredentials to AWS ECR feeds to support using worker credentials to authenticate.

[sc-104095]