### PR TITLE
Remove the `Octopus.Server.MessageContracts.Base` reference 

### DIFF
--- a/source/Octopus.Client.E2ETests/InlinedDependenciesFixture.cs
+++ b/source/Octopus.Client.E2ETests/InlinedDependenciesFixture.cs
@@ -49,7 +49,6 @@ namespace Octopus.Client.E2ETests
         [TestCase("Octopus.TinyTypes", "Octopus.TinyTypes.TinyType`1", Visibility.Internal)]
         [TestCase("Octopus.TinyTypes.Json", "Octopus.TinyTypes.Json.TinyTypeJsonConverter", Visibility.Internal)]
         [TestCase("Octopus.TinyTypes.TypeConverters", "Octopus.TinyTypes.TypeConverters.TinyTypeConverter`1", Visibility.Internal)]
-        [TestCase("Octopus.Server.MessageContracts.Base", "Octopus.Server.MessageContracts.Base.ICommand`2", Visibility.Public)]
         public void HasInlinedDependency(string library, string typeName, Visibility expectedVisibility)
         {
             var type = assembly.GetTypes()

--- a/source/Octopus.Server.Client/Octopus.Server.Client.csproj
+++ b/source/Octopus.Server.Client/Octopus.Server.Client.csproj
@@ -51,7 +51,6 @@ This package contains the non-ILmerged client library for the HTTP API in Octopu
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
     <PackageReference Include="Octopus.Octodiff" Version="2.0.547" />
-    <PackageReference Include="Octopus.Server.MessageContracts.Base" Version="3.2.810" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1317" />
     <PackageReference Include="Octopus.TinyTypes.Json" Version="2.2.1317" />
     <PackageReference Include="Octopus.TinyTypes.TypeConverters" Version="2.2.1317" />


### PR DESCRIPTION
It is no longer used by anything in the client.

The `Octopus.Client` assembly uses IL Inlining so that it can be standalone (`Octopus.Server.Client` does not).

I used dotPeak to compare this branch built assembly against the current release version and found the expected  differences:

![image](https://github.com/user-attachments/assets/cf6b1b55-f091-491f-acc0-ed9a4504c68c)

