### PR TITLE
Add Observability repository for live status

### DIFF
--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -190,6 +190,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.Async.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.Async.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.Async.IObservabilityRepository Observability { get; }
     Octopus.Client.Repositories.Async.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.Async.IProjectRepository Projects { get; }
     Octopus.Client.Repositories.Async.IProjectTriggerRepository ProjectTriggers { get; }
@@ -234,6 +235,7 @@ Octopus.Client
     Octopus.Client.Repositories.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.IObservabilityRepository Observability { get; }
     Octopus.Client.Repositories.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.IProjectRepository Projects { get; }
     Octopus.Client.Repositories.IProjectTriggerRepository ProjectTriggers { get; }
@@ -401,6 +403,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.Async.IMachineRepository Machines { get; }
     Octopus.Client.Repositories.Async.IMigrationRepository Migrations { get; }
+    Octopus.Client.Repositories.Async.IObservabilityRepository Observability { get; }
     Octopus.Client.Repositories.Async.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.Async.IPerformanceConfigurationRepository PerformanceConfiguration { get; }
     Octopus.Client.Repositories.Async.IProjectGroupRepository ProjectGroups { get; }
@@ -541,6 +544,7 @@ Octopus.Client
     Octopus.Client.Repositories.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.IMachineRepository Machines { get; }
     Octopus.Client.Repositories.IMigrationRepository Migrations { get; }
+    Octopus.Client.Repositories.IObservabilityRepository Observability { get; }
     Octopus.Client.Repositories.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.IPerformanceConfigurationRepository PerformanceConfiguration { get; }
     Octopus.Client.Repositories.IProjectGroupRepository ProjectGroups { get; }
@@ -7798,6 +7802,210 @@ Octopus.Client.Model.Migrations
     String TaskId { get; set; }
   }
 }
+Octopus.Client.Model.Observability
+{
+  class BeginContainerLogsSessionCommand
+  {
+    .ctor()
+    String ContainerName { get; set; }
+    Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+    String EnvironmentId { get; set; }
+    String MachineId { get; set; }
+    String PodName { get; set; }
+    String ProjectId { get; set; }
+    Boolean ShowPreviousContainer { get; set; }
+    String TenantId { get; set; }
+  }
+  class BeginContainerLogsSessionResponse
+  {
+    .ctor()
+    String SessionId { get; set; }
+  }
+  class BeginResourceEventsSessionCommand
+  {
+    .ctor()
+    Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+    String EnvironmentId { get; set; }
+    String MachineId { get; set; }
+    String ProjectId { get; set; }
+    String TenantId { get; set; }
+  }
+  class BeginResourceEventsSessionResponse
+  {
+    .ctor()
+    String SessionId { get; set; }
+  }
+  class ContainerLogLineResource
+  {
+    .ctor()
+    String Message { get; set; }
+    Instant Timestamp { get; set; }
+  }
+  class GetContainerLogsRequest
+  {
+    .ctor()
+    String SessionId { get; set; }
+  }
+  class GetContainerLogsResponse
+  {
+    .ctor()
+    Octopus.Client.Model.Observability.MonitorErrorResource Error { get; set; }
+    Boolean IsSessionCompleted { get; set; }
+    ICollection<ContainerLogLineResource> Logs { get; set; }
+  }
+  class GetLiveStatusRequest
+  {
+    .ctor()
+    String EnvironmentId { get; set; }
+    String ProjectId { get; set; }
+    Boolean SummaryOnly { get; set; }
+    String TenantId { get; set; }
+  }
+  class GetLiveStatusResponse
+  {
+    .ctor()
+    IReadOnlyCollection<KubernetesMachineLiveStatusResource> MachineStatuses { get; set; }
+    Octopus.Client.Model.Observability.LiveStatusSummaryResource Summary { get; set; }
+  }
+  class GetResourceEventsRequest
+  {
+    .ctor()
+    String SessionId { get; set; }
+  }
+  class GetResourceEventsResponse
+  {
+    .ctor()
+    Octopus.Client.Model.Observability.MonitorErrorResource Error { get; set; }
+    ICollection<KubernetesEventResource> Events { get; set; }
+    Boolean IsSessionCompleted { get; set; }
+  }
+  class GetResourceManifestRequest
+  {
+    .ctor()
+    Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+    String EnvironmentId { get; set; }
+    String MachineId { get; set; }
+    String ProjectId { get; set; }
+    String TenantId { get; set; }
+  }
+  class GetResourceManifestResponse
+  {
+    .ctor()
+    String DesiredManifest { get; set; }
+    Octopus.Client.Model.Observability.LiveResourceDiff Diff { get; set; }
+    String LiveManifest { get; set; }
+  }
+  class GetResourceRequest
+  {
+    .ctor()
+    Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+    String EnvironmentId { get; set; }
+    String MachineId { get; set; }
+    String ProjectId { get; set; }
+    String TenantId { get; set; }
+  }
+  class GetResourceResponse
+  {
+    .ctor()
+    Octopus.Client.Model.Observability.KubernetesLiveStatusDetailedResource Resource { get; set; }
+  }
+  class KubernetesEventResource
+  {
+    .ctor()
+    String Action { get; set; }
+    Int32 Count { get; set; }
+    Instant FirstObservedTime { get; set; }
+    Instant LastObservedTime { get; set; }
+    String Manifest { get; set; }
+    String Note { get; set; }
+    String Reason { get; set; }
+    String ReportingController { get; set; }
+    String ReportingInstance { get; set; }
+    String Type { get; set; }
+  }
+  class KubernetesLiveStatusDetailedResource
+  {
+    .ctor()
+    IReadOnlyCollection<KubernetesLiveStatusDetailedResource> Children { get; set; }
+    Nullable<Guid> DesiredResourceId { get; set; }
+    Octopus.Client.Model.Observability.KubernetesLiveStatusManifestDetailsResource Details { get; set; }
+    String HealthStatus { get; set; }
+    String Kind { get; set; }
+    Instant LastUpdated { get; set; }
+    String MachineId { get; set; }
+    String Name { get; set; }
+    String Namespace { get; set; }
+    Nullable<Guid> ResourceId { get; set; }
+    String SyncStatus { get; set; }
+  }
+  class KubernetesLiveStatusManifestDetailsResource
+  {
+    .ctor()
+    Dictionary<String, String> Annotations { get; set; }
+    IReadOnlyCollection<String> Containers { get; set; }
+    DateTimeOffset CreationTimestamp { get; set; }
+    Dictionary<String, String> Labels { get; set; }
+  }
+  class KubernetesLiveStatusResource
+  {
+    .ctor()
+    IReadOnlyCollection<KubernetesLiveStatusResource> Children { get; set; }
+    Nullable<Guid> DesiredResourceId { get; set; }
+    String HealthStatus { get; set; }
+    String Kind { get; set; }
+    String MachineId { get; set; }
+    String Name { get; set; }
+    String Namespace { get; set; }
+    Nullable<Guid> ResourceId { get; set; }
+    String SyncStatus { get; set; }
+  }
+  class KubernetesMachineLiveStatusResource
+  {
+    .ctor()
+    String MachineId { get; set; }
+    IReadOnlyCollection<KubernetesLiveStatusResource> Resources { get; set; }
+    String Status { get; set; }
+  }
+  class KubernetesMonitorResource
+  {
+    .ctor()
+    String Id { get; set; }
+    String InstallationId { get; set; }
+    String MachineId { get; set; }
+  }
+  class LiveResourceDiff
+  {
+    .ctor()
+    String Diff { get; set; }
+    String Left { get; set; }
+    String Right { get; set; }
+  }
+  class LiveStatusSummaryResource
+  {
+    .ctor()
+    Instant LastUpdated { get; set; }
+    String Status { get; set; }
+  }
+  class MonitorErrorResource
+  {
+    .ctor()
+    String ErrorCode { get; set; }
+    String ErrorMessage { get; set; }
+  }
+  class RegisterKubernetesMonitorCommand
+  {
+    .ctor()
+    String InstallationId { get; set; }
+    String MachineId { get; set; }
+  }
+  class RegisterKubernetesMonitorResponse
+  {
+    .ctor()
+    String AuthenticationToken { get; set; }
+    String CertificateThumbprint { get; set; }
+    Octopus.Client.Model.Observability.KubernetesMonitorResource Resource { get; set; }
+  }
+}
 Octopus.Client.Model.SmtpConfiguration
 {
   class AzureSmtpConfigurationResource
@@ -8824,6 +9032,17 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Repositories.TResource Modify(Octopus.Client.Repositories.TResource)
   }
+  interface IObservabilityRepository
+  {
+    Octopus.Client.Model.Observability.BeginContainerLogsSessionResponse BeginContainerLogsSession(Octopus.Client.Model.Observability.BeginContainerLogsSessionCommand)
+    Octopus.Client.Model.Observability.BeginResourceEventsSessionResponse BeginResourceEventsSession(Octopus.Client.Model.Observability.BeginResourceEventsSessionCommand)
+    Octopus.Client.Model.Observability.GetLiveStatusResponse Get(Octopus.Client.Model.Observability.GetLiveStatusRequest)
+    Octopus.Client.Model.Observability.GetContainerLogsResponse GetContainerLogs(Octopus.Client.Model.Observability.GetContainerLogsRequest)
+    Octopus.Client.Model.Observability.GetResourceResponse GetResource(Octopus.Client.Model.Observability.GetResourceRequest)
+    Octopus.Client.Model.Observability.GetResourceEventsResponse GetResourceEvents(Octopus.Client.Model.Observability.GetResourceEventsRequest)
+    Octopus.Client.Model.Observability.GetResourceManifestResponse GetResourceManifest(Octopus.Client.Model.Observability.GetResourceManifestRequest)
+    Octopus.Client.Model.Observability.RegisterKubernetesMonitorResponse RegisterKubernetesMonitor(Octopus.Client.Model.Observability.RegisterKubernetesMonitorCommand)
+  }
   interface IOctopusServerNodeRepository
     Octopus.Client.Repositories.IModify<OctopusServerNodeResource>
     Octopus.Client.Repositories.IDelete<OctopusServerNodeResource>
@@ -9212,6 +9431,19 @@ Octopus.Client.Repositories
     List<WorkerResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.WorkerResource)
     Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+  }
+  class ObservabilityRepository
+    Octopus.Client.Repositories.IObservabilityRepository
+  {
+    .ctor(Octopus.Client.IOctopusRepository)
+    Octopus.Client.Model.Observability.BeginContainerLogsSessionResponse BeginContainerLogsSession(Octopus.Client.Model.Observability.BeginContainerLogsSessionCommand)
+    Octopus.Client.Model.Observability.BeginResourceEventsSessionResponse BeginResourceEventsSession(Octopus.Client.Model.Observability.BeginResourceEventsSessionCommand)
+    Octopus.Client.Model.Observability.GetLiveStatusResponse Get(Octopus.Client.Model.Observability.GetLiveStatusRequest)
+    Octopus.Client.Model.Observability.GetContainerLogsResponse GetContainerLogs(Octopus.Client.Model.Observability.GetContainerLogsRequest)
+    Octopus.Client.Model.Observability.GetResourceResponse GetResource(Octopus.Client.Model.Observability.GetResourceRequest)
+    Octopus.Client.Model.Observability.GetResourceEventsResponse GetResourceEvents(Octopus.Client.Model.Observability.GetResourceEventsRequest)
+    Octopus.Client.Model.Observability.GetResourceManifestResponse GetResourceManifest(Octopus.Client.Model.Observability.GetResourceManifestRequest)
+    Octopus.Client.Model.Observability.RegisterKubernetesMonitorResponse RegisterKubernetesMonitor(Octopus.Client.Model.Observability.RegisterKubernetesMonitorCommand)
   }
   class PerformanceConfigurationRepository
     Octopus.Client.Repositories.IPerformanceConfigurationRepository
@@ -9618,6 +9850,17 @@ Octopus.Client.Repositories.Async
   {
     Task<TResource> Modify(Octopus.Client.Repositories.Async.TResource)
     Task<TResource> Modify(Octopus.Client.Repositories.Async.TResource, CancellationToken)
+  }
+  interface IObservabilityRepository
+  {
+    Task<BeginContainerLogsSessionResponse> BeginContainerLogsSession(Octopus.Client.Model.Observability.BeginContainerLogsSessionCommand, CancellationToken)
+    Task<BeginResourceEventsSessionResponse> BeginResourceEventsSession(Octopus.Client.Model.Observability.BeginResourceEventsSessionCommand, CancellationToken)
+    Task<GetLiveStatusResponse> Get(Octopus.Client.Model.Observability.GetLiveStatusRequest, CancellationToken)
+    Task<GetContainerLogsResponse> GetContainerLogs(Octopus.Client.Model.Observability.GetContainerLogsRequest, CancellationToken)
+    Task<GetResourceResponse> GetResource(Octopus.Client.Model.Observability.GetResourceRequest, CancellationToken)
+    Task<GetResourceEventsResponse> GetResourceEvents(Octopus.Client.Model.Observability.GetResourceEventsRequest, CancellationToken)
+    Task<GetResourceManifestResponse> GetResourceManifest(Octopus.Client.Model.Observability.GetResourceManifestRequest, CancellationToken)
+    Task<RegisterKubernetesMonitorResponse> RegisterKubernetesMonitor(Octopus.Client.Model.Observability.RegisterKubernetesMonitorCommand, CancellationToken)
   }
   interface IOctopusServerNodeRepository
     Octopus.Client.Repositories.Async.IModify<OctopusServerNodeResource>
@@ -10096,6 +10339,19 @@ Octopus.Client.Repositories.Async
     Task<List<WorkerResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource)
     Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+  }
+  class ObservabilityRepository
+    Octopus.Client.Repositories.Async.IObservabilityRepository
+  {
+    .ctor(Octopus.Client.IOctopusAsyncRepository)
+    Task<BeginContainerLogsSessionResponse> BeginContainerLogsSession(Octopus.Client.Model.Observability.BeginContainerLogsSessionCommand, CancellationToken)
+    Task<BeginResourceEventsSessionResponse> BeginResourceEventsSession(Octopus.Client.Model.Observability.BeginResourceEventsSessionCommand, CancellationToken)
+    Task<GetLiveStatusResponse> Get(Octopus.Client.Model.Observability.GetLiveStatusRequest, CancellationToken)
+    Task<GetContainerLogsResponse> GetContainerLogs(Octopus.Client.Model.Observability.GetContainerLogsRequest, CancellationToken)
+    Task<GetResourceResponse> GetResource(Octopus.Client.Model.Observability.GetResourceRequest, CancellationToken)
+    Task<GetResourceEventsResponse> GetResourceEvents(Octopus.Client.Model.Observability.GetResourceEventsRequest, CancellationToken)
+    Task<GetResourceManifestResponse> GetResourceManifest(Octopus.Client.Model.Observability.GetResourceManifestRequest, CancellationToken)
+    Task<RegisterKubernetesMonitorResponse> RegisterKubernetesMonitor(Octopus.Client.Model.Observability.RegisterKubernetesMonitorCommand, CancellationToken)
   }
   class SpaceScopedOperationOutsideOfCurrentSpaceContextException
     ISerializable

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETCore.approved.txt
@@ -7928,23 +7928,15 @@ Octopus.Client.Model.Observability
     .ctor()
     IReadOnlyCollection<KubernetesLiveStatusDetailedResource> Children { get; set; }
     Nullable<Guid> DesiredResourceId { get; set; }
-    Octopus.Client.Model.Observability.KubernetesLiveStatusManifestDetailsResource Details { get; set; }
     String HealthStatus { get; set; }
     String Kind { get; set; }
     Instant LastUpdated { get; set; }
     String MachineId { get; set; }
+    Octopus.Client.Model.Observability.ManifestSummaryResource ManifestSummary { get; set; }
     String Name { get; set; }
     String Namespace { get; set; }
     Nullable<Guid> ResourceId { get; set; }
     String SyncStatus { get; set; }
-  }
-  class KubernetesLiveStatusManifestDetailsResource
-  {
-    .ctor()
-    Dictionary<String, String> Annotations { get; set; }
-    IReadOnlyCollection<String> Containers { get; set; }
-    DateTimeOffset CreationTimestamp { get; set; }
-    Dictionary<String, String> Labels { get; set; }
   }
   class KubernetesLiveStatusResource
   {
@@ -7986,11 +7978,24 @@ Octopus.Client.Model.Observability
     Instant LastUpdated { get; set; }
     String Status { get; set; }
   }
+  class ManifestSummaryResource
+  {
+    .ctor()
+    Dictionary<String, String> Annotations { get; set; }
+    DateTimeOffset CreationTimestamp { get; set; }
+    Dictionary<String, String> Labels { get; set; }
+  }
   class MonitorErrorResource
   {
     .ctor()
     String ErrorCode { get; set; }
     String ErrorMessage { get; set; }
+  }
+  class PodManifestSummaryResource
+    Octopus.Client.Model.Observability.ManifestSummaryResource
+  {
+    .ctor()
+    IReadOnlyCollection<String> Containers { get; set; }
   }
   class RegisterKubernetesMonitorCommand
   {

--- a/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
+++ b/source/Octopus.Client.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress..NETFramework.approved.txt
@@ -190,6 +190,7 @@ Octopus.Client
     Octopus.Client.Repositories.Async.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.Async.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.Async.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.Async.IObservabilityRepository Observability { get; }
     Octopus.Client.Repositories.Async.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.Async.IProjectRepository Projects { get; }
     Octopus.Client.Repositories.Async.IProjectTriggerRepository ProjectTriggers { get; }
@@ -234,6 +235,7 @@ Octopus.Client
     Octopus.Client.Repositories.IMachinePolicyRepository MachinePolicies { get; }
     Octopus.Client.Repositories.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.IMachineRepository Machines { get; }
+    Octopus.Client.Repositories.IObservabilityRepository Observability { get; }
     Octopus.Client.Repositories.IProjectGroupRepository ProjectGroups { get; }
     Octopus.Client.Repositories.IProjectRepository Projects { get; }
     Octopus.Client.Repositories.IProjectTriggerRepository ProjectTriggers { get; }
@@ -539,6 +541,7 @@ Octopus.Client
     Octopus.Client.Repositories.IMachineRoleRepository MachineRoles { get; }
     Octopus.Client.Repositories.IMachineRepository Machines { get; }
     Octopus.Client.Repositories.IMigrationRepository Migrations { get; }
+    Octopus.Client.Repositories.IObservabilityRepository Observability { get; }
     Octopus.Client.Repositories.IOctopusServerNodeRepository OctopusServerNodes { get; }
     Octopus.Client.Repositories.IPerformanceConfigurationRepository PerformanceConfiguration { get; }
     Octopus.Client.Repositories.IProjectGroupRepository ProjectGroups { get; }
@@ -7821,6 +7824,210 @@ Octopus.Client.Model.Migrations
     String TaskId { get; set; }
   }
 }
+Octopus.Client.Model.Observability
+{
+  class BeginContainerLogsSessionCommand
+  {
+    .ctor()
+    String ContainerName { get; set; }
+    Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+    String EnvironmentId { get; set; }
+    String MachineId { get; set; }
+    String PodName { get; set; }
+    String ProjectId { get; set; }
+    Boolean ShowPreviousContainer { get; set; }
+    String TenantId { get; set; }
+  }
+  class BeginContainerLogsSessionResponse
+  {
+    .ctor()
+    String SessionId { get; set; }
+  }
+  class BeginResourceEventsSessionCommand
+  {
+    .ctor()
+    Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+    String EnvironmentId { get; set; }
+    String MachineId { get; set; }
+    String ProjectId { get; set; }
+    String TenantId { get; set; }
+  }
+  class BeginResourceEventsSessionResponse
+  {
+    .ctor()
+    String SessionId { get; set; }
+  }
+  class ContainerLogLineResource
+  {
+    .ctor()
+    String Message { get; set; }
+    Instant Timestamp { get; set; }
+  }
+  class GetContainerLogsRequest
+  {
+    .ctor()
+    String SessionId { get; set; }
+  }
+  class GetContainerLogsResponse
+  {
+    .ctor()
+    Octopus.Client.Model.Observability.MonitorErrorResource Error { get; set; }
+    Boolean IsSessionCompleted { get; set; }
+    ICollection<ContainerLogLineResource> Logs { get; set; }
+  }
+  class GetLiveStatusRequest
+  {
+    .ctor()
+    String EnvironmentId { get; set; }
+    String ProjectId { get; set; }
+    Boolean SummaryOnly { get; set; }
+    String TenantId { get; set; }
+  }
+  class GetLiveStatusResponse
+  {
+    .ctor()
+    IReadOnlyCollection<KubernetesMachineLiveStatusResource> MachineStatuses { get; set; }
+    Octopus.Client.Model.Observability.LiveStatusSummaryResource Summary { get; set; }
+  }
+  class GetResourceEventsRequest
+  {
+    .ctor()
+    String SessionId { get; set; }
+  }
+  class GetResourceEventsResponse
+  {
+    .ctor()
+    Octopus.Client.Model.Observability.MonitorErrorResource Error { get; set; }
+    ICollection<KubernetesEventResource> Events { get; set; }
+    Boolean IsSessionCompleted { get; set; }
+  }
+  class GetResourceManifestRequest
+  {
+    .ctor()
+    Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+    String EnvironmentId { get; set; }
+    String MachineId { get; set; }
+    String ProjectId { get; set; }
+    String TenantId { get; set; }
+  }
+  class GetResourceManifestResponse
+  {
+    .ctor()
+    String DesiredManifest { get; set; }
+    Octopus.Client.Model.Observability.LiveResourceDiff Diff { get; set; }
+    String LiveManifest { get; set; }
+  }
+  class GetResourceRequest
+  {
+    .ctor()
+    Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+    String EnvironmentId { get; set; }
+    String MachineId { get; set; }
+    String ProjectId { get; set; }
+    String TenantId { get; set; }
+  }
+  class GetResourceResponse
+  {
+    .ctor()
+    Octopus.Client.Model.Observability.KubernetesLiveStatusDetailedResource Resource { get; set; }
+  }
+  class KubernetesEventResource
+  {
+    .ctor()
+    String Action { get; set; }
+    Int32 Count { get; set; }
+    Instant FirstObservedTime { get; set; }
+    Instant LastObservedTime { get; set; }
+    String Manifest { get; set; }
+    String Note { get; set; }
+    String Reason { get; set; }
+    String ReportingController { get; set; }
+    String ReportingInstance { get; set; }
+    String Type { get; set; }
+  }
+  class KubernetesLiveStatusDetailedResource
+  {
+    .ctor()
+    IReadOnlyCollection<KubernetesLiveStatusDetailedResource> Children { get; set; }
+    Nullable<Guid> DesiredResourceId { get; set; }
+    Octopus.Client.Model.Observability.KubernetesLiveStatusManifestDetailsResource Details { get; set; }
+    String HealthStatus { get; set; }
+    String Kind { get; set; }
+    Instant LastUpdated { get; set; }
+    String MachineId { get; set; }
+    String Name { get; set; }
+    String Namespace { get; set; }
+    Nullable<Guid> ResourceId { get; set; }
+    String SyncStatus { get; set; }
+  }
+  class KubernetesLiveStatusManifestDetailsResource
+  {
+    .ctor()
+    Dictionary<String, String> Annotations { get; set; }
+    IReadOnlyCollection<String> Containers { get; set; }
+    DateTimeOffset CreationTimestamp { get; set; }
+    Dictionary<String, String> Labels { get; set; }
+  }
+  class KubernetesLiveStatusResource
+  {
+    .ctor()
+    IReadOnlyCollection<KubernetesLiveStatusResource> Children { get; set; }
+    Nullable<Guid> DesiredResourceId { get; set; }
+    String HealthStatus { get; set; }
+    String Kind { get; set; }
+    String MachineId { get; set; }
+    String Name { get; set; }
+    String Namespace { get; set; }
+    Nullable<Guid> ResourceId { get; set; }
+    String SyncStatus { get; set; }
+  }
+  class KubernetesMachineLiveStatusResource
+  {
+    .ctor()
+    String MachineId { get; set; }
+    IReadOnlyCollection<KubernetesLiveStatusResource> Resources { get; set; }
+    String Status { get; set; }
+  }
+  class KubernetesMonitorResource
+  {
+    .ctor()
+    String Id { get; set; }
+    String InstallationId { get; set; }
+    String MachineId { get; set; }
+  }
+  class LiveResourceDiff
+  {
+    .ctor()
+    String Diff { get; set; }
+    String Left { get; set; }
+    String Right { get; set; }
+  }
+  class LiveStatusSummaryResource
+  {
+    .ctor()
+    Instant LastUpdated { get; set; }
+    String Status { get; set; }
+  }
+  class MonitorErrorResource
+  {
+    .ctor()
+    String ErrorCode { get; set; }
+    String ErrorMessage { get; set; }
+  }
+  class RegisterKubernetesMonitorCommand
+  {
+    .ctor()
+    String InstallationId { get; set; }
+    String MachineId { get; set; }
+  }
+  class RegisterKubernetesMonitorResponse
+  {
+    .ctor()
+    String AuthenticationToken { get; set; }
+    String CertificateThumbprint { get; set; }
+    Octopus.Client.Model.Observability.KubernetesMonitorResource Resource { get; set; }
+  }
+}
 Octopus.Client.Model.SmtpConfiguration
 {
   class AzureSmtpConfigurationResource
@@ -8848,6 +9055,17 @@ Octopus.Client.Repositories
   {
     Octopus.Client.Repositories.TResource Modify(Octopus.Client.Repositories.TResource)
   }
+  interface IObservabilityRepository
+  {
+    Octopus.Client.Model.Observability.BeginContainerLogsSessionResponse BeginContainerLogsSession(Octopus.Client.Model.Observability.BeginContainerLogsSessionCommand)
+    Octopus.Client.Model.Observability.BeginResourceEventsSessionResponse BeginResourceEventsSession(Octopus.Client.Model.Observability.BeginResourceEventsSessionCommand)
+    Octopus.Client.Model.Observability.GetLiveStatusResponse Get(Octopus.Client.Model.Observability.GetLiveStatusRequest)
+    Octopus.Client.Model.Observability.GetContainerLogsResponse GetContainerLogs(Octopus.Client.Model.Observability.GetContainerLogsRequest)
+    Octopus.Client.Model.Observability.GetResourceResponse GetResource(Octopus.Client.Model.Observability.GetResourceRequest)
+    Octopus.Client.Model.Observability.GetResourceEventsResponse GetResourceEvents(Octopus.Client.Model.Observability.GetResourceEventsRequest)
+    Octopus.Client.Model.Observability.GetResourceManifestResponse GetResourceManifest(Octopus.Client.Model.Observability.GetResourceManifestRequest)
+    Octopus.Client.Model.Observability.RegisterKubernetesMonitorResponse RegisterKubernetesMonitor(Octopus.Client.Model.Observability.RegisterKubernetesMonitorCommand)
+  }
   interface IOctopusServerNodeRepository
     Octopus.Client.Repositories.IModify<OctopusServerNodeResource>
     Octopus.Client.Repositories.IDelete<OctopusServerNodeResource>
@@ -9236,6 +9454,19 @@ Octopus.Client.Repositories
     List<WorkerResource> FindByThumbprint(String)
     Octopus.Client.Model.MachineConnectionStatus GetConnectionStatus(Octopus.Client.Model.WorkerResource)
     Octopus.Client.Model.ResourceCollection<WorkerResource> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+  }
+  class ObservabilityRepository
+    Octopus.Client.Repositories.IObservabilityRepository
+  {
+    .ctor(Octopus.Client.IOctopusRepository)
+    Octopus.Client.Model.Observability.BeginContainerLogsSessionResponse BeginContainerLogsSession(Octopus.Client.Model.Observability.BeginContainerLogsSessionCommand)
+    Octopus.Client.Model.Observability.BeginResourceEventsSessionResponse BeginResourceEventsSession(Octopus.Client.Model.Observability.BeginResourceEventsSessionCommand)
+    Octopus.Client.Model.Observability.GetLiveStatusResponse Get(Octopus.Client.Model.Observability.GetLiveStatusRequest)
+    Octopus.Client.Model.Observability.GetContainerLogsResponse GetContainerLogs(Octopus.Client.Model.Observability.GetContainerLogsRequest)
+    Octopus.Client.Model.Observability.GetResourceResponse GetResource(Octopus.Client.Model.Observability.GetResourceRequest)
+    Octopus.Client.Model.Observability.GetResourceEventsResponse GetResourceEvents(Octopus.Client.Model.Observability.GetResourceEventsRequest)
+    Octopus.Client.Model.Observability.GetResourceManifestResponse GetResourceManifest(Octopus.Client.Model.Observability.GetResourceManifestRequest)
+    Octopus.Client.Model.Observability.RegisterKubernetesMonitorResponse RegisterKubernetesMonitor(Octopus.Client.Model.Observability.RegisterKubernetesMonitorCommand)
   }
   class PerformanceConfigurationRepository
     Octopus.Client.Repositories.IPerformanceConfigurationRepository
@@ -9642,6 +9873,17 @@ Octopus.Client.Repositories.Async
   {
     Task<TResource> Modify(Octopus.Client.Repositories.Async.TResource)
     Task<TResource> Modify(Octopus.Client.Repositories.Async.TResource, CancellationToken)
+  }
+  interface IObservabilityRepository
+  {
+    Task<BeginContainerLogsSessionResponse> BeginContainerLogsSession(Octopus.Client.Model.Observability.BeginContainerLogsSessionCommand, CancellationToken)
+    Task<BeginResourceEventsSessionResponse> BeginResourceEventsSession(Octopus.Client.Model.Observability.BeginResourceEventsSessionCommand, CancellationToken)
+    Task<GetLiveStatusResponse> Get(Octopus.Client.Model.Observability.GetLiveStatusRequest, CancellationToken)
+    Task<GetContainerLogsResponse> GetContainerLogs(Octopus.Client.Model.Observability.GetContainerLogsRequest, CancellationToken)
+    Task<GetResourceResponse> GetResource(Octopus.Client.Model.Observability.GetResourceRequest, CancellationToken)
+    Task<GetResourceEventsResponse> GetResourceEvents(Octopus.Client.Model.Observability.GetResourceEventsRequest, CancellationToken)
+    Task<GetResourceManifestResponse> GetResourceManifest(Octopus.Client.Model.Observability.GetResourceManifestRequest, CancellationToken)
+    Task<RegisterKubernetesMonitorResponse> RegisterKubernetesMonitor(Octopus.Client.Model.Observability.RegisterKubernetesMonitorCommand, CancellationToken)
   }
   interface IOctopusServerNodeRepository
     Octopus.Client.Repositories.Async.IModify<OctopusServerNodeResource>
@@ -10120,6 +10362,19 @@ Octopus.Client.Repositories.Async
     Task<List<WorkerResource>> FindByThumbprint(String)
     Task<MachineConnectionStatus> GetConnectionStatus(Octopus.Client.Model.WorkerResource)
     Task<ResourceCollection<WorkerResource>> List(Int32, Nullable<Int32>, String, String, String, Nullable<Boolean>, String, String, String)
+  }
+  class ObservabilityRepository
+    Octopus.Client.Repositories.Async.IObservabilityRepository
+  {
+    .ctor(Octopus.Client.IOctopusAsyncRepository)
+    Task<BeginContainerLogsSessionResponse> BeginContainerLogsSession(Octopus.Client.Model.Observability.BeginContainerLogsSessionCommand, CancellationToken)
+    Task<BeginResourceEventsSessionResponse> BeginResourceEventsSession(Octopus.Client.Model.Observability.BeginResourceEventsSessionCommand, CancellationToken)
+    Task<GetLiveStatusResponse> Get(Octopus.Client.Model.Observability.GetLiveStatusRequest, CancellationToken)
+    Task<GetContainerLogsResponse> GetContainerLogs(Octopus.Client.Model.Observability.GetContainerLogsRequest, CancellationToken)
+    Task<GetResourceResponse> GetResource(Octopus.Client.Model.Observability.GetResourceRequest, CancellationToken)
+    Task<GetResourceEventsResponse> GetResourceEvents(Octopus.Client.Model.Observability.GetResourceEventsRequest, CancellationToken)
+    Task<GetResourceManifestResponse> GetResourceManifest(Octopus.Client.Model.Observability.GetResourceManifestRequest, CancellationToken)
+    Task<RegisterKubernetesMonitorResponse> RegisterKubernetesMonitor(Octopus.Client.Model.Observability.RegisterKubernetesMonitorCommand, CancellationToken)
   }
   class SpaceScopedOperationOutsideOfCurrentSpaceContextException
     ISerializable

--- a/source/Octopus.Server.Client/IOctopusSpaceAsyncRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusSpaceAsyncRepository.cs
@@ -33,6 +33,7 @@ namespace Octopus.Client
         IMachinePolicyRepository MachinePolicies { get; }
         IMachineRepository Machines { get; }
         IMachineRoleRepository MachineRoles { get; }
+        IObservabilityRepository Observability { get; }
         IProjectGroupRepository ProjectGroups { get; }
         IProjectRepository Projects { get; }
         IRunbookRepository Runbooks { get; }

--- a/source/Octopus.Server.Client/IOctopusSpaceRepository.cs
+++ b/source/Octopus.Server.Client/IOctopusSpaceRepository.cs
@@ -32,6 +32,7 @@ namespace Octopus.Client
         IMachinePolicyRepository MachinePolicies { get; }
         IMachineRepository Machines { get; }
         IMachineRoleRepository MachineRoles { get; }
+        IObservabilityRepository Observability { get; }
         IProjectGroupRepository ProjectGroups { get; }
         IProjectRepository Projects { get; }
         IRunbookRepository Runbooks { get; }

--- a/source/Octopus.Server.Client/Model/Observability/BeginContainerLogsSessionCommand.cs
+++ b/source/Octopus.Server.Client/Model/Observability/BeginContainerLogsSessionCommand.cs
@@ -1,0 +1,30 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class BeginContainerLogsSessionCommand
+{
+    [Required]
+    public string ProjectId { get; set; }
+
+    [Required]
+    public string EnvironmentId { get; set; }
+
+    public string TenantId { get; set; }
+
+    [Required]
+    public string MachineId { get; set; }
+
+    [Required]
+    public Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+
+    [Required]
+    public string PodName { get; set; }
+
+    [Required]
+    public string ContainerName { get; set; }
+
+    [Required]
+    public bool ShowPreviousContainer { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/BeginContainerLogsSessionResponse.cs
+++ b/source/Octopus.Server.Client/Model/Observability/BeginContainerLogsSessionResponse.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class BeginContainerLogsSessionResponse
+{
+    [Required]
+    public string SessionId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/BeginResourceEventsSessionCommand.cs
+++ b/source/Octopus.Server.Client/Model/Observability/BeginResourceEventsSessionCommand.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class BeginResourceEventsSessionCommand
+{
+    [Required]
+    public string ProjectId { get; set; }
+
+    [Required]
+    public string EnvironmentId { get; set; }
+
+    public string TenantId { get; set; }
+
+    [Required]
+    public string MachineId { get; set; }
+
+    [Required]
+    public Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/BeginResourceEventsSessionResponse.cs
+++ b/source/Octopus.Server.Client/Model/Observability/BeginResourceEventsSessionResponse.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class BeginResourceEventsSessionResponse
+{
+    [Required]
+    public string SessionId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/ContainerLogLineResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/ContainerLogLineResource.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using NodaTime;
+
+namespace Octopus.Client.Model.Observability;
+
+public class ContainerLogLineResource
+{
+    [Required]
+    public Instant Timestamp { get; set; }
+
+    [Required]
+    public string Message { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetContainerLogsRequest.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetContainerLogsRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetContainerLogsRequest
+{
+    [Required]
+    public string SessionId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetContainerLogsResponse.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetContainerLogsResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetContainerLogsResponse
+{
+    [Required]
+    public ICollection<ContainerLogLineResource> Logs { get; set; }
+
+    [Required]
+    public bool IsSessionCompleted { get; set; }
+
+    public MonitorErrorResource Error { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetLiveStatusRequest.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetLiveStatusRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetLiveStatusRequest
+{
+    [Required]
+    public string ProjectId { get; set; }
+
+    [Required]
+    public string EnvironmentId { get; set; }
+
+    public string TenantId { get; set; }
+
+    public bool SummaryOnly { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetLiveStatusResponse.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetLiveStatusResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetLiveStatusResponse
+{
+    [Required]
+    public IReadOnlyCollection<KubernetesMachineLiveStatusResource> MachineStatuses { get; set; }
+
+    [Required]
+    public LiveStatusSummaryResource Summary { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetResourceEventsRequest.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetResourceEventsRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetResourceEventsRequest
+{
+    [Required]
+    public string SessionId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetResourceEventsResponse.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetResourceEventsResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetResourceEventsResponse
+{
+    [Required]
+    public ICollection<KubernetesEventResource> Events { get; set; }
+
+    [Required]
+    public bool IsSessionCompleted { get; set; }
+
+    public MonitorErrorResource Error { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetResourceManifestRequest.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetResourceManifestRequest.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetResourceManifestRequest
+{
+    [Required]
+    public string ProjectId { get; set; }
+
+    [Required]
+    public string EnvironmentId { get; set; }
+
+    public string TenantId { get; set; }
+
+    [Required]
+    public string MachineId { get; set; }
+
+    [Required]
+    public Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetResourceManifestResponse.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetResourceManifestResponse.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetResourceManifestResponse
+{
+    [Required]
+    public string LiveManifest { get; set; }
+
+    public string DesiredManifest { get; set; }
+
+    public LiveResourceDiff Diff { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetResourceRequest.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetResourceRequest.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetResourceRequest
+{
+    [Required]
+    public string ProjectId { get; set; }
+
+    [Required]
+    public string EnvironmentId { get; set; }
+
+    public string TenantId { get; set; }
+
+    [Required]
+    public string MachineId { get; set; }
+
+    [Required]
+    public Guid DesiredOrKubernetesMonitoredResourceId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/GetResourceResponse.cs
+++ b/source/Octopus.Server.Client/Model/Observability/GetResourceResponse.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class GetResourceResponse
+{
+    [Required]
+    public KubernetesLiveStatusDetailedResource Resource { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/KubernetesEventResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/KubernetesEventResource.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+using NodaTime;
+
+namespace Octopus.Client.Model.Observability;
+
+public class KubernetesEventResource
+{
+    [Required]
+    public Instant FirstObservedTime { get; set; }
+
+    [Required]
+    public Instant LastObservedTime { get; set; }
+
+    [Required]
+    public int Count { get; set; }
+
+    [Required]
+    public string Action { get; set; }
+
+    [Required]
+    public string Reason { get; set; }
+
+    [Required]
+    public string Note { get; set; }
+
+    [Required]
+    public string ReportingController { get; set; }
+
+    [Required]
+    public string ReportingInstance { get; set; }
+
+    [Required]
+    public string Type { get; set; }
+
+    [Required]
+    public string Manifest { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/KubernetesLiveStatusDetailedResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/KubernetesLiveStatusDetailedResource.cs
@@ -26,7 +26,7 @@ public class KubernetesLiveStatusDetailedResource
     [Required]
     public Instant LastUpdated { get; set; }
 
-    public KubernetesLiveStatusManifestDetailsResource Details { get; set; }
+    public ManifestSummaryResource ManifestSummary { get; set; }
 
     [Required]
     public IReadOnlyCollection<KubernetesLiveStatusDetailedResource> Children { get; set; }

--- a/source/Octopus.Server.Client/Model/Observability/KubernetesLiveStatusDetailedResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/KubernetesLiveStatusDetailedResource.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using NodaTime;
+
+namespace Octopus.Client.Model.Observability;
+
+public class KubernetesLiveStatusDetailedResource
+{
+    [Required]
+    public string Name { get; set; }
+
+    public string Namespace { get; set; }
+
+    [Required]
+    public string Kind { get; set; }
+
+    [Required]
+    public string HealthStatus { get; set; }
+
+    public string SyncStatus { get; set; }
+
+    [Required]
+    public string MachineId { get; set; }
+
+    [Required]
+    public Instant LastUpdated { get; set; }
+
+    public KubernetesLiveStatusManifestDetailsResource Details { get; set; }
+
+    [Required]
+    public IReadOnlyCollection<KubernetesLiveStatusDetailedResource> Children { get; set; }
+
+    public Guid? DesiredResourceId { get; set; }
+
+    public Guid? ResourceId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/KubernetesLiveStatusManifestDetailsResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/KubernetesLiveStatusManifestDetailsResource.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class KubernetesLiveStatusManifestDetailsResource
+{
+    [Required]
+    public Dictionary<string, string> Labels { get; set; }
+
+    [Required]
+    public Dictionary<string, string> Annotations { get; set; }
+
+    [Required]
+    public DateTimeOffset CreationTimestamp { get; set; }
+
+    [Required]
+    public IReadOnlyCollection<string> Containers { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/KubernetesLiveStatusResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/KubernetesLiveStatusResource.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class KubernetesLiveStatusResource
+{
+    [Required]
+    public string Name { get; set; }
+
+    public string Namespace { get; set; }
+
+    [Required]
+    public string Kind { get; set; }
+
+    [Required]
+    public string HealthStatus { get; set; }
+
+    public string SyncStatus { get; set; }
+
+    [Required]
+    public string MachineId { get; set; }
+
+    [Required]
+    public IReadOnlyCollection<KubernetesLiveStatusResource> Children { get; set; }
+
+    public Guid? DesiredResourceId { get; set; }
+
+    public Guid? ResourceId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/KubernetesMachineLiveStatusResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/KubernetesMachineLiveStatusResource.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class KubernetesMachineLiveStatusResource
+{
+    [Required]
+    public string MachineId { get; set; }
+
+    [Required]
+    public string Status { get; set; }
+
+    [Required]
+    public IReadOnlyCollection<KubernetesLiveStatusResource> Resources { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/KubernetesMonitorResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/KubernetesMonitorResource.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class KubernetesMonitorResource
+{
+    [Required]
+    public string Id { get; set; }
+
+    [Required]
+    public string InstallationId { get; set; }
+
+    [Required]
+    public string MachineId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/LiveResourceDiff.cs
+++ b/source/Octopus.Server.Client/Model/Observability/LiveResourceDiff.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class LiveResourceDiff
+{
+    [Required]
+    public string Left { get; set; }
+
+    [Required]
+    public string Right { get; set; }
+
+    [Required]
+    public string Diff { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/LiveStatusSummaryResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/LiveStatusSummaryResource.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using NodaTime;
+
+namespace Octopus.Client.Model.Observability;
+
+public class LiveStatusSummaryResource
+{
+    [Required]
+    public string Status { get; set; }
+
+    [Required]
+    public Instant LastUpdated { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/ManifestSummaryResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/ManifestSummaryResource.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Octopus.Client.Model.Observability;
 
-public class KubernetesLiveStatusManifestDetailsResource
+public class ManifestSummaryResource
 {
     [Required]
     public Dictionary<string, string> Labels { get; set; }
@@ -14,7 +14,10 @@ public class KubernetesLiveStatusManifestDetailsResource
 
     [Required]
     public DateTimeOffset CreationTimestamp { get; set; }
+}
 
+public class PodManifestSummaryResource : ManifestSummaryResource
+{
     [Required]
     public IReadOnlyCollection<string> Containers { get; set; }
 }

--- a/source/Octopus.Server.Client/Model/Observability/MonitorErrorResource.cs
+++ b/source/Octopus.Server.Client/Model/Observability/MonitorErrorResource.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class MonitorErrorResource
+{
+    [Required]
+    public string ErrorMessage { get; set; }
+
+    [Required]
+    public string ErrorCode { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/RegisterKubernetesMonitorCommand.cs
+++ b/source/Octopus.Server.Client/Model/Observability/RegisterKubernetesMonitorCommand.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class RegisterKubernetesMonitorCommand
+{
+    /// <summary>
+    /// Installation ID of that uniquely identifies the physical installation of the agent.
+    /// </summary>
+    [Required]
+    public string InstallationId { get; set; }
+
+    /// <summary>
+    /// Machine ID of that uniquely identifies the deployment target or worker that is being observed
+    /// </summary>
+    [Required]
+    public string MachineId { get; set; }
+}

--- a/source/Octopus.Server.Client/Model/Observability/RegisterKubernetesMonitorResponse.cs
+++ b/source/Octopus.Server.Client/Model/Observability/RegisterKubernetesMonitorResponse.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octopus.Client.Model.Observability;
+
+public class RegisterKubernetesMonitorResponse
+{
+    [Required]
+    public KubernetesMonitorResource Resource { get; set; }
+
+    [Required]
+    public string AuthenticationToken { get; set; }
+
+    [Required]
+    public string CertificateThumbprint { get; set; }
+}

--- a/source/Octopus.Server.Client/OctopusAsyncRepository.cs
+++ b/source/Octopus.Server.Client/OctopusAsyncRepository.cs
@@ -88,6 +88,7 @@ namespace Octopus.Client
             MachineRoles = new MachineRoleRepository(this);
             Machines = new MachineRepository(this);
             Migrations = new MigrationRepository(this);
+            Observability = new ObservabilityRepository(this);
             OctopusServerNodes = new OctopusServerNodeRepository(this);
             PerformanceConfiguration = new PerformanceConfigurationRepository(this);
             ProjectGroups = new ProjectGroupRepository(this);
@@ -159,6 +160,7 @@ namespace Octopus.Client
         public IMachineRepository Machines { get; }
         public IMachineRoleRepository MachineRoles { get; }
         public IMigrationRepository Migrations { get; }
+        public IObservabilityRepository Observability { get; }
         public IOctopusServerNodeRepository OctopusServerNodes { get; }
         public IPerformanceConfigurationRepository PerformanceConfiguration { get; }
         public IProjectGroupRepository ProjectGroups { get; }

--- a/source/Octopus.Server.Client/OctopusRepository.cs
+++ b/source/Octopus.Server.Client/OctopusRepository.cs
@@ -83,6 +83,7 @@ namespace Octopus.Client
             MachineRoles = new MachineRoleRepository(this);
             Machines = new MachineRepository(this);
             Migrations = new MigrationRepository(this);
+            Observability = new ObservabilityRepository(this);
             OctopusServerNodes = new OctopusServerNodeRepository(this);
             PerformanceConfiguration = new PerformanceConfigurationRepository(this);
             ProjectGroups = new ProjectGroupRepository(this);
@@ -152,6 +153,7 @@ namespace Octopus.Client
         public IMachineRepository Machines { get; }
         public IMachineRoleRepository MachineRoles { get; }
         public IMigrationRepository Migrations { get; }
+        public IObservabilityRepository Observability { get; }
         public IOctopusServerNodeRepository OctopusServerNodes { get; }
         public IPerformanceConfigurationRepository PerformanceConfiguration { get; }
         public IProjectGroupRepository ProjectGroups { get; }

--- a/source/Octopus.Server.Client/Repositories/Async/ObservabilityRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/Async/ObservabilityRepository.cs
@@ -1,0 +1,118 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Client.Model.Observability;
+
+namespace Octopus.Client.Repositories.Async;
+
+public interface IObservabilityRepository
+{
+    Task<GetLiveStatusResponse> Get(GetLiveStatusRequest request, CancellationToken cancellationToken);
+    Task<GetResourceResponse> GetResource(GetResourceRequest request, CancellationToken cancellationToken);
+
+    Task<GetResourceManifestResponse> GetResourceManifest(
+        GetResourceManifestRequest request,
+        CancellationToken cancellationToken);
+
+    Task<RegisterKubernetesMonitorResponse> RegisterKubernetesMonitor(
+        RegisterKubernetesMonitorCommand command,
+        CancellationToken cancellationToken);
+
+    Task<BeginContainerLogsSessionResponse> BeginContainerLogsSession(
+        BeginContainerLogsSessionCommand command,
+        CancellationToken cancellationToken);
+
+    Task<GetContainerLogsResponse> GetContainerLogs(
+        GetContainerLogsRequest request,
+        CancellationToken cancellationToken);
+
+    Task<BeginResourceEventsSessionResponse> BeginResourceEventsSession(
+        BeginResourceEventsSessionCommand command,
+        CancellationToken cancellationToken);
+
+    Task<GetResourceEventsResponse> GetResourceEvents(
+        GetResourceEventsRequest request,
+        CancellationToken cancellationToken);
+}
+
+public class ObservabilityRepository(IOctopusAsyncRepository repository) : IObservabilityRepository
+{
+    public async Task<GetLiveStatusResponse> Get(GetLiveStatusRequest request, CancellationToken cancellationToken)
+    {
+        var link = (string.IsNullOrWhiteSpace(request.TenantId))
+            ? await repository.Link("LiveStatus").ConfigureAwait(false)
+            : await repository.Link("TenantedLiveStatus").ConfigureAwait(false);
+
+        return await repository.Client.Get<GetLiveStatusResponse>(link, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<GetResourceResponse> GetResource(GetResourceRequest request, CancellationToken cancellationToken)
+    {
+        var link = string.IsNullOrWhiteSpace(request.TenantId)
+            ? await repository.Link("Resource").ConfigureAwait(false)
+            : await repository.Link("TenantedResource").ConfigureAwait(false);
+
+        return await repository.Client.Get<GetResourceResponse>(link, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<GetResourceManifestResponse> GetResourceManifest(
+        GetResourceManifestRequest request,
+        CancellationToken cancellationToken)
+    {
+        var link = string.IsNullOrWhiteSpace(request.TenantId)
+            ? await repository.Link("ResourceManifest").ConfigureAwait(false)
+            : await repository.Link("TenantedResourceManifest").ConfigureAwait(false);
+
+        return await repository.Client.Get<GetResourceManifestResponse>(link, request, cancellationToken);
+    }
+
+    public async Task<RegisterKubernetesMonitorResponse> RegisterKubernetesMonitor(
+        RegisterKubernetesMonitorCommand command,
+        CancellationToken cancellationToken)
+    {
+        var link = await repository.Link("KubernetesMonitor").ConfigureAwait(false);
+        return await repository.Client
+            .Post<RegisterKubernetesMonitorCommand, RegisterKubernetesMonitorResponse>(link, command, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<BeginContainerLogsSessionResponse> BeginContainerLogsSession(
+        BeginContainerLogsSessionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var link = await repository.Link("ContainerLogs").ConfigureAwait(false);
+        return await repository.Client
+            .Post<BeginContainerLogsSessionCommand, BeginContainerLogsSessionResponse>(link, command, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<GetContainerLogsResponse> GetContainerLogs(
+        GetContainerLogsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var link = await repository.Link("ContainerLogs").ConfigureAwait(false);
+        return await repository.Client.Get<GetContainerLogsResponse>(link, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<BeginResourceEventsSessionResponse> BeginResourceEventsSession(
+        BeginResourceEventsSessionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var link = await repository.Link("ResourceEvents").ConfigureAwait(false);
+        return await repository.Client
+            .Post<BeginResourceEventsSessionCommand, BeginResourceEventsSessionResponse>(
+                link,
+                command,
+                cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<GetResourceEventsResponse> GetResourceEvents(
+        GetResourceEventsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var link = await repository.Link("ResourceEvents").ConfigureAwait(false);
+        return await repository.Client.Get<GetResourceEventsResponse>(link, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/source/Octopus.Server.Client/Repositories/ObservabilityRepository.cs
+++ b/source/Octopus.Server.Client/Repositories/ObservabilityRepository.cs
@@ -1,0 +1,75 @@
+using Octopus.Client.Model.Observability;
+
+namespace Octopus.Client.Repositories;
+
+public interface IObservabilityRepository
+{
+    GetLiveStatusResponse Get(GetLiveStatusRequest request);
+    GetResourceResponse GetResource(GetResourceRequest request);
+    GetResourceManifestResponse GetResourceManifest(GetResourceManifestRequest request);
+    RegisterKubernetesMonitorResponse RegisterKubernetesMonitor(RegisterKubernetesMonitorCommand command);
+    BeginContainerLogsSessionResponse BeginContainerLogsSession(BeginContainerLogsSessionCommand command);
+    GetContainerLogsResponse GetContainerLogs(GetContainerLogsRequest request);
+    BeginResourceEventsSessionResponse BeginResourceEventsSession(BeginResourceEventsSessionCommand command);
+    GetResourceEventsResponse GetResourceEvents(GetResourceEventsRequest request);
+}
+
+public class ObservabilityRepository(IOctopusRepository repository) : IObservabilityRepository
+{
+    public GetLiveStatusResponse Get(GetLiveStatusRequest request)
+    {
+        var link = (string.IsNullOrWhiteSpace(request.TenantId))
+            ? repository.Link("LiveStatus")
+            : repository.Link("TenantedLiveStatus");
+
+        return repository.Client.Get<GetLiveStatusResponse>(link, request);
+    }
+
+    public GetResourceResponse GetResource(GetResourceRequest request)
+    {
+        var link = string.IsNullOrWhiteSpace(request.TenantId)
+            ? repository.Link("Resource")
+            : repository.Link("TenantedResource");
+
+        return repository.Client.Get<GetResourceResponse>(link, request);
+    }
+
+    public GetResourceManifestResponse GetResourceManifest(GetResourceManifestRequest request)
+    {
+        var link = string.IsNullOrWhiteSpace(request.TenantId)
+            ? repository.Link("ResourceManifest")
+            : repository.Link("TenantedResourceManifest");
+
+        return repository.Client.Get<GetResourceManifestResponse>(link, request);
+    }
+
+    public RegisterKubernetesMonitorResponse RegisterKubernetesMonitor(RegisterKubernetesMonitorCommand command)
+    {
+        var link = repository.Link("KubernetesMonitor");
+        return repository.Client.Post<RegisterKubernetesMonitorCommand, RegisterKubernetesMonitorResponse>(link, command);
+    }
+
+    public BeginContainerLogsSessionResponse BeginContainerLogsSession(BeginContainerLogsSessionCommand command)
+    {
+        var link = repository.Link("ContainerLogs");
+        return repository.Client.Post<BeginContainerLogsSessionCommand, BeginContainerLogsSessionResponse>(link, command);
+    }
+
+    public GetContainerLogsResponse GetContainerLogs(GetContainerLogsRequest request)
+    {
+        var link = repository.Link("ContainerLogs");
+        return repository.Client.Get<GetContainerLogsResponse>(link, request);
+    }
+
+    public BeginResourceEventsSessionResponse BeginResourceEventsSession(BeginResourceEventsSessionCommand command)
+    {
+        var link = repository.Link("ResourceEvents");
+        return repository.Client.Post<BeginResourceEventsSessionCommand, BeginResourceEventsSessionResponse>(link, command);
+    }
+
+    public GetResourceEventsResponse GetResourceEvents(GetResourceEventsRequest request)
+    {
+        var link = repository.Link("ResourceEvents");
+        return repository.Client.Get<GetResourceEventsResponse>(link, request);
+    }
+}


### PR DESCRIPTION
Adds repository and models for the recent set of observability endpoints used for Kubernetes Live Object status.

[Internal ticket](https://whimsical.com/review-endpoints-yc1qTdy4mvtaXMmys2oVo)