### PR TITLE
Remove `Optional` attribute from Deployment Freezes

### DIFF
--- a/source/Octopus.Server.Client/Model/DeploymentFreezes/CreateDeploymentFreezeCommand.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentFreezes/CreateDeploymentFreezeCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Octopus.Server.MessageContracts.Base.Attributes;
 
 namespace Octopus.Client.Model.DeploymentFreezes;
 
@@ -18,12 +17,9 @@ public class CreateDeploymentFreezeCommand
     [Required(ErrorMessage = "Please provide an end time.")]
     public DateTimeOffset End { get; set; }
 
-    [Optional]
     public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope { get; set; }
 
-    [Optional]
     public List<TenantProjectEnvironment> TenantProjectEnvironmentScope { get; set; }
     
-    [Optional]
     public string OwnerId { get; set; }
 }

--- a/source/Octopus.Server.Client/Model/DeploymentFreezes/CreateDeploymentFreezeResponse.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentFreezes/CreateDeploymentFreezeResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Octopus.Server.MessageContracts.Base.Attributes;
 
 namespace Octopus.Client.Model.DeploymentFreezes;
 
@@ -19,13 +18,10 @@ public class CreateDeploymentFreezeResponse
     [Required]
     public DateTimeOffset End { get; set; }
         
-    [Optional]
     public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope  { get; set; }
 
-    [Optional]
     public List<TenantProjectEnvironment> TenantProjectEnvironmentScope  { get; set; }
 
-    [Optional] 
     public string OwnerId { get; set; }
 
 }

--- a/source/Octopus.Server.Client/Model/DeploymentFreezes/GetDeploymentFreezeByIdResponse.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentFreezes/GetDeploymentFreezeByIdResponse.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Octopus.Server.MessageContracts.Base.Attributes;
 
 namespace Octopus.Client.Model.DeploymentFreezes;
 
@@ -19,13 +18,10 @@ public class GetDeploymentFreezeByIdResponse
     [Required]
     public DateTimeOffset End { get; set; }
     
-    [Optional]
     public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope { get; protected set; }
 
-    [Optional]
     public List<TenantProjectEnvironment> TenantProjectEnvironmentScope { get; protected set; } 
     
-    [Optional]
     public string OwnerId { get; set;}
 
 }

--- a/source/Octopus.Server.Client/Model/DeploymentFreezes/GetDeploymentFreezesRequest.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentFreezes/GetDeploymentFreezesRequest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Octopus.Server.MessageContracts.Base.Attributes;
 
 namespace Octopus.Client.Model.DeploymentFreezes;
 
@@ -10,31 +9,26 @@ public class GetDeploymentFreezesRequest
     /// <summary>
     /// List of DeploymentFreeze IDs which if specified, filters the result to only include DeploymentFreeze with matching IDs.
     /// </summary>
-    [Optional]
     public IReadOnlyCollection<string> Ids { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// List of Project IDs which if specified, filters the result to only include DeploymentFreeze with matching Project IDs.
     /// </summary>
-    [Optional]
     public IReadOnlyCollection<string> ProjectIds { get; set; } = Array.Empty<string>();
     
     /// <summary>
     /// List of Tenant IDs which if specified, filters the result to only include DeploymentFreeze with matching Project IDs.
     /// </summary>
-    [Optional]
     public IReadOnlyCollection<string> TenantIds { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// List of Environment IDs which if specified, filters the result to only include DeploymentFreeze with matching Environment IDs.
     /// </summary>
-    [Optional]
     public IReadOnlyCollection<string> EnvironmentIds { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// A partial or complete name to search on. This will perform a "contains" style match against the supplied name or name-fragment
     /// </summary>
-    [Optional]
     public string PartialName { get; set; }
 
     [Required]

--- a/source/Octopus.Server.Client/Model/DeploymentFreezes/GetDeploymentFreezesResponse.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentFreezes/GetDeploymentFreezesResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Octopus.Server.MessageContracts.Base.Attributes;
 
 namespace Octopus.Client.Model.DeploymentFreezes;
 
@@ -22,9 +21,9 @@ public class DeploymentFreezeResource
 
     [Required] public DateTimeOffset End { get; set; }
 
-    [Optional] public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope { get; set; }
+    public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope { get; set; }
 
-    [Optional] public List<TenantProjectEnvironment> TenantProjectEnvironmentScope { get; set; }
+    public List<TenantProjectEnvironment> TenantProjectEnvironmentScope { get; set; }
     
-    [Optional] public string OwnerId { get; set; }
+    public string OwnerId { get; set; }
 }

--- a/source/Octopus.Server.Client/Model/DeploymentFreezes/ModifyDeploymentFreezeCommand.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentFreezes/ModifyDeploymentFreezeCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Octopus.Server.MessageContracts.Base.Attributes;
 
 namespace Octopus.Client.Model.DeploymentFreezes;
 
@@ -20,9 +19,9 @@ public class ModifyDeploymentFreezeCommand
     [Required(ErrorMessage = "Please provide an end time.")]
     public DateTimeOffset End { get; set; }
 
-    [Optional] public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope { get; set; }
+    public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope { get; set; }
     
-    [Optional] public List<TenantProjectEnvironment> TenantProjectEnvironmentScope { get; set; }
+    public List<TenantProjectEnvironment> TenantProjectEnvironmentScope { get; set; }
     
-    [Optional] public string OwnerId { get; set; }
+    public string OwnerId { get; set; }
 }

--- a/source/Octopus.Server.Client/Model/DeploymentFreezes/ModifyDeploymentFreezeResponse.cs
+++ b/source/Octopus.Server.Client/Model/DeploymentFreezes/ModifyDeploymentFreezeResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Octopus.Server.MessageContracts.Base.Attributes;
 
 namespace Octopus.Client.Model.DeploymentFreezes;
 
@@ -15,9 +14,9 @@ public class ModifyDeploymentFreezeResponse
 
     [Required] public DateTimeOffset End { get; set; }
 
-    [Optional] public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope { get; set; }
+    public Dictionary<string, ReferenceCollection> ProjectEnvironmentScope { get; set; }
     
-    [Optional] public List<TenantProjectEnvironment> TenantProjectEnvironmentScope { get; set; }
+    public List<TenantProjectEnvironment> TenantProjectEnvironmentScope { get; set; }
     
-    [Optional] public string OwnerId { get; set; }
+    public string OwnerId { get; set; }
 }


### PR DESCRIPTION
Unless this was an intentional inclusion, but since none of the other contracts have the Optional attribute (that is currently a server side concern), it looks like it wasn't. 

This will let us remove the `Octopus.Server.MessageContracts.Base` dependency.